### PR TITLE
[#313] Added jQuery to grey out submit buttons after click event.

### DIFF
--- a/akvo/templates/admin/rsr/project/change_form.html
+++ b/akvo/templates/admin/rsr/project/change_form.html
@@ -93,6 +93,15 @@
           {# JavaScript for prepopulated fields #}
           {% prepopulated_fields_js %}
 
+          {# Disable form submit buttons after they have been clicked #}
+          <script type="text/javascript">
+              (function($) {
+                  $("input:submit").click(function(){
+                      $("input:submit").attr("disabled", true);   
+                  });
+              })(django.jQuery);
+          </script>
+
       </div>
     </form>
   </div>


### PR DESCRIPTION
This should help to workaround the fact that Project admin forms can take a long time to respond/save.

Developed blind without a running RSR environment, so this may need further work.
