### PR TITLE
[#342] Fixed 'about' links in RSR and partner site sign in templates.

### DIFF
--- a/akvo/templates/partner_sites/auth/sign-in.html
+++ b/akvo/templates/partner_sites/auth/sign-in.html
@@ -70,7 +70,7 @@
       <li>{% trans "Create updates on your organisation's projects" %}</li>
       <li>{% trans "Leave comments on projects" %}</li>
     </ul>
-    <p>{% trans 'And much more! <a href="/web/">Learn about</a> how Akvo works.' %}</p>
+    <p>{% trans 'And much more! <a href="/about-us/">Learn about</a> how Akvo works.' %}</p>
     <span class="small">
       <a href="{{rsr_password_reset_url}}">{% trans "I forgot my username and/or password" %}</a>
     </span>

--- a/akvo/templates/rsr/sign_in.html
+++ b/akvo/templates/rsr/sign_in.html
@@ -59,7 +59,7 @@
             <li>{% trans "Create updates on your organisation's projects" %}</li>
             <li>{% trans 'Leave comments on projects' %}</li>
           </ul>
-          <p>{% trans "And much more! <a href='/web/'>Learn about</a> how Akvo works." %}</p>
+          <p>{% trans "And much more! <a href='/about-us/'>Learn about</a> how Akvo works." %}</p>
 					
         </div>
         <div class="clear"></div>


### PR DESCRIPTION
These should be absolutely safe to pull into develop without review.
