### PR TITLE
[#159] Use thumbnail for partner site map popup

### DIFF
--- a/akvo/rsr/views.py
+++ b/akvo/rsr/views.py
@@ -1408,7 +1408,7 @@ def global_organisation_projects_map_json(request, org_id):
     organisation = Organisation.objects.get(id=org_id)
     for project in organisation.published_projects():
         try:
-            image_url = project.current_image.url
+            image_url = project.current_image.extra_thumbnails['map_thumb'].absolute_url
         except:
             image_url = ""
         for location in project.locations.all():


### PR DESCRIPTION
The map of projects on the partner sites home page uses the original
image in the popups dispayed when you click a pin.

Fix by using the named thumbnail "map_thumb" instead.
