### PR TITLE
#423 Removed FB App ID from Admin

### DIFF
--- a/akvo/rsr/admin.py
+++ b/akvo/rsr/admin.py
@@ -1163,7 +1163,7 @@ class PartnerSiteAdmin(admin.ModelAdmin):
         (u'HTTP', dict(fields=('hostname', 'cname', 'custom_return_url',))),
         (u'Style and content', dict(fields=('about_box', 'about_image', 'custom_css', 'custom_logo', 'custom_favicon',))),
         (u'Languages and translation', dict(fields=('default_language', 'ui_translation', 'google_translation',))),
-        (u'Social', dict(fields=('twitter_button', 'facebook_button', 'facebook_app_id',))),
+        (u'Social', dict(fields=('twitter_button', 'facebook_button',))),
     )
     # the notes field is not shown to everyone
     restricted_fieldsets = (


### PR DESCRIPTION
@stellanl I've removed the App ID from the Admin just so it doesn't cause any confusion. I don't think we need to make any further changes ot the functionality as everyting works as expected right now.
