### PR TITLE
[#390] Fix XSLT to handle RAIN budgets

### DIFF
--- a/akvo/api/xml/iati-xslt.xsl
+++ b/akvo/api/xml/iati-xslt.xsl
@@ -352,8 +352,8 @@
       <!-- ignore Cordaid's budgets, they are handled by post-processing -->
       <xsl:when test="../budget[@akvo:budget-from]">
       </xsl:when>
-      <!-- if there's a type="2" budget we use that instead, see below -->
-      <xsl:when test="../budget[@type='2']">
+      <!-- if there's a type="2" budget and it has value tags we use that instead, see below -->
+      <xsl:when test="../budget[@type='2'] and ../budget[@type='2']/value">
       </xsl:when>
       <xsl:otherwise>
         <xsl:apply-templates select="value"/>


### PR DESCRIPTION
The XSLT selects the budget[@type='2'] even if there are no values in
it. Fix by adding test for the existance of <value> tags.

As noted in the issue, this is just a small fix to the XSLT, the bulk of the new code is already in develop.
