### PR TITLE
[#438] Links in updates are urlized

### DIFF
--- a/akvo/templates/partner_sites/project/base_project.html
+++ b/akvo/templates/partner_sites/project/base_project.html
@@ -90,7 +90,7 @@
                   <p class="small marg_bottom0" style="margin-top: 15px;">
                     <b><a href="{% url 'update_main' project.id update.id %}">{{update.title}}</a></b><br/>
                     <div class="update_preview">
-                      {{update.text|smart_truncate:50|markdown:"safe"}}
+                      {{update.text|smart_truncate:50|markdown:"safe"|urlize}}
                     </div>
                   </p>
                 </div>
@@ -116,7 +116,7 @@
                 <p class="small marg_bottom0" style="margin-top: 15px;">
                   <b><a href="{% url 'update_main' project.id update.id %}">{{update.title}}</a></b><br />
                   <div class="update_preview">
-                    {{update.text|smart_truncate:120|markdown:"safe"}}
+                    {{update.text|smart_truncate:120|markdown:"safe"|urlize}}
                   </div>
                 </p>
               </div>

--- a/akvo/templates/partner_sites/project/update_main.html
+++ b/akvo/templates/partner_sites/project/update_main.html
@@ -123,7 +123,7 @@
     
     {% if update.text_location == 'B' %}
       <p class="small grey">
-        {{ update.text|markdown:"safe" }}
+        {{ update.text|markdown:"safe"|urlize }}
       </p>
     {% endif %}	
     {% if update.video %}
@@ -151,7 +151,7 @@
     {% endif %}
     {% if update.text_location == 'E' %}
       <p class="small grey">
-        {{ update.text|markdown:"safe"}}
+        {{ update.text|markdown:"safe"|urlize }}
       </p>
     {% endif %}
     <hr style="margin-bottom:5px;" />

--- a/akvo/templates/rsr/project/project_directory.html
+++ b/akvo/templates/rsr/project/project_directory.html
@@ -73,7 +73,7 @@
         <h1 class="h0">{{focus_area}} {% trans 'projects' %}</h1>
         <div id="focus_area_description" class="column span-{% if focus_area.slug != 'all' %}15{% else %}18{% endif %}">
           <img width="120" height="90" style="float: left; margin: 0 20px 20px 0;" src="{% thumbnail focus_area.image 120x90 sharpen %}" alt="{{focus_area}}"/>
-          {{focus_area.description|apply_markup:"markdown"}}
+          {{focus_area.description|apply_markup:"markdown"|urlize}}
         </div>
       {% endif %}
       <div class="clear"></div>

--- a/akvo/templates/rsr/project/project_update.html
+++ b/akvo/templates/rsr/project/project_update.html
@@ -88,7 +88,7 @@
       {% update_thumb update 580 435 %}
     {% endif %}   	
     {% if update.text_location == 'E' %}
-      {{ update.text|markdown:"safe" }}
+      {{ update.text|markdown:"safe"|urlize }}
     {% endif %}
     <hr style="margin-bottom:5px;" />
     <div class="text_right">


### PR DESCRIPTION
If a link is present in the markdown update, but not marked
as a proper link we use the urlize template tag to create a
link from the url. This link will show the full url as the link

We do not urlize texts that are limited in chars. Examples of this
is the project list and the small preview on the main project page.
The motivation for this is that it might be unsafe to deal with.
