### PR TITLE
[#309] Point registering on Pages to step 2

### DIFF
--- a/akvo/rsr/views_partner_sites/auth.py
+++ b/akvo/rsr/views_partner_sites/auth.py
@@ -54,15 +54,24 @@ class SignInView(PartnerSitesMixin, FormView):
             rsr_domain= rsr_domain,
             register1_path = register1_path,
         )
+        register2_path = reverse('register2', urlconf='akvo.urls.rsr')
+        org_query_string = "?org_id={}".format(self.request.organisation_id)
+        register2_url = "http://{rsr_domain}{register2_path}{org_query_string}".format(
+            rsr_domain= rsr_domain,
+            register2_path = register2_path,
+            org_query_string=org_query_string,
+        )
         rsr_password_reset_path = reverse('rsr_password_reset', urlconf='akvo.urls.rsr')
         rsr_password_reset_url = "http://{rsr_domain}{rsr_password_reset_path}".format(
             rsr_domain= rsr_domain,
             rsr_password_reset_path = rsr_password_reset_path,
         )
         if getattr(settings, 'HTTPS_SUPPORT', True):
-            return register1_url.replace('http://', 'https://')
+            return register2_url.replace('http://', 'https://')
         context['register1_url'] = register1_url
+        context['register2_url'] = register2_url
         context['rsr_password_reset_url'] = rsr_password_reset_url
+        context['organisation_absolute_url'] = self.request.partner_site.organisation.get_absolute_url()
         return context
 
     def render_to_response(self, context):

--- a/akvo/templates/partner_sites/auth/sign-in.html
+++ b/akvo/templates/partner_sites/auth/sign-in.html
@@ -64,12 +64,29 @@
   <div class="clearfix" style="float:left;width:465px;padding-top:20px">
     <h3>{% trans "I don't have an account" %}</h3>
     <p>
-    {% blocktrans %}By <a href='{{register1_url}}'>registering</a> with Akvo, you will be able to:{% endblocktrans %}
+    {% blocktrans %}
+      By <a target="_blank" href='{{register2_url}}'>registering</a> with Akvo, you will be able to:
+    {% endblocktrans %}
     </p>
     <ul class="simplelist">
       <li>{% trans "Create updates on your organisation's projects" %}</li>
       <li>{% trans "Leave comments on projects" %}</li>
     </ul>
+    <p>
+      {% blocktrans %}
+        You will be registering as a user under the organisation <a href="{{organisation_absolute_url}}">{{organisation}}</a>
+      {% endblocktrans %}
+    </p>
+    <p>
+      {% blocktrans %}
+        If you are not a member of this organisation,
+        please click <a target="_blank" href="{{register1_url}}">here</a> to select your organisation from the list.
+      {% endblocktrans %}
+    </p>
+
+
+
+
     <p>{% trans 'And much more! <a href="http://akvo.org/about-us/">Learn about</a> how Akvo works.' %}</p>
     <span class="small">
       <a href="{{rsr_password_reset_url}}">{% trans "I forgot my username and/or password" %}</a>


### PR DESCRIPTION
When registering while at a Pages site the registration should default
to be with the organisation of the site.

Change the link to registration to reflect this, going directly to
step two.

Add a second link pointing to step one of registraion if the user wants
to register with another organisation.

Also set target on those links to "_blank" to open a new window/tab for
the registration since we can't redirect back correctly.
