### PR TITLE
Adding Raven as a dependency in order to communicate with Sentry

### DIFF
--- a/scripts/deployment/pip/requirements/2_rsr.txt
+++ b/scripts/deployment/pip/requirements/2_rsr.txt
@@ -60,3 +60,6 @@ django-piwik==0.1
 # statsd and graphite integration
 django-statsd-mozilla==0.3.9
 statsd==2.0.3
+
+# Sentry integration
+raven==4.2.1


### PR DESCRIPTION
This additional package is required to communicate with Sentry (for error logging) - see #541 
