### PR TITLE
[#570] Update django-counter requirement

### DIFF
--- a/scripts/deployment/pip/requirements/2_rsr.txt
+++ b/scripts/deployment/pip/requirements/2_rsr.txt
@@ -18,7 +18,7 @@ djangorestframework==2.3.13
 django-tastypie==0.11.1
 
 # Django apps from VCS web services
--e git://github.com/carlio/django-counter.git@31bbc8b994d208b84911c006d8a0f796fcd78940#egg=django-counter
+-e git://github.com/akvo/django-counter.git@e437712696fe48771e3142ee000a64abd055ee2a#egg=django-counter
 -e git://github.com/lukeman/django-sorting.git@d3456924ff2140c2a3466a2dd9d674486500393e#egg=django-sorting
 -e git://github.com/carlio/djangoembed.git@cc655adb61d3deafe8bedf14ad34a7b7712acdef#egg=djangoembed
 


### PR DESCRIPTION
django-counter needed patching to be compatible with Django 1.5+.
This fix refers to the patched version in the pip requirements.
