### PR TITLE
[#612] Switch to vanilla Tastypie

### DIFF
--- a/scripts/deployment/pip/requirements/2_rsr.txt
+++ b/scripts/deployment/pip/requirements/2_rsr.txt
@@ -15,12 +15,12 @@ mimeparse==0.1.3
 python-dateutil==2.2
 requests==2.3.0
 djangorestframework==2.3.13
+django-tastypie==0.11.1
 
 # Django apps from VCS web services
 -e git://github.com/akvo/django-counter.git@3b38f45a243970fda1a61124fd6ec8b9bd352c35#egg=django-counter
 -e git://github.com/lukeman/django-sorting.git@d3456924ff2140c2a3466a2dd9d674486500393e#egg=django-sorting
 -e git://github.com/akvo/djangoembed.git@3a1d6b955bcff4b2ec04eefca79a0b2ebb31289a#egg=djangoembed
--e git://github.com/akvo/django-tastypie.git@781fea26200b741c292cf166b30b7066e9e40f44#egg=django-tastypie
 -e git://github.com/akvo/django-registration.git@d1ff9eba18854fc41892de5a16562db77b93a25a#egg=registration
 
 # Akvonaut apps


### PR DESCRIPTION
Change back to using django-tastypie==0.11.1 since our local fixes were
for running Django 1.7.
