### PR TITLE
[#652] Fix creation of new budget items in post_import.py

### DIFF
--- a/akvo/rsr/models.py
+++ b/akvo/rsr/models.py
@@ -1155,6 +1155,7 @@ class Benchmark(models.Model):
 
 
 class BudgetItemLabel(models.Model):
+    TOTAL_BUDGET_LABEL_ID = 14
     label = ValidXMLCharField(_(u'label'), max_length=20, unique=True, db_index=True)
 
     def __unicode__(self):

--- a/akvo/scripts/cordaid/post_import.py
+++ b/akvo/scripts/cordaid/post_import.py
@@ -113,7 +113,7 @@ def fix_funding(budgets):
             old_budgets.delete()
             BudgetItem.objects.create(
                 project=project,
-                label = BudgetItemLabel.objects.get(pk=13), #total budget label
+                label = BudgetItemLabel.objects.get(pk=BudgetItemLabel.TOTAL_BUDGET_LABEL_ID),
                 amount = total_budget
             )
             log(


### PR DESCRIPTION
When creating new budget items, the script breaks when trying to create
items with the "total" label.

Fix by creating BudgetItemLabel.TOTAL_BUDGET_LABEL_ID and referring to
it rather than a fixed int in the script.
