### PR TITLE
[#28] Replaced Oembed with embed.ly API

### DIFF
--- a/akvo/settings/30-rsr.conf
+++ b/akvo/settings/30-rsr.conf
@@ -48,6 +48,10 @@ MOLLIE_FEE_BASE = 1.20  # ¢99 plus Dutch VAT...
 DECIMALS_DEBUG = False
 DECIMALS_DECIMAL_PLACES = 2
 
+# embed.ly
+EMBEDLY_URL = 'https://api.embed.ly/1/oembed?'
+EMBEDLY_API = 'df0d55df3bbb4caa835bfc412f6e0df0'
+
 WORDPRESS_NEWS_CATEGORY = 13
 
 PROJECT_UPDATE_TIMEOUT = 20

--- a/akvo/templates/rsr/project/project_updates.html
+++ b/akvo/templates/rsr/project/project_updates.html
@@ -30,7 +30,7 @@
                 <div class="clearfix">
                   <a class="video_thumb" href="{{ update.get_absolute_url }}">
                   <img src="{{update.get_video_thumbnail_url}}" style="width:240px;" alt="" />
-                  <i style="background-image: url({{ MEDIA_URL }}core/img/play_button_small.png); bottom:7px; cursor:pointer; left:5px;  width:50px; height:50px; position: absolute"></i>
+                  <i style="background-image: url({{ STATIC_URL }}common/img/play_button_small.png); bottom:7px; cursor:pointer; left:5px;  width:50px; height:50px; position: absolute"></i>
                 </a>
                 </div>
               {% else %}


### PR DESCRIPTION
@zzgvh @adriancollier This should work, but not sure if we actually need to implement it :confused:. Since the issue is already pretty old, and djangoembed still works fine. 

The embed.ly API works fine as well, though the free version has a limit of 5000 unique hourly urls. Only with testing I've used 28 of those, my guess would be that this runs out pretty fast. The monthly subscription gives us 50000 urls per month, but that costs $19 p/m. So maybe we should just keep the current implementation..
