### PR TITLE
[#670] Don't delete keywords on IATI import

### DIFF
--- a/akvo/api/resources/project.py
+++ b/akvo/api/resources/project.py
@@ -105,7 +105,6 @@ class IATIProjectResource(ModelResource):
             ProjectLocation.objects.filter(location_target=bundle.obj).delete()
             Partnership.objects.filter(project=bundle.obj).delete()
             Benchmark.objects.filter(project=bundle.obj).delete()
-            Keyword.objects.filter(project=bundle.obj).delete()
             bundle.obj.categories.clear()
 
         self.authorized_update_detail(self.get_object_list(bundle.request), bundle)


### PR DESCRIPTION
The keywords for a project should not be deleted when updating a project
using the API IATI import

This might need to be revisited if/when keywords becomme part of the
import, but for now they're managed solely through the admin.
