### PR TITLE
[#686] Fixed CSS and image link for 404 page

### DIFF
--- a/akvo/templates/404.html
+++ b/akvo/templates/404.html
@@ -3,7 +3,7 @@
 
 {% block head %}
 {{ block.super }}
-<link rel="stylesheet" type="text/css" href="/media/akvo/css/src/404.css">
+<link rel="stylesheet" type="text/css" href="{{STATIC_URL}}rsr/main/css/src/404.css">
 {% endblock head %}
 
 {% block breadcrum_items %}
@@ -20,7 +20,7 @@
     </h1>
     </header>
     <section class="post-content twoColumns floats-in">
-      <div><img src="{{ STATIC_URL }}site/img/404/Surprise-polaroid-L.png" alt="Products"  style="max-height:450px;margin-left:5%;"/></div>
+      <div><img src="{{ STATIC_URL }}rsr/main/img/404/Surprise-polaroid-L.png" alt="Products"  style="max-height:450px;margin-left:5%;"/></div>
       <div style="margin-top:2em;">
         <p class="strongType">
           <br/>


### PR DESCRIPTION
@zzgvh Can you check? 403 and 500 pages don't have any links to CSS or images, so those still work fine :+1: 
