### PR TITLE
[#769] Add filtering on created_at to project_update_extra

### DIFF
--- a/akvo/rest/views/project_update.py
+++ b/akvo/rest/views/project_update.py
@@ -43,4 +43,7 @@ class ProjectUpdateExtraViewSet(BaseRSRViewSet):
         uuid = self.request.QUERY_PARAMS.get('uuid', None)
         if uuid is not None:
             queryset = self.queryset.filter(uuid=uuid)
+        created_at = self.request.QUERY_PARAMS.get('created_at__gt', None)
+        if created_at is not None:
+            queryset = self.queryset.filter(created_at__gt=created_at)
         return queryset


### PR DESCRIPTION
Add filtering to project_update_extra that returns only updates newer than the time queried for.

The querystring is on the form created_at__gt=YYYY-MM-DDTHH:MM:SS
