### PR TITLE
[#820] Fix exception in ProjectUpdateResourceExtra.dehydrate()

### DIFF
--- a/akvo/api/resources/project_update.py
+++ b/akvo/api/resources/project_update.py
@@ -76,7 +76,10 @@ class ProjectUpdateResourceExtra(ProjectUpdateResource):
         def primary_location_data_for_update(obj):
             """ We need similar data for both the project and the organisation associated with the update
             """
-            primary_location = dict(obj.primary_location.__dict__)
+            try:
+                primary_location = dict(obj.primary_location.__dict__)
+            except:
+                return None
             # remove Django internal field
             primary_location.pop('_state', None)
             country_id = primary_location.pop('country_id', None)
@@ -93,7 +96,6 @@ class ProjectUpdateResourceExtra(ProjectUpdateResource):
                 # remove Django internal field
                 country_dict.pop('_state', None)
                 primary_location['country'].update(country_dict)
-
             return primary_location
 
         def org_data_for_update(organisation):


### PR DESCRIPTION
primary_location_data_for_update() in
ProjectUpdateResourceExtra.dehydrate() throws an unhandled exceltion if
the organisation or project doesn't have a primary location.

Since we don't require orgs to have a location wrap the creation of the
primary_location dics in a try-except and return None if there's no
location.
