### PR TITLE
[#901] Show original images and correct ratio

### DIFF
--- a/akvo/rsr/static/rsr/v3/css/src/main.css
+++ b/akvo/rsr/static/rsr/v3/css/src/main.css
@@ -342,11 +342,11 @@ header {
   background: #FFFFFF; }
 
 /* Project carousel */
-.carousel-inner > .item > img {
+.carousel-inner > .item > a > img {
   max-height: 400px;
   margin: auto; }
 
-.carousel-inner > .item {
+.carousel-inner > .item > a {
   text-align: center; }
 
 .carousel-control.right {

--- a/akvo/rsr/static/rsr/v3/css/src/main.css
+++ b/akvo/rsr/static/rsr/v3/css/src/main.css
@@ -336,12 +336,24 @@ header {
   height: 300px;
   background: #ccc; }
 
-.carousel-inner > .item > img {
-  max-height: 400px; }
-
+/* Project timeline */
 #timeline {
   height: 400px;
   background: #FFFFFF; }
+
+/* Project carousel */
+.carousel-inner > .item > img {
+  max-height: 400px;
+  margin: auto; }
+
+.carousel-inner > .item {
+  text-align: center; }
+
+.carousel-control.right {
+  background-image: none; }
+
+.carousel-control.left {
+  background-image: none; }
 
 /* Project hierarchy */
 .project-hierarchy-window {

--- a/akvo/rsr/static/rsr/v3/css/src/main.scss
+++ b/akvo/rsr/static/rsr/v3/css/src/main.scss
@@ -379,11 +379,11 @@ header {
 }
 
 /* Project carousel */
-.carousel-inner > .item > img {
+.carousel-inner > .item > a > img {
     max-height: 400px;
     margin: auto;
 }
-.carousel-inner > .item {
+.carousel-inner > .item > a {
     text-align: center;
 }
 .carousel-control.right {

--- a/akvo/rsr/static/rsr/v3/css/src/main.scss
+++ b/akvo/rsr/static/rsr/v3/css/src/main.scss
@@ -371,14 +371,27 @@ header {
 	height: 300px;
 	background: #ccc;
 }
-.carousel-inner > .item > img {
-    max-height: 400px;
-}
+
+/* Project timeline */
 #timeline {
 	height: 400px;
 	background: #FFFFFF;
 }
 
+/* Project carousel */
+.carousel-inner > .item > img {
+    max-height: 400px;
+    margin: auto;
+}
+.carousel-inner > .item {
+    text-align: center;
+}
+.carousel-control.right {
+    background-image: none;
+}
+.carousel-control.left {
+    background-image: none;
+}
 
 /* Project hierarchy */
 .project-hierarchy-window {

--- a/akvo/rsr/static/rsr/v3/js/src/react-project-main.js
+++ b/akvo/rsr/static/rsr/v3/js/src/react-project-main.js
@@ -51,7 +51,7 @@ var CarouselInstance = React.createClass({displayName: 'CarouselInstance',
         var photos = this.props.source.photos.map(function(photo) {
           return (
             CarouselItem(null, 
-                React.DOM.img( {width:"100%", height:400, src:photo.url} ),
+                React.DOM.img( {src:photo.url} ),
                 React.DOM.div( {className:"carousel-caption"}, 
                     React.DOM.h3(null, photo.caption),
                     React.DOM.p(null, photo.credit)

--- a/akvo/rsr/static/rsr/v3/js/src/react-project-main.js
+++ b/akvo/rsr/static/rsr/v3/js/src/react-project-main.js
@@ -51,7 +51,7 @@ var CarouselInstance = React.createClass({displayName: 'CarouselInstance',
         var photos = this.props.source.photos.map(function(photo) {
           return (
             CarouselItem(null, 
-                React.DOM.img( {src:photo.url} ),
+                React.DOM.a( {href:photo.original_url, target:"_blank"}, React.DOM.img( {src:photo.url} )),
                 React.DOM.div( {className:"carousel-caption"}, 
                     React.DOM.h3(null, photo.caption),
                     React.DOM.p(null, photo.credit)

--- a/akvo/rsr/static/rsr/v3/js/src/react-project-main.jsx
+++ b/akvo/rsr/static/rsr/v3/js/src/react-project-main.jsx
@@ -51,7 +51,7 @@ var CarouselInstance = React.createClass({
         var photos = this.props.source.photos.map(function(photo) {
           return (
             <CarouselItem>
-                <img width='100%' height={400} src={photo.url} />
+                <img src={photo.url} />
                 <div className="carousel-caption">
                     <h3>{photo.caption}</h3>
                     <p>{photo.credit}</p>

--- a/akvo/rsr/static/rsr/v3/js/src/react-project-main.jsx
+++ b/akvo/rsr/static/rsr/v3/js/src/react-project-main.jsx
@@ -51,7 +51,7 @@ var CarouselInstance = React.createClass({
         var photos = this.props.source.photos.map(function(photo) {
           return (
             <CarouselItem>
-                <img src={photo.url} />
+                <a href={photo.original_url} target="_blank"><img src={photo.url} /></a>
                 <div className="carousel-caption">
                     <h3>{photo.caption}</h3>
                     <p>{photo.credit}</p>

--- a/akvo/rsr/views/project.py
+++ b/akvo/rsr/views/project.py
@@ -84,6 +84,7 @@ def _get_carousel_data(project):
             "url": im.url,
             "caption": project.current_image_caption,
             "credit": project.current_image_credit,
+            "original_url": project.current_image.url,
         })
     for update in project.updates_desc():
         if len(photos) > 9:
@@ -94,6 +95,7 @@ def _get_carousel_data(project):
                 "url": im.url,
                 "caption": update.photo_caption,
                 "credit": update.photo_credit,
+                "original_url": update.photo.url,
             })
     return {"photos": photos}
 

--- a/akvo/rsr/views/project.py
+++ b/akvo/rsr/views/project.py
@@ -18,6 +18,8 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 
+from sorl.thumbnail import get_thumbnail
+
 
 def _get_accordion_data(project):
     accordion_data = dict()
@@ -77,8 +79,9 @@ def _get_timeline_data(project):
 def _get_carousel_data(project):
     photos = []
     if project.current_image:
+        im = get_thumbnail(project.current_image, '750x400', quality=99)
         photos.append({
-            "url": project.current_image.url,
+            "url": im.url,
             "caption": project.current_image_caption,
             "credit": project.current_image_credit,
         })
@@ -86,8 +89,9 @@ def _get_carousel_data(project):
         if len(photos) > 9:
             break
         if update.photo:
+            im = get_thumbnail(update.photo, '750x400', quality=99)
             photos.append({
-                "url": update.photo.url,
+                "url": im.url,
                 "caption": update.photo_caption,
                 "credit": update.photo_credit,
             })

--- a/akvo/templates/organisation_main.html
+++ b/akvo/templates/organisation_main.html
@@ -29,7 +29,9 @@
             {% endif %}
         </div>
         <div class="col-sm-7">
-            {% img organisation 350 250 organisation.name %}
+            {% if organisation.logo %}
+                <a href="{{organisation.logo.url}}" target="_blank">{% img organisation 350 250 organisation.name %}</a>
+            {% endif %}
         </div>
     </div>
     <div class="row">

--- a/akvo/templates/update_main.html
+++ b/akvo/templates/update_main.html
@@ -41,7 +41,7 @@
                             </p>
                             {% endif %}
                             {% if update.photo %}
-                            <p>{% img update 600 450 update.title %}</p>
+                            <p><a href="{{update.photo.url}}" target="_blank">{% img update 600 450 update.title %}</a></p>
                             <p class="small">
                                 {% if update.photo_caption %}
                                 "{{ update.photo_caption }}"{% if update.photo_credit %}<br>{% endif %}


### PR DESCRIPTION
- The ratio of the images in the carousel has been updated
  - This causes white spaces on the sides of most images, so the shadow on the side of the carousel box has been removed because this looks weird
- The images in the carousel, on the update main page and on the organisation main page are now clickable and show the original image in a new tab