### PR TITLE
[#1045] Improved typeahead for organisations

### DIFF
--- a/akvo/rest/views/organisation.py
+++ b/akvo/rest/views/organisation.py
@@ -87,4 +87,7 @@ class OrganisationViewSet(BaseRSRViewSet):
         name = self.request.QUERY_PARAMS.get('name', None)
         if name is not None:
             queryset = queryset.filter(name=name)
+        long_name = self.request.QUERY_PARAMS.get('long_name', None)
+        if long_name is not None:
+            queryset = queryset.filter(long_name=long_name)
         return queryset

--- a/akvo/rsr/static/rsr/v3/js/src/react-my-details.js
+++ b/akvo/rsr/static/rsr/v3/js/src/react-my-details.js
@@ -89,18 +89,11 @@ var AddEmploymentForm = React.createClass({displayName: 'AddEmploymentForm',
         };
     },
 
-    addEmployment: function() {
-        this.setState({
-            title: "Sending request",
-            response: "Waiting..."
-        });
-
-        serializedData = this.getFormData();
-
+    postEmployment: function( data ) {
         $.ajax({
             type: "POST",
             url: this.props.link + "?format=json",
-            data : JSON.stringify(serializedData),
+            data : JSON.stringify( data ),
             contentType : 'application/json; charset=UTF-8',
             success: function(response) {
                 this.handleAddEmployment(response);
@@ -118,20 +111,85 @@ var AddEmploymentForm = React.createClass({displayName: 'AddEmploymentForm',
                 } else {
                     this.setState({
                         title: "Request failed",
-                        response: "Request failed, check if the organisation field is filled in correctly."
+                        response: "Request failed, could not connect to organisation."
                     })
                 }
             }.bind(this)
         });
     },
 
+    getOrgByName: function( serializedData ) {
+        var name = $('#organisationInput').val();
+        $.get(this.props.org_link + "?format=json&name=" + name, function( data ) {
+            if (data.count == 1) {
+                serializedData.organisation = data.results[0].id;
+                this.postEmployment( serializedData );
+            } else if (data.count > 1) {
+                this.setState({
+                    title: "Request failed",
+                    response: "Request failed, multiple organisations found."
+                })
+            } else {
+                this.setState({
+                    title: "Request failed",
+                    response: "Request failed, organisation not found."
+                })
+            }
+        }.bind(this))
+            .fail(function() {
+                this.setState({
+                    title: "Request failed",
+                    response: "Request failed, organisation not found."
+                })
+            }.bind(this)
+        );
+    },
+
+    getOrgByLongName: function( serializedData ) {
+        this.setState({
+            response: "Retrieving organisation information..."
+        });
+        var name = $('#organisationInput').val();
+        $.get(this.props.org_link + "?format=json&long_name=" + name, function( data ) {
+            if (data.count == 1) {
+                serializedData.organisation = data.results[0].id;
+                this.postEmployment( serializedData );
+            } else if (data.count > 1) {
+                this.setState({
+                    title: "Request failed",
+                    response: "Request failed, multiple organisations found."
+                })
+            } else {
+                this.getOrgByName( serializedData );
+            }
+        }.bind(this))
+            .fail(function() {
+                this.getOrgByName( serializedData )
+            }.bind(this)
+        );
+    },
+
+    addEmployment: function() {
+        this.setState({
+            title: "Sending request",
+            response: "Waiting..."
+        });
+
+        var serializedData = this.getFormData();
+
+        if (typeof serializedData.organisation === "undefined") {
+            this.getOrgByLongName( serializedData );
+        } else {
+            this.postEmployment( serializedData );
+        }
+    },
+
     getFormData: function() {
-        var data = {
+        return {
             organisation: $('#organisationInput').attr('value_id'),
             country: $('#countriesInput').attr('value_id'),
             job_title: $('#jobtitleInput').val()
-        };
-        return data
+        }
     },
 
     handleAddEmployment: function(employment) {
@@ -180,7 +238,7 @@ var EmploymentApp = React.createClass({displayName: 'EmploymentApp',
             React.DOM.span(null, 
                 React.DOM.h2(null, "My organisations"),
                 EmploymentList( {employments:this.state.employments} ),
-                AddEmploymentForm( {link:this.props.link, addEmployment:this.addEmployment} )
+                AddEmploymentForm( {link:this.props.link, org_link:this.props.org_link, addEmployment:this.addEmployment} )
             )
             );
     }
@@ -190,6 +248,6 @@ var initial_data = JSON.parse(document.getElementById("initial-data").innerHTML)
 var request_link = JSON.parse(document.getElementById("user-request-link").innerHTML);
 
 React.renderComponent(
-    EmploymentApp( {source:initial_data, link:request_link.link} ),
+    EmploymentApp( {source:initial_data, link:request_link.link, org_link:request_link.org_rest_link} ),
     document.getElementById('organisations')
 );

--- a/akvo/rsr/static/rsr/v3/js/src/react-my-details.jsx
+++ b/akvo/rsr/static/rsr/v3/js/src/react-my-details.jsx
@@ -89,18 +89,11 @@ var AddEmploymentForm = React.createClass({
         };
     },
 
-    addEmployment: function() {
-        this.setState({
-            title: "Sending request",
-            response: "Waiting..."
-        });
-
-        serializedData = this.getFormData();
-
+    postEmployment: function( data ) {
         $.ajax({
             type: "POST",
             url: this.props.link + "?format=json",
-            data : JSON.stringify(serializedData),
+            data : JSON.stringify( data ),
             contentType : 'application/json; charset=UTF-8',
             success: function(response) {
                 this.handleAddEmployment(response);
@@ -118,20 +111,85 @@ var AddEmploymentForm = React.createClass({
                 } else {
                     this.setState({
                         title: "Request failed",
-                        response: "Request failed, check if the organisation field is filled in correctly."
+                        response: "Request failed, could not connect to organisation."
                     })
                 }
             }.bind(this)
         });
     },
 
+    getOrgByName: function( serializedData ) {
+        var name = $('#organisationInput').val();
+        $.get(this.props.org_link + "?format=json&name=" + name, function( data ) {
+            if (data.count == 1) {
+                serializedData.organisation = data.results[0].id;
+                this.postEmployment( serializedData );
+            } else if (data.count > 1) {
+                this.setState({
+                    title: "Request failed",
+                    response: "Request failed, multiple organisations found."
+                })
+            } else {
+                this.setState({
+                    title: "Request failed",
+                    response: "Request failed, organisation not found."
+                })
+            }
+        }.bind(this))
+            .fail(function() {
+                this.setState({
+                    title: "Request failed",
+                    response: "Request failed, organisation not found."
+                })
+            }.bind(this)
+        );
+    },
+
+    getOrgByLongName: function( serializedData ) {
+        this.setState({
+            response: "Retrieving organisation information..."
+        });
+        var name = $('#organisationInput').val();
+        $.get(this.props.org_link + "?format=json&long_name=" + name, function( data ) {
+            if (data.count == 1) {
+                serializedData.organisation = data.results[0].id;
+                this.postEmployment( serializedData );
+            } else if (data.count > 1) {
+                this.setState({
+                    title: "Request failed",
+                    response: "Request failed, multiple organisations found."
+                })
+            } else {
+                this.getOrgByName( serializedData );
+            }
+        }.bind(this))
+            .fail(function() {
+                this.getOrgByName( serializedData )
+            }.bind(this)
+        );
+    },
+
+    addEmployment: function() {
+        this.setState({
+            title: "Sending request",
+            response: "Waiting..."
+        });
+
+        var serializedData = this.getFormData();
+
+        if (typeof serializedData.organisation === "undefined") {
+            this.getOrgByLongName( serializedData );
+        } else {
+            this.postEmployment( serializedData );
+        }
+    },
+
     getFormData: function() {
-        var data = {
+        return {
             organisation: $('#organisationInput').attr('value_id'),
             country: $('#countriesInput').attr('value_id'),
             job_title: $('#jobtitleInput').val()
-        };
-        return data
+        }
     },
 
     handleAddEmployment: function(employment) {
@@ -180,7 +238,7 @@ var EmploymentApp = React.createClass({
             <span>
                 <h2>My organisations</h2>
                 <EmploymentList employments={this.state.employments} />
-                <AddEmploymentForm link={this.props.link} addEmployment={this.addEmployment} />
+                <AddEmploymentForm link={this.props.link} org_link={this.props.org_link} addEmployment={this.addEmployment} />
             </span>
             );
     }
@@ -190,6 +248,6 @@ var initial_data = JSON.parse(document.getElementById("initial-data").innerHTML)
 var request_link = JSON.parse(document.getElementById("user-request-link").innerHTML);
 
 React.renderComponent(
-    <EmploymentApp source={initial_data} link={request_link.link} />,
+    <EmploymentApp source={initial_data} link={request_link.link} org_link={request_link.org_rest_link} />,
     document.getElementById('organisations')
 );

--- a/akvo/templates/myrsr/my_details.html
+++ b/akvo/templates/myrsr/my_details.html
@@ -81,7 +81,8 @@
     {{ user_data|safe }}
   </script>
   <script type="application/json" id="user-request-link">
-    {"link": "{% url 'user_request_organisation' user.id %}"}
+    {"link": "{% url 'user_request_organisation' user.id %}",
+     "org_rest_link": "{% url 'organisation-list' %}"}
   </script>
   <script type="application/json" id="akvo-rsr-ajax-url">
     {"ajaxUrl": "{% url 'user_update_details' user.id %}?format=json"}


### PR DESCRIPTION
On the 'My details' page it's now possible, in addition to selecting an organisation from the dropdown, to type in the long_name or name of an organisation in order to connect to an organisation.