### PR TITLE
[#1116] Populate created at

### DIFF
--- a/akvo/rsr/migrations/0086_created_stamps.py
+++ b/akvo/rsr/migrations/0086_created_stamps.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 from django.contrib.admin.models import LogEntry, ADDITION
 from django.contrib.contenttypes.models import ContentType
 from south.utils import datetime_utils as datetime
-from south.db import db
 from south.v2 import DataMigration
 import tablib
 
@@ -24,7 +23,7 @@ class Migration(DataMigration):
         models = (project_data, org_data)
 
         def model_dict(csv_file):
-            """
+            """ Create a dictionary from the projects and organisations CSV files with created timestamps data
             :param csv_file: the file with object IDs and created_at timestamps.
                 Used when we don't find a record for creation in the django_admin_log
             :return: a dictionary with object IDs as keys and the created timestamp as values
@@ -41,26 +40,25 @@ class Migration(DataMigration):
 
         for model in models:
             timestamps = model_dict(model.csv_file)
-            for object in model.south_model.objects.all():
-                if object.created_at is None:
+            for obj in model.south_model.objects.all():
+                if obj.created_at is None:
                     try:
                         log = LogEntry.objects.get(
                             content_type=ContentType.objects.get_for_model(model.south_model),
-                            object_id=object.id,
+                            object_id=obj.id,
                             action_flag=ADDITION
                         )
-                        object.created_at = log.action_time
+                        obj.created_at = log.action_time
                     except:
                         try:
-                            object.created_at = timestamps[object.id]
+                            obj.created_at = timestamps[obj.id]
                         except:
-                            print "No creation date for {} {}".format(model.south_model.__name__, object.id)
+                            print "No creation date for {} {}".format(model.south_model.__name__, obj.id)
                     else:
-                        object.save()
-
+                        obj.save()
 
     def backwards(self, orm):
-        "Write your backwards methods here."
+        "Can't reverse this data migration, sorry..."
 
     models = {
         u'auth.group': {

--- a/akvo/rsr/migrations/0086_created_stamps.py
+++ b/akvo/rsr/migrations/0086_created_stamps.py
@@ -1,0 +1,646 @@
+# -*- coding: utf-8 -*-
+from collections import namedtuple
+from django.contrib.admin.models import LogEntry, ADDITION
+from django.contrib.contenttypes.models import ContentType
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+import tablib
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        """ Migration adding created_at data to Project and Organisation objects.
+        The code first tries to find a record in the django_admin_log table (LogEntry model) and if found
+        just copies that timestamp to created_at.
+        Failing that we do a lookup in the CSV data that Lynn has handcrafted with additional timestamps
+        If that also fails we just bring the sad news to the console
+        """
+        Model = namedtuple('Model', 'south_model, csv_file')
+
+        project_data = Model(orm['rsr.Project'],'/var/akvo/rsr/code/akvo/scripts/projects.csv')
+        org_data = Model(orm['rsr.Organisation'],'/var/akvo/rsr/code/akvo/scripts/organisations.csv')
+        models = (project_data, org_data)
+
+        def model_dict(csv_file):
+            """
+            :param csv_file: the file with object IDs and created_at timestamps.
+                Used when we don't find a record for creation in the django_admin_log
+            :return: a dictionary with object IDs as keys and the created timestamp as values
+            """
+            data = tablib.Dataset()
+            with open(csv_file, 'r') as f:
+                data.csv = f.read()
+            return dict(
+                [
+                    (int(k), datetime.datetime.strptime(v, "%Y-%m-%d")) for k, v in
+                        zip(data['id'], data['created_at'])
+                ]
+            )
+
+        for model in models:
+            timestamps = model_dict(model.csv_file)
+            for object in model.south_model.objects.all():
+                if object.created_at is None:
+                    try:
+                        log = LogEntry.objects.get(
+                            content_type=ContentType.objects.get_for_model(model.south_model),
+                            object_id=object.id,
+                            action_flag=ADDITION
+                        )
+                        object.created_at = log.action_time
+                    except:
+                        try:
+                            object.created_at = timestamps[object.id]
+                        except:
+                            print "No creation date for {} {}".format(model.south_model.__name__, object.id)
+                    else:
+                        object.save()
+
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'rsr.benchmark': {
+            'Meta': {'ordering': "('category__name', 'name__order')", 'object_name': 'Benchmark'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Category']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Benchmarkname']"}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'benchmarks'", 'to': "orm['rsr.Project']"}),
+            'value': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'rsr.benchmarkname': {
+            'Meta': {'ordering': "['order', 'name']", 'object_name': 'Benchmarkname'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '80'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'rsr.budgetitem': {
+            'Meta': {'ordering': "('label',)", 'unique_together': "(('project', 'label'),)", 'object_name': 'BudgetItem'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'max_digits': '10', 'decimal_places': '2'}),
+            'currency': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.BudgetItemLabel']"}),
+            'other_extra': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'period_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'period_end_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'period_start': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'period_start_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'budget_items'", 'to': "orm['rsr.Project']"}),
+            'type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'value_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'rsr.budgetitemlabel': {
+            'Meta': {'ordering': "('label',)", 'object_name': 'BudgetItemLabel'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '20', 'db_index': 'True'})
+        },
+        'rsr.category': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Category'},
+            'benchmarknames': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['rsr.Benchmarkname']", 'symmetrical': 'False', 'blank': 'True'}),
+            'focus_area': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'categories'", 'symmetrical': 'False', 'to': "orm['rsr.FocusArea']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'db_index': 'True'})
+        },
+        'rsr.country': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Country'},
+            'continent': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '20', 'db_index': 'True'}),
+            'continent_code': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '2', 'db_index': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '50', 'db_index': 'True'})
+        },
+        'rsr.countrybudgetitem': {
+            'Meta': {'object_name': 'CountryBudgetItem'},
+            'code': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '6', 'blank': 'True'}),
+            'description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'percentage': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '1', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'country_budget_items'", 'to': "orm['rsr.Project']"}),
+            'vocabulary': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'})
+        },
+        'rsr.employment': {
+            'Meta': {'object_name': 'Employment'},
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Country']", 'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'employments'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_approved': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'job_title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'organisation': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'employees'", 'to': "orm['rsr.Organisation']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'employers'", 'to': "orm['rsr.User']"})
+        },
+        'rsr.focusarea': {
+            'Meta': {'ordering': "['name']", 'object_name': 'FocusArea'},
+            'description': ('akvo.rsr.fields.ValidXMLTextField', [], {'max_length': '500'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': (u'sorl.thumbnail.fields.ImageField', [], {'max_length': '100'}),
+            'link_to': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'})
+        },
+        'rsr.goal': {
+            'Meta': {'object_name': 'Goal'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'goals'", 'to': "orm['rsr.Project']"}),
+            'text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        'rsr.indicator': {
+            'Meta': {'object_name': 'Indicator'},
+            'ascending': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'baseline_comment': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'baseline_value': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'baseline_year': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'description_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'measure': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'result': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'indicators'", 'to': "orm['rsr.Result']"}),
+            'title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        'rsr.indicatorperiod': {
+            'Meta': {'object_name': 'IndicatorPeriod'},
+            'actual_comment': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'actual_value': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'indicator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'periods'", 'to': "orm['rsr.Indicator']"}),
+            'period_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'period_start': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'target_comment': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'target_value': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        'rsr.internalorganisationid': {
+            'Meta': {'unique_together': "(('recording_org', 'referenced_org'),)", 'object_name': 'InternalOrganisationID'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'identifier': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '200'}),
+            'recording_org': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'internal_ids'", 'to': "orm['rsr.Organisation']"}),
+            'referenced_org': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'reference_ids'", 'to': "orm['rsr.Organisation']"})
+        },
+        'rsr.invoice': {
+            'Meta': {'ordering': "['-id']", 'object_name': 'Invoice'},
+            'amount': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'amount_received': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '10', 'decimal_places': '2', 'blank': 'True'}),
+            'bank': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '4', 'blank': 'True'}),
+            'campaign_code': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '15', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'engine': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'paypal'", 'max_length': '10'}),
+            'http_referer': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ipn': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'is_anonymous': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'notes': ('akvo.rsr.fields.ValidXMLTextField', [], {'default': "''", 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'invoices'", 'to': "orm['rsr.Project']"}),
+            'status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'test': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'transaction_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.User']", 'null': 'True', 'blank': 'True'})
+        },
+        'rsr.keyword': {
+            'Meta': {'ordering': "('label',)", 'object_name': 'Keyword'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '30', 'db_index': 'True'})
+        },
+        'rsr.legacydata': {
+            'Meta': {'object_name': 'LegacyData'},
+            'iati_equivalent': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'legacy_data'", 'to': "orm['rsr.Project']"}),
+            'value': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        'rsr.link': {
+            'Meta': {'object_name': 'Link'},
+            'caption': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'kind': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'links'", 'to': "orm['rsr.Project']"}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'rsr.minicms': {
+            'Meta': {'ordering': "['-active', '-id']", 'object_name': 'MiniCMS'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'feature_box': ('akvo.rsr.fields.ValidXMLTextField', [], {'max_length': '350'}),
+            'feature_image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50'}),
+            'lower_height': ('django.db.models.fields.IntegerField', [], {'default': '500'}),
+            'top_right_box': ('akvo.rsr.fields.ValidXMLTextField', [], {'max_length': '350'})
+        },
+        'rsr.molliegateway': {
+            'Meta': {'object_name': 'MollieGateway'},
+            'currency': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'EUR'", 'max_length': '3'}),
+            'description': ('akvo.rsr.fields.ValidXMLTextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255'}),
+            'notification_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'partner_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '10'})
+        },
+        'rsr.organisation': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Organisation'},
+            'allow_edit': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'contact_email': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'contact_person': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '30', 'blank': 'True'}),
+            'content_owner': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Organisation']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'description': ('akvo.rsr.fields.ValidXMLTextField', [], {'blank': 'True'}),
+            'facebook': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'fax': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '20', 'blank': 'True'}),
+            'iati_org_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'db_index': 'True', 'max_length': '75', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'internal_org_ids': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'recording_organisation'", 'symmetrical': 'False', 'through': "orm['rsr.InternalOrganisationID']", 'to': "orm['rsr.Organisation']"}),
+            'language': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'en'", 'max_length': '2'}),
+            'last_modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'linkedin': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'logo': (u'sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'long_name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75', 'blank': 'True'}),
+            'mobile': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '20', 'blank': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '25', 'db_index': 'True'}),
+            'new_organisation_type': ('django.db.models.fields.IntegerField', [], {'default': '22', 'db_index': 'True'}),
+            'notes': ('akvo.rsr.fields.ValidXMLTextField', [], {'default': "''", 'blank': 'True'}),
+            'organisation_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'db_index': 'True'}),
+            'partner_types': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['rsr.PartnerType']", 'symmetrical': 'False'}),
+            'phone': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '20', 'blank': 'True'}),
+            'primary_location': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.OrganisationLocation']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'twitter': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        'rsr.organisationaccount': {
+            'Meta': {'object_name': 'OrganisationAccount'},
+            'account_level': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'archived'", 'max_length': '12'}),
+            'organisation': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['rsr.Organisation']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'rsr.organisationlocation': {
+            'Meta': {'ordering': "['id']", 'object_name': 'OrganisationLocation'},
+            'address_1': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'address_2': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'city': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Country']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('akvo.rsr.fields.LatitudeField', [], {'default': '0', 'db_index': 'True'}),
+            'location_target': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locations'", 'null': 'True', 'to': "orm['rsr.Organisation']"}),
+            'longitude': ('akvo.rsr.fields.LongitudeField', [], {'default': '0', 'db_index': 'True'}),
+            'postcode': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '10', 'blank': 'True'}),
+            'state': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        'rsr.partnership': {
+            'Meta': {'ordering': "['partner_type']", 'object_name': 'Partnership'},
+            'funding_amount': ('django.db.models.fields.DecimalField', [], {'db_index': 'True', 'null': 'True', 'max_digits': '10', 'decimal_places': '2', 'blank': 'True'}),
+            'iati_activity_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'db_index': 'True', 'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'iati_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'internal_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'db_index': 'True', 'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'organisation': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'partnerships'", 'to': "orm['rsr.Organisation']"}),
+            'partner_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '8', 'db_index': 'True'}),
+            'partner_type_extra': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'partnerships'", 'to': "orm['rsr.Project']"}),
+            'related_activity_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        'rsr.partnersite': {
+            'Meta': {'ordering': "('organisation__name',)", 'object_name': 'PartnerSite'},
+            'about_box': ('akvo.rsr.fields.ValidXMLTextField', [], {'max_length': '500', 'blank': 'True'}),
+            'about_image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'cname': ('akvo.rsr.fields.NullCharField', [], {'max_length': '100', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'custom_css': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'blank': 'True'}),
+            'custom_favicon': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'blank': 'True'}),
+            'custom_logo': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'blank': 'True'}),
+            'custom_return_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'custom_return_url_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "''", 'max_length': '50', 'blank': 'True'}),
+            'default_language': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'en'", 'max_length': '5'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'exclude_keywords': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'facebook_app_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'facebook_button': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'google_translation': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hostname': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'keywords': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'partnersites'", 'blank': 'True', 'to': "orm['rsr.Keyword']"}),
+            'last_modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'notes': ('akvo.rsr.fields.ValidXMLTextField', [], {'default': "''", 'blank': 'True'}),
+            'organisation': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Organisation']"}),
+            'partner_projects': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'piwik_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'twitter_button': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'ui_translation': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'rsr.partnertype': {
+            'Meta': {'ordering': "('label',)", 'object_name': 'PartnerType'},
+            'id': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '8', 'primary_key': 'True'}),
+            'label': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'rsr.paymentgatewayselector': {
+            'Meta': {'object_name': 'PaymentGatewaySelector'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mollie_gateway': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': "orm['rsr.MollieGateway']"}),
+            'paypal_gateway': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': "orm['rsr.PayPalGateway']"}),
+            'project': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['rsr.Project']", 'unique': 'True'})
+        },
+        'rsr.paypalgateway': {
+            'Meta': {'object_name': 'PayPalGateway'},
+            'account_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'currency': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'EUR'", 'max_length': '3'}),
+            'description': ('akvo.rsr.fields.ValidXMLTextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'US'", 'max_length': '2'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255'}),
+            'notification_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'})
+        },
+        'rsr.planneddisbursement': {
+            'Meta': {'object_name': 'PlannedDisbursement'},
+            'currency': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'period_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'period_start': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'planned_disbursements'", 'to': "orm['rsr.Project']"}),
+            'type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.DecimalField', [], {'max_digits': '10', 'decimal_places': '2', 'blank': 'True'}),
+            'value_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'rsr.policymarker': {
+            'Meta': {'object_name': 'PolicyMarker'},
+            'description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'policy_marker': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'policy_markers'", 'to': "orm['rsr.Project']"}),
+            'significance': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'vocabulary': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '5', 'blank': 'True'})
+        },
+        'rsr.project': {
+            'Meta': {'ordering': "['-id']", 'object_name': 'Project'},
+            'background': ('akvo.rsr.fields.ProjectLimitedTextField', [], {'blank': 'True'}),
+            'budget': ('django.db.models.fields.DecimalField', [], {'decimal_places': '2', 'default': '0', 'max_digits': '10', 'blank': 'True', 'null': 'True', 'db_index': 'True'}),
+            'capital_spend_percentage': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '1', 'blank': 'True'}),
+            'categories': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'projects'", 'blank': 'True', 'to': "orm['rsr.Category']"}),
+            'collaboration_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'currency': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'EUR'", 'max_length': '3'}),
+            'current_image': (u'sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'current_image_caption': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'current_image_credit': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'current_status': ('akvo.rsr.fields.ProjectLimitedTextField', [], {'blank': 'True'}),
+            'date_end_actual': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_end_planned': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_start_actual': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_start_planned': ('django.db.models.fields.DateField', [], {'default': 'datetime.date.today'}),
+            'default_aid_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'default_finance_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'default_flow_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'default_tied_status': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'donate_button': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'funds': ('django.db.models.fields.DecimalField', [], {'decimal_places': '2', 'default': '0', 'max_digits': '10', 'blank': 'True', 'null': 'True', 'db_index': 'True'}),
+            'funds_needed': ('django.db.models.fields.DecimalField', [], {'decimal_places': '2', 'default': '0', 'max_digits': '10', 'blank': 'True', 'null': 'True', 'db_index': 'True'}),
+            'goals_overview': ('akvo.rsr.fields.ProjectLimitedTextField', [], {}),
+            'hierarchy': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '1', 'null': 'True', 'blank': 'True'}),
+            'iati_activity_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'db_index': 'True', 'max_length': '100', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'keywords': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'projects'", 'blank': 'True', 'to': "orm['rsr.Keyword']"}),
+            'language': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'en'", 'max_length': '2'}),
+            'last_modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'last_update': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'the_project'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['rsr.ProjectUpdate']"}),
+            'notes': ('akvo.rsr.fields.ValidXMLTextField', [], {'default': "''", 'blank': 'True'}),
+            'partners': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'projects'", 'symmetrical': 'False', 'through': "orm['rsr.Partnership']", 'to': "orm['rsr.Organisation']"}),
+            'primary_location': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.ProjectLocation']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'project_plan': ('akvo.rsr.fields.ValidXMLTextField', [], {'blank': 'True'}),
+            'project_plan_summary': ('akvo.rsr.fields.ProjectLimitedTextField', [], {}),
+            'project_rating': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'project_scope': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'status': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'N'", 'max_length': '1', 'db_index': 'True'}),
+            'subtitle': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75'}),
+            'sustainability': ('akvo.rsr.fields.ValidXMLTextField', [], {}),
+            'sync_owner': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Organisation']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'sync_owner_secondary_reporter': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'target_group': ('akvo.rsr.fields.ProjectLimitedTextField', [], {'blank': 'True'}),
+            'title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '45', 'db_index': 'True'})
+        },
+        'rsr.projectcomment': {
+            'Meta': {'ordering': "('-id',)", 'object_name': 'ProjectComment'},
+            'comment': ('akvo.rsr.fields.ValidXMLTextField', [], {}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments'", 'to': "orm['rsr.Project']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.User']"})
+        },
+        'rsr.projectcondition': {
+            'Meta': {'object_name': 'ProjectCondition'},
+            'attached': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'conditions'", 'to': "orm['rsr.Project']"}),
+            'text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'})
+        },
+        'rsr.projectcontact': {
+            'Meta': {'object_name': 'ProjectContact'},
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'contacts'", 'null': 'True', 'to': "orm['rsr.Country']"}),
+            'department': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'job_title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'mailing_address': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'organisation': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'person_name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'to': "orm['rsr.Project']"}),
+            'state': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'telephone': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '15', 'blank': 'True'}),
+            'type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        'rsr.projectdocument': {
+            'Meta': {'ordering': "['-id']", 'object_name': 'ProjectDocument'},
+            'category': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'document': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'blank': 'True'}),
+            'format': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'documents'", 'to': "orm['rsr.Project']"}),
+            'title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'title_language': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        'rsr.projectlocation': {
+            'Meta': {'ordering': "['id']", 'object_name': 'ProjectLocation'},
+            'activity_description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'address_1': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'address_2': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'administrative_code': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '25', 'blank': 'True'}),
+            'administrative_level': ('django.db.models.fields.PositiveSmallIntegerField', [], {'max_length': '1', 'null': 'True', 'blank': 'True'}),
+            'administrative_vocabulary': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'city': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Country']"}),
+            'description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'exactness': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'feature_designation': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '5', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('akvo.rsr.fields.LatitudeField', [], {'default': '0', 'db_index': 'True'}),
+            'location_class': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'location_code': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '25', 'blank': 'True'}),
+            'location_reach': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'location_target': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locations'", 'null': 'True', 'to': "orm['rsr.Project']"}),
+            'longitude': ('akvo.rsr.fields.LongitudeField', [], {'default': '0', 'db_index': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'postcode': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '10', 'blank': 'True'}),
+            'reference': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'state': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'vocabulary': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'})
+        },
+        'rsr.projectupdate': {
+            'Meta': {'ordering': "['-id']", 'object_name': 'ProjectUpdate'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'en'", 'max_length': '2'}),
+            'last_modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'notes': ('akvo.rsr.fields.ValidXMLTextField', [], {'default': "''", 'blank': 'True'}),
+            'photo': (u'sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'photo_caption': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75', 'blank': 'True'}),
+            'photo_credit': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '25', 'blank': 'True'}),
+            'primary_location': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.ProjectUpdateLocation']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'project_updates'", 'to': "orm['rsr.Project']"}),
+            'text': ('akvo.rsr.fields.ValidXMLTextField', [], {'blank': 'True'}),
+            'title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'update_method': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'W'", 'max_length': '1', 'db_index': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.User']"}),
+            'user_agent': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'uuid': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "''", 'max_length': '40', 'db_index': 'True', 'blank': 'True'}),
+            'video': ('embed_video.fields.EmbedVideoField', [], {'max_length': '200', 'blank': 'True'}),
+            'video_caption': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75', 'blank': 'True'}),
+            'video_credit': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '25', 'blank': 'True'})
+        },
+        'rsr.projectupdatelocation': {
+            'Meta': {'ordering': "['id']", 'object_name': 'ProjectUpdateLocation'},
+            'address_1': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'address_2': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'city': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Country']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('akvo.rsr.fields.LatitudeField', [], {'default': '0', 'db_index': 'True'}),
+            'location_target': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locations'", 'null': 'True', 'to': "orm['rsr.ProjectUpdate']"}),
+            'longitude': ('akvo.rsr.fields.LongitudeField', [], {'default': '0', 'db_index': 'True'}),
+            'postcode': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '10', 'blank': 'True'}),
+            'state': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        'rsr.publishingstatus': {
+            'Meta': {'ordering': "('-status', 'project')", 'object_name': 'PublishingStatus'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['rsr.Project']", 'unique': 'True'}),
+            'status': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'unpublished'", 'max_length': '30'})
+        },
+        'rsr.recipientcountry': {
+            'Meta': {'object_name': 'RecipientCountry'},
+            'country': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'percentage': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '1', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'recipient_countries'", 'to': "orm['rsr.Project']"}),
+            'text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        'rsr.recipientregion': {
+            'Meta': {'object_name': 'RecipientRegion'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'percentage': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '1', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'recipient_regions'", 'to': "orm['rsr.Project']"}),
+            'region': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'region_vocabulary': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        'rsr.relatedproject': {
+            'Meta': {'ordering': "['project']", 'object_name': 'RelatedProject'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_projects'", 'to': "orm['rsr.Project']"}),
+            'related_project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_to_projects'", 'to': "orm['rsr.Project']"}),
+            'relation': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1'})
+        },
+        'rsr.result': {
+            'Meta': {'object_name': 'Result'},
+            'aggregation_status': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'description_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'results'", 'to': "orm['rsr.Project']"}),
+            'title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'})
+        },
+        'rsr.sector': {
+            'Meta': {'object_name': 'Sector'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'percentage': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '1', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sectors'", 'to': "orm['rsr.Project']"}),
+            'sector_code': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '5', 'blank': 'True'}),
+            'text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'vocabulary': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '5', 'blank': 'True'})
+        },
+        'rsr.transaction': {
+            'Meta': {'object_name': 'Transaction'},
+            'aid_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'aid_type_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'currency': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'disbursement_channel': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'disbursement_channel_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'finance_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'finance_type_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'flow_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'flow_type_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'transactions'", 'to': "orm['rsr.Project']"}),
+            'provider_organisation': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'provider_organisation_activity': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'provider_organisation_ref': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'receiver_organisation': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'receiver_organisation_activity': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'receiver_organisation_ref': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'reference': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '25', 'blank': 'True'}),
+            'tied_status': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'tied_status_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'transaction_date': ('django.db.models.fields.DateField', [], {'blank': 'True'}),
+            'transaction_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'transaction_type_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'value': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '11', 'decimal_places': '1', 'blank': 'True'}),
+            'value_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'rsr.user': {
+            'Meta': {'ordering': "['username']", 'object_name': 'User'},
+            'avatar': (u'sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'null': 'True'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '254'}),
+            'first_name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '30', 'blank': 'True'}),
+            'notes': ('akvo.rsr.fields.ValidXMLTextField', [], {'default': "''", 'blank': 'True'}),
+            'organisations': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'users'", 'blank': 'True', 'through': "orm['rsr.Employment']", 'to': "orm['rsr.Organisation']"}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '254'})
+        }
+    }
+
+    complete_apps = ['rsr']
+    symmetrical = True

--- a/akvo/scripts/organisations.csv
+++ b/akvo/scripts/organisations.csv
@@ -1,0 +1,2262 @@
+id,name,full_name,type,created_at
+1,Plieger,,C,2008-06-19
+2,IDYDC,"Iringa Development of Youth, Disabled and Children Care ",N,2008-06-19
+7,CBHCC,Community Based Health Care Council ,N,2008-06-30
+8,Simavi,Simavi,N,2008-06-30
+12,CUS,Calcutta Urban Service,N,2008-07-14
+12,CUS,Calcutta Urban Service,N,2008-07-15
+13,WASTE,WASTE advisers on urban environment and development,N,2008-07-15
+14,FODRA,Foundation of Development Research and Action,N,2008-07-15
+15,PRACTICA,PRACTICA Foundation,N,2008-07-16
+16,CRS,Catholic Relief Service,N,2008-07-16
+17,VSA,Voahary Salama Association,N,2008-07-16
+18,FSG,FrÃ¨res de Saint Gabriel,N,2008-07-16
+19,BASA,Bangladesh Association for Social Awareness,N,2008-07-16
+20,PA Bangladesh,Practical Action Bangladesh,N,2008-07-16
+21,Sahel SolidaritÃ©,,N,2008-07-16
+22,ADEID,"Action pour un DÃ©veloppement Ã‰quitable, IntÃ©grÃ© et Durable",N,2008-07-16
+25,ENPHO,ENPHO,N,2008-07-16
+26,Hygiene Village Project,,N,2008-07-16
+27,Simli AiD,,N,2008-07-16
+28,ERHA,ERHA,N,2008-07-16
+29,ESF,Electriciens Sans FrontiÃ¨res,N,2008-07-16
+30,Lore Eco Club,,N,2008-07-16
+31,FVC,Femei pentru o Vitorii Curat,N,2008-07-16
+32,RCDA,Rural Communities Development Agency,N,2008-07-16
+33,Vozrojdeny,"Regional public ecological organisation \Vozrojdenye\"" of Tatarbunary""",N,2008-07-16
+34,IICD,International Institute for Communication and Development,N,2008-07-16
+35,RAIN,RAIN,N,2008-07-16
+36,WECF,,N,2008-07-17
+37,GRET,GRET a Solidarity and International Cooperation Association,N,2008-07-17
+39,CRAID,,N,2008-07-17
+41,UrSU,The State University of Urgench,K,2008-07-17
+41,UrSU,The State University of Urgench,K,2008-07-29
+42,Akvo,Akvo Foundation,N,2008-07-17
+42,Akvo,Akvo Foundation,N,2008-08-04
+43,Aqua for All,Aqua for All,N,2008-07-17
+43,Aqua for All,Aqua for All,N,2008-08-10
+44,NOTS Foundation,NOTS Entrepreneurial Development Aid,N,2008-07-17
+44,NOTS Foundation,NOTS Entrepreneurial Development Aid,N,2008-08-10
+45,PRIDE,,N,2008-07-17
+45,PRIDE,,N,2008-08-10
+46,UP4S ,Uganda Primary-Secondary School Support Scheme,N,2008-08-10
+47,Salek,Stimulate African Life by Education for Kids ,N,2008-08-10
+48,EFLI,Education For Life Initiative,N,2008-08-10
+50,Stichting Daryeel,,N,2008-08-11
+52,EARTH Concepts,EARTH Concepts,C,2008-08-13
+53,Parade,Theaterfestival de Parade,N,2008-08-13
+55,TAPPS,TAPPS Strandvolleybal.net ,C,2008-08-15
+56,Connect International,Stichting Connect International,N,2008-11-04
+57,SHIPO,Southern Highlands Participatory Organisation,N,2008-11-04
+58,PSOC,Program to Save the Old City of Fianarantsoa,G,2008-12-18
+59,ASAP,Association for Small African Projects,N,2008-12-18
+60,Arghyam,,N,2009-01-23
+64,SI/E Kisumu,Soroptimist Kisumu Winam Club,N,2009-01-27
+65,WfWP,Women for Water Partnership,N,2009-01-27
+66,SI/E Addis Ababa,Soroptimist International Addis Ababa Club,N,2009-01-27
+67,SI/E Bamako,Soroptimist International Bamako Espoir,N,2009-01-27
+68,SI/E Sweden,"Soroptimist Club Kalmar, Sweden",N,2009-01-27
+69,VAM,Women and Labour Market Foundation,N,2009-01-28
+71,Ramro,Stichting Ramro,N,2009-02-14
+74,MACERUDET,Mmanze Center For Rural Development,N,2009-02-15
+75,Fred Foundation,Fred Foundation,N,2009-02-15
+77,Namelok,Stichting Namelok,N,2009-02-16
+79,Silent Work,Stichting Silent Work,N,2009-02-16
+80,WvW 2009,Wandelen voor Water 2009,N,2009-02-16
+81,Vrienden van de Sahel,Stichting Vrienden van de Sahel ,N,2009-02-16
+82,A.C.D.,Action Couverture et Developpement ,N,2009-02-16
+86,Sahjeevan,,N,2009-02-20
+87,WASMO,Water and Sanitation Management Organisation,G,2009-02-20
+88,WOPD,Womenâ€™s Organisation for Progress and Development,N,2009-02-25
+89,ZijActief ,ZijActief Nederland ,N,2009-02-25
+90,Agriterra,Agriterra,N,2009-02-25
+91,HOAT,Agricultural Relief Organisation Thailand,N,2009-02-26
+92,AquaEst,AquaEst Europe B.V.,C,2009-02-26
+93,World Vision Cyprus,World Vision International - Cyprus,N,2009-02-26
+94,AMREF Kenya,African Medical and Research Foundation,N,2009-03-03
+95,Amref Flying Doctors,Stichting Amref Flying Doctors Nederland,N,2009-03-03
+96,Wilde Ganzen,Stichting Wilde Ganzen,N,2009-03-03
+98,HORCO,Hope for Rural Children and Orphans,N,2009-04-02
+99,KIRDARC,Karnali Integrated Rural Development & Research Centre,N,2009-04-06
+100,SNV Asia,SNV Netherlands Development Organisation â€“ Asia,N,2009-04-06
+101,Together in Action,Foundation Together in Action,N,2009-05-07
+102,AAWS,Aqua-Aero WaterSystems BV,C,2009-05-25
+103,Rotary Goes,Rotary Club Goes,N,2009-05-25
+104,S.P.S.,Stichting Plattelandsontwikkeling Senegal,N,2009-05-25
+105,QuaWater ,QuaWater ,C,2009-06-16
+106,Impulsis,"Impulsis, een initiatief van ICCO, Edukans en Kerk in Actie",N,2009-06-16
+108,COFORWA,COFORWA (Les Compagnons Fontainiers Rwandais),N,2009-06-23
+109,Abdo,Abdo Foundation,N,2009-07-22
+110,Pump Aid,Pump Aid,N,2009-07-30
+111,Meal-A-Day,Christadelphian meal-a-day fund,N,2009-07-30
+112,AIDFI,Alternative Indigenous Development Foundation,N,2009-08-11
+113,Wandelen voor Water ,Wandelen voor Water ,N,2009-08-21
+114,SLYI,Sierra Leone Youth Initiative,N,2009-08-28
+115,Max Foundation,Max Foundation,N,2009-09-01
+118,Twestival Karlshamn,Twestival Karlshamn,N,2009-09-04
+120,Twestival NorrkÃ¶ping,Twestival NorrkÃ¶ping,N,2009-09-07
+121,arche noVa,,N,2009-09-14
+122,C-DARMA,Centre de DÃ©veloppement de l'Artisanat Rural et du Machinisme Agricole,N,2009-09-17
+123,Splash,Splash,N,2009-09-23
+124,Splash - China,Splash- China,N,2009-09-23
+126,E-Water,E-Water Deutschland ,N,2009-09-23
+127,Helder Water,Stichting Helder Water,N,2009-09-25
+128,Lien Aid,Lien Aid Limited,N,2009-09-25
+129,RWC,Rain Water Cambodia ,N,2009-09-25
+130,LVIA,,N,2009-09-27
+131,CRWF ,Canadian Rotarian Water Foundation,N,2009-09-27
+132,Rotary D9210,"Rotary Club of Hunyani, District 9210 - Zimbabwe",N,2009-09-27
+133,Fondo para la Paz ,,N,2009-09-29
+134,GWC,,N,2009-09-30
+135,Manna Energy Foundation,Manna Energy Foundation,N,2009-09-30
+136,Water for People,Water for People,N,2009-09-30
+137,ADPP Mozambique,Ajuda de Desenvolvimento de Povo para Povo ,N,2009-10-06
+138,DAPP Zambia ,Development Aid from People to People in Zambia,N,2009-10-06
+139,AWHHE,Armenian Women for Health and Healthy Environment ,N,2009-10-06
+140,CONSAM LTDA,Consultoria Sanitaria y Ambiental Ltda.,C,2009-10-06
+141,Tree Africa,Tree Africa,N,2009-10-08
+142,EcoTact,EcoTact,C,2009-10-08
+143,Mama-86,Mama-86-Kharkiv,N,2009-10-09
+144,Unilever,Unilever South Africa,C,2009-10-09
+145,Wildlands,,N,2009-10-09
+146,Dien Bien WRS,Dien Bien Water Resources Sub-Department,G,2009-10-12
+147,Live Earth,Live Earth LLC,C,2009-10-13
+148,Chawama Youth Project,Chawama Youth Project (CYP),N,2009-10-15
+149,Emesco,Emesco Development Foundation (EDF),N,2009-10-15
+150,SVHB,Stichting Vrienden Holten-Bedanda,N,2009-10-16
+151,IWP,,N,2009-10-19
+152,JointhePipe.org,JointhePipe.org,N,2009-11-03
+153,BSP Nepal,BSP Nepal,N,2009-11-04
+154,CARITAS KAOLACK,CARITAS KAOLACK,N,2009-11-04
+155,NRCS,Nepal Red Cross Society,N,2009-11-04
+156,SCOPE,Society for Community Organisation and Peoples Education,N,2009-11-20
+157,The Resource Foundation,The Resource Foundation ,N,2009-11-26
+158,APP,Agua Para el Pueblo,N,2009-11-26
+159,Action Aid Senegal,Action Aid Senegal,N,2009-12-09
+160,ARFA,Association pour la Recherche et la Formation en Agro-ecologie,N,2009-12-10
+161,AGED,Association pour la Gestion de l'Environnement et le Developpement,N,2009-12-10
+162,Huisman Foundation,Huisman Foundation,N,2009-12-11
+164,Rotary Apeldoorn 't Loo,Rotary Apeldoorn 't Loo,N,2009-12-16
+165,Waterschap De Dommel ,Waterschap De Dommel ,G,2009-12-22
+166,Kijlstra,Kijlstra,C,2009-12-23
+168,Other contributions,Individual donations / local contributions,N,2010-01-07
+169,Le Connaisseur Utrecht,Grand Restaurant Le Connaisseur Utrecht BV,N,2010-01-08
+170,ARRAKIS,,C,2010-01-14
+171,WASRAG,Water & Sanitation Rotarian Action Group,N,2010-01-15
+172,AMREF Tanzania,African Medical and Research Foundation,N,2010-01-19
+173,BISWA,Bharat Integrated Social Welfare Agency,N,2010-01-20
+174,Riverfoundation,,N,2010-01-21
+176,St. Wageningen-Ndiza,Stichting Samenwerking Wageningen-Ndiza,N,2010-02-02
+177,Gemeente Wageningen,Gemeente Wageningen,G,2010-02-02
+179,DHAN Foundation,DHAN Vayalagam (Tank) Foundation,N,2010-02-03
+180,Rabobank Foundation,Rabobank Foundation,N,2010-02-03
+181,RC Wageningen-Bergpoort,Rotary Club Wageningen-Bergpoort,N,2010-02-04
+182,Demotech,"Demotech, design for self-reliance",N,2010-02-12
+184,India Water Portal,India Water Portal,N,2010-02-16
+185,S.K.I.,Stichting Kinderhulp IndonesiÃ«,N,2010-02-17
+186,Tweed Shire Council,Tweed Shire Council,G,2010-02-17
+187,Tweed Kenya,Tweed Community Kenya Mentoring Program,N,2010-02-17
+188,Kansarmen Sri Lanka,Stichting Kansarmen Sri Lanka,N,2010-02-22
+189,SPEG,Stichting Projectkoppeling Eindhoven Gedaref,N,2010-02-24
+190,Brabant Water,Brabant Water,C,2010-02-26
+191,Gemeente Eindhoven,Gemeente Eindhoven,G,2010-02-26
+192,SBNN,Stichting Buru Nyakwere Nederland,N,2010-02-27
+193,Rotary Hulst,Rotary Club Hulst,N,2010-02-27
+195,Msele,Stichting Msele ~ Vechters voor water,N,2010-03-01
+196,YelkabÃ©,Stichting YelkabÃ©,N,2010-03-01
+197,BARKA,The BARKA Foundation,N,2010-03-04
+198,Espacio Agua,Espacio Agua,N,2010-03-08
+199,IIED-AL,Instituto International de Medio Ambiente y Desarrollo - AmÃ©rica Latina ,N,2010-03-08
+200,CDO,Cambodia Dutch Organization,N,2010-03-09
+201,Rainbows4children,Rainbows4children Stiftung,N,2010-03-09
+202,TDVA,Tigray Disabled Veterans Association,N,2010-03-09
+203,Naandi,Naandi Foundation,N,2010-03-10
+204,SANA,Sustainable Aid in Africa International,N,2010-03-11
+206,VJNNS,Visakha Jilla Nava Nirmana Samithi,N,2010-03-12
+207,ZOA Ethiopia,ZOA Ethiopia,N,2010-03-15
+208,SAP,Stichting Afrika Projecten,N,2010-03-15
+209,WvW 2010 ,Wandelen voor Water 2010,N,2010-03-16
+210,FINISH,Financial INclusion Improves Sanitation and Health,N,2010-03-16
+212,Bouwmaat,Bouwmaat,C,2010-03-17
+214,Stichting MIM,Stichting Mirjam in Malawi,N,2010-03-18
+215,LONAB,Loterie Nationale BurkinabÃ©,C,2010-03-20
+216,Source Connection,The Source Connection Foundation,N,2010-03-26
+217,NCDO,Nationale Commissie Internationale Samenwerking Duurzame Ontwikkeling,N,2010-03-26
+219,Instituto e,Instituto e,N,2010-03-29
+220,CILSJ,ConsÃ³rcio Intermunicipal Lagos - SÃ£o JoÃ£o,G,2010-03-29
+221,Warhammer for Water,,N,2010-03-30
+222,World Waternet ,World Waternet ,G,2010-04-06
+223,BWADC,Behira Water & Drainage Co.,C,2010-04-06
+225,St. Lembaga Kerja Sama,,N,2010-04-07
+226,RC Valkenswaard,Rotary Club Valkenswaard,N,2010-04-07
+227,Cycle for Water,Cycle for Water,N,2010-04-08
+228,Dow Chemical IbÃ©rica,Dow Chemical IbÃ©rica,C,2010-04-16
+229,Live Earth Singapore,Live Earth Singapore,N,2010-04-28
+230,Dow Benelux ,Dow Benelux BV,C,2010-04-29
+233,Emmaus Regenboog,Emmaus Regenboog,N,2010-05-11
+234,Bas & Frida 40 jaar ,Bas & Frida 40 jaar getrouwd,N,2010-05-17
+235,Live Earth Mexico,Live Earth Mexico ,N,2010-05-18
+237,Live Earth Hong Kong,Live Earth Hong Kong,N,2010-05-21
+238,LIve Earth Melbourne,LIve Earth Melbourne,N,2010-05-31
+239,DOS Doetinchem,Stichting Doetinchem en Ontwikkelingssamenwerking (DOS),N,2010-06-08
+240,PFP,Potters for Peace,N,2010-06-10
+241,Live Earth Brazil,Live Earth Brazil,N,2010-06-18
+242,CCM,Christian Council of Mozambique,N,2010-06-18
+243,Dorcas,Dorcas Aid International,N,2010-06-18
+244,ICU service centre,International Contact Uganda Service Centre,N,2010-06-21
+245,Rotary Rijssen,Rotary Club Rijssen,N,2010-07-01
+246,C4C,Concerts For Change,N,2010-07-05
+247,Live Earth Argentina,Live Earth Argentina,N,2010-08-04
+248,OOGvoorBrunapeg,Foundation 'OOG for Brunapeg',N,2010-08-16
+250,H+H 50 ,Hans en Hanneke Gelderblom,N,2010-09-21
+251,Shechen Clinic,"Shechen Clinic and Hospice, Nepal",N,2010-09-29
+252,RC Brummen-Engelenburg,Rotaryclub Brummen-Engelenburg,N,2010-09-29
+254,TU Delft,Delft University of Technology,K,2010-10-06
+255,Students 4 Sustainability,Stichting Students 4 Sustainability,N,2010-10-06
+256,Zontaclub 't Gooi,Zontaclub 't Gooi,N,2010-11-04
+260,IRC,IRC International Water and Sanitation Centre,K,2010-11-11
+266,H2O for Life,H2O for Life,N,2010-11-11
+267,MAPRONET,Market Access Promotion Network,N,2010-11-11
+268,Hivos,Hivos,N,2010-11-14
+269,Pag-La-Yiri,Pag-La-Yiri,N,2010-11-15
+271,Bernard van Leer,Bernard van Leer Foundation,N,2010-11-15
+272,Connect4Change,Connect4Change,N,2010-11-15
+273,Cordaid,Cordaid,N,2010-11-15
+274,Health Child,Health Child,N,2010-11-15
+275,Dutch WASH Alliance,Dutch WASH Alliance,N,2010-11-15
+276,AVINA,FundaciÃ³n AVINA,N,2010-11-19
+277,CARE Ecuador,CARE Internacional en Ecuador,N,2010-11-19
+278,Loja Provincial Gov.,Loja Provincial Government,G,2010-11-19
+279,Cotelvo Limitada (Ltda),Cooperativa Telefonica de Provision de Obras y Servicios Publicos,C,2010-11-19
+280,AHJASA,Asociacion Hondurena de Juntas Administradoras de Sistemas de Agua (AHJASA),N,2010-11-22
+281,The International Center,The International Center ,N,2010-11-22
+282,PPG Industries,"PPG Industries, Inc.",C,2010-11-22
+283,Basisschool de Oosthoek,Basisschool de Oosthoek,G,2010-11-24
+284,Paul Sieverding-Fonds,Rotterdamse Vereniging voor Katholiek Onderwijs,N,2010-11-24
+289,WvW 2011,Wandelen voor Water 2011,N,2010-11-25
+290,TEDxAward,TEDxAmsterdam Award,N,2010-12-06
+291,DDD2012,Dutch Delta Design 2012,N,2010-12-06
+292,IDE Ethiopia,International Development Enterprise Ethiopia,N,2010-12-07
+293,Selam Awassa,Selam Awassa Technical and Vocational Training College,C,2010-12-07
+294,Text to Change,Text to Change,N,2010-12-07
+295,SEEtrust,SEEtrust Women Entrepreneurship,N,2010-12-08
+296,DED,Deutscher Entwicklungsdienst,N,2010-12-08
+297,Stichting Sahelp,Stichting Sahelp,N,2010-12-10
+298,WADEP,Women and Development Project,N,2010-12-14
+299,CD Bethesda,Community Development Unit of Bethesda Hospital,N,2010-12-14
+300,ELCT,ELCT,N,2010-12-14
+301,HHDelfland,Hoogheemraadschap van Delfland,G,2010-12-16
+302,CDN,Consortium of Dutch NGOÂ´s ,N,2010-12-16
+303,SEND Foundation,SEND Foundation West Africa,N,2010-12-16
+304,Close the Gap,Close the Gap ,N,2010-12-20
+305,CFSU,Computers for Schools Uganda,N,2010-12-20
+308,UCMB,Uganda Catholic Medical Bureau,N,2010-12-20
+309,RFR,Red Financiera Rural,N,2010-12-21
+310,CSSC,Christian Social Services Commission,N,2010-12-21
+311,Sengerema Hospital,Sengerema Designated District Hospital,N,2010-12-21
+312,Magu District Council  ,Magu District Council  ,G,2010-12-21
+313,Friends of Nyanje/11000km,Friends of Nyanje foundation with www.11000km.nl,N,2010-12-21
+314,Nyanje school,Nyanje Day Secondary School and the Nyanje Basic School in Zambia,K,2010-12-21
+315,Tauw ,Tauw bv,C,2010-12-21
+316,GreenAdsBlue,GreenAdsBlue Foundation,N,2010-12-21
+317,FEPPASI,FÃ©dÃ©ration des Professionnels Agricoles de la Sissili,N,2010-12-22
+318,SDC Burkina,Swiss Development Cooperation,G,2010-12-22
+319,Edukans,Edukans,N,2010-12-22
+320,SEED Samburu,Samburu Empowerment through Education and Development,N,2010-12-23
+321,Mpelembe Secondary School,"Mpelembe Secondary School, Zambia",K,2011-01-03
+322,Tenda Pamoja,Stichting Tenda Pamoja Kenia,N,2011-01-04
+323,Support Yayeme,Stichting Support Yayeme,N,2011-01-04
+324,GMB Civiel B.V.,GMB Civiel B.V.,C,2011-01-10
+325,ADAF Yungar,Association pour le DÃ©veloppement de l'Arrondissement de Fimela Yungar,N,2011-01-11
+327,CERTES,Centre dâ€™Expertise et de Recherche en Telemedecine et E-Sante ,N,2011-01-17
+328,Sene Kunafoni Bulon,Sene Kunafoni Bulon,N,2011-01-17
+329,FRUILEMA,GIE FRUILEMA,C,2011-01-17
+330,SDC Mali,Swiss Development Cooperation,G,2011-01-18
+331,Keneya Blown,Keneya Blown,N,2011-01-19
+332,Various investors,Various investors,C,2011-01-19
+333,Manobi,Manobi,C,2011-01-19
+334,Waves of Change,Waves of Change,C,2011-02-01
+335,Stichting KAP,Stichting Vrienden van het Kitale AIDS Programme,N,2011-02-01
+336,KAP,Kitale AIDS Programme,N,2011-02-01
+337,Janivo,Stichting Janivo,N,2011-02-01
+338,KJS,Kon. Julianaschool,K,2011-02-10
+339,Local Communities Kitale,Local Communities Kitale,N,2011-02-15
+340,Arthacharya Foundation,Arthacharya Foundation,N,2011-02-20
+341,Rabobank UHR,Rabobank Utrechtse Heuvelrug,C,2011-03-02
+342,Stichting Onamika ,Stichting Onamika ,N,2011-03-03
+343,Nova College,Nova College Haarlem,K,2011-03-03
+344,Walking for Water 2011,Walking for Water international 2011,N,2011-03-03
+345,Water-Right,Stichting Water-Right ,C,2011-03-08
+346,Ological,Ological waterkoelers,C,2011-03-10
+347,Vrienden van Congo,Stichting Vrienden van Congo,N,2011-03-24
+348,F.N.P.C,FRATERNITE NATIONALE DES PRISONS AU CONGO,N,2011-03-24
+349,PKN steenwijk,Protestantse gemeente Steenwijk,N,2011-03-24
+350,Gemeente Steenwijkerland,Gemeente Steenwijkerland,G,2011-03-24
+351,St. Peters Primary School,St. Peters RC Primary School,G,2011-03-31
+352,Fundauniban,FundaciÃ³n de Bananeros UNIBAN,N,2011-04-15
+353,Agius de Soldanis School,Agius de Soldanis Girls' Secondary School,K,2011-04-15
+354,Resilience,Resilience Foundation,N,2011-04-28
+355,TWG,Tegemeo Women Group,N,2011-05-18
+356,Leiden-Buffalo City,Stichting Stedenband Leiden-Buffalo City,N,2011-05-19
+357,ELCYCC,East London Child and Youth Care Centre,N,2011-05-19
+358,Our Lady's & St Joseph's,Our Lady's & St Joseph primary school,K,2011-05-23
+359,Lijn in Waterloop,De HKV Lijn in Waterloop,C,2011-05-27
+360,CommonSites,CommonSites.net,N,2011-05-30
+361,Leiden University,"Faculty of Archaeology, Leiden University",K,2011-05-30
+362,MOTA-DACH,Department of Antiquities and Cultural Heritage,G,2011-05-30
+363,Neth. Repr. Off. Ramallah,Netherlands Representative Office (NRO) to the Palestinian Authority ,G,2011-05-30
+364,UNESCO Ramallah,UNESCO Office Ramallah,G,2011-05-30
+365,Partners for Water,Partners for Water,G,2011-05-31
+366,EMF,The Ecological Management Foundation,C,2011-06-01
+367,ProPortion,ProPortion Foundation,N,2011-06-06
+368,Muso Ladamunen,Project Muso Ladamunen,N,2011-06-07
+369,FENASCOM,FÃ©dÃ©ration nationale des associations de santÃ© communautaire du Mali,N,2011-06-07
+371,Earth Water Spain,Earth Water Spain,C,2011-06-07
+372,ZHP,Zambia Honey Partnership (ZHP),N,2011-06-07
+373,OPPAZ,Organic Producers and Processors Association of Zambia,N,2011-06-07
+374,Network for Africa,Network for Africa,N,2011-06-08
+375,Aspire Rwanda,Aspire Rwanda,N,2011-06-08
+376,Voltea,Voltea,C,2011-06-08
+377,DAM,Dhaka Ahsania Mission ,N,2011-06-09
+378,Dykesmains primary school,Dykesmains primary school,K,2011-06-14
+379,Unilever Ventures,Unilever Ventures Limited,C,2011-06-15
+380,Pentair Foundation,Pentair Foundation,C,2011-06-15
+381,Valley Foundation,The Valley Foundation,C,2011-06-15
+382,MWF,Micro Water Facility (MWF),N,2011-06-15
+383,Archeon,Archeon,C,2011-06-21
+384,New Covenant Ministries,New Covenant Ministries,N,2011-06-29
+385,PCCO,Patongo Community Counselling Outreach,N,2011-06-30
+386,AFDC,Association pour la Facilitation du DÃ©veloppement Communautaire,C,2011-06-30
+387,St. Faso,Stichting Faso,K,2011-06-30
+388,Share4More,Rabobank Share4More,N,2011-07-03
+389,Biome,Biome Environmental Trust,N,2011-07-07
+390,Rainwater Club,Rainwater Club,N,2011-07-07
+391,Kantara,Stichting Kantara,N,2011-07-14
+392,CharITy,CharITy,N,2011-07-14
+393,Nicaraguan Heritage ,Central Nicaragua Archaeological Project,N,2011-07-18
+395,Yojana,Yojana Projecthulp,N,2011-08-12
+396,SEDT,Socio Economic Development Trust,N,2011-08-12
+397,YPS,Yerala Project Society,N,2011-08-12
+398,Eureko Achmea,Eureko Achmea Foundation,C,2011-08-12
+399,Neba,Nederland-Batam foundation,N,2011-08-16
+400,Pinaesaan clinic,Klinik KB Perkotaan Pinaesaan,N,2011-08-16
+401,Serba Usaha cooperation,KOPERASI SERBA USAHA JATIROGO,N,2011-08-16
+402,KOMPASS,"KOMPASS, Sangihe",N,2011-08-16
+403,Health[e]Foundation ,Health[e]Foundation ,N,2011-08-16
+404,FC,Facilitator for change,N,2011-08-18
+405,ICCO,ICCO,N,2011-08-18
+406,ASIAN EYE CARE,Association for Eye Care Development in Asia,N,2011-08-30
+407,Choray Hospital ,Ho Chi MinhCommunist Youth Union of Cho Ray Hospital,G,2011-08-30
+408,SAPP,The Sponsoring Association for Poor Patients,N,2011-08-30
+409,Kinderhulp Bodhgaya,Stichting Kinderhulp Bodhgaya,N,2011-09-05
+410,NBJK,Nav Bharat Jagriti Kendra,N,2011-09-05
+411,1%Club,Stichting 1%CLUB,N,2011-09-05
+412,KEWASNET,Kenya Water and Sanitation CSOs Network ,N,2011-09-08
+413,Practical Action Kenya,Practical Action Kenya,N,2011-09-08
+414,SASOL Foundation,SASOL Foundation,N,2011-09-08
+415,ICRAF Kenya,International Centre for Research in Agroforestry,K,2011-09-08
+416,WaterAid Kenya,WaterAid Kenya,N,2011-09-08
+417,EFDA,Education for Development Assocation,N,2011-09-16
+418,NVEA,New Vision in Education Association,N,2011-09-16
+419,IWCIDA,Illu Women and Children Developement Association,N,2011-09-16
+420,DEC,DEC,N,2011-09-16
+421,ARHR,Alliance for Reproductive Health Rights (ARHR),N,2011-10-04
+422,ADAA,African Development Aid Association,N,2011-10-06
+423,CDI,Center for Development Initiatives,N,2011-10-06
+424,OSRA,Oromo Self Reliance Association,N,2011-10-06
+425,HUNDEE,HUNDEE Oromo Grassroots Development Initiative,N,2011-10-07
+426,ERSHA,ERSHA,N,2011-10-07
+427,SavSign,Savana Signatures,N,2011-10-24
+428,UNDP,United Nations Development Programme,K,2011-10-26
+430,Government of Finland,Ministry for Foreign Affairs Finland,G,2011-10-26
+431,ITFC,International Islamic Trade Finance Corporation,G,2011-10-26
+432,UNDP Armenia,"United Nations Development Programme, Armenia",G,2011-10-26
+434,UNDP Georgia,United Nations Development Programme Georgia,G,2011-10-26
+435,Adjara Government ,"Adjara Government, Georgia",G,2011-10-26
+438,One Foundation,The One Foundation,N,2011-11-14
+439,NETWAS,NETWAS,N,2011-11-14
+440,Oxfam GB,Oxfam GB,N,2011-11-14
+441,ETC-UA,ETC Urban Agriculture,N,2011-11-14
+442,Co-operative,The Co-operative,C,2011-11-14
+443,Plan International,Plan International,N,2011-11-14
+444,WvW 2012,Wandelen voor Water 2012,N,2011-11-14
+445,Waterschap Groot Salland,Waterschap Groot Salland,G,2011-11-15
+446,Aspect Capital,Aspect Capital,C,2011-11-17
+447,CEPAC,Centro de PromociÃ³n Agropecuaria Campesina,N,2011-11-21
+448,FAUTAPO,Fundacion Fautapo,N,2011-11-21
+449,PROINPA,FundaciÃ³n PROINPA,N,2011-11-21
+450,AOPEB,AsociaciÃ³n de organizaciones de productores EcolÃ³gicos de Bolivia,N,2011-11-21
+451,Fe y AlegrÃ­a,Fe y AlegrÃ­a Bolivia,N,2011-11-21
+452,IRFA,Instituto RadiofÃ³nico Fe y Alegria,N,2011-11-21
+454,APCOB,Apoyo Para el Campesino-Indigena del Oriente Boliviano,N,2011-11-21
+455,Educatic,Educatic bolivia,N,2011-11-21
+456,FundaciÃ³n ACLO,FundaciÃ³n AcciÃ³n Cultural Loyola,N,2011-11-21
+457,Profit Rural,Profit Rural,N,2011-11-21
+458,CIOEC Bolivia,Coodinadora de Integracion de OECAs,N,2011-11-21
+459,CEE,ComisiÃ³n Episcopal de EducaciÃ³n,N,2011-11-21
+460,EFP,"Asociacion de EFP (AFID, FAAAS, FINCAFE)",N,2011-11-22
+461,Ayuda en AcciÃ³n,Ayuda en AcciÃ³n,N,2011-11-23
+462,dance4life,dance4life,N,2011-11-25
+463,Restless Development,Restless Development,N,2011-11-25
+464,Dutch Ministry of Foreign,Dutch Ministry of Foreign Affairs,G,2011-11-25
+467,Daphne Foundation,The Daphne Foundation,N,2011-11-28
+468,ASM,Aide du Sahel Mali,N,2011-11-29
+471,DHS ,Department of Human Settlements ,G,2011-12-02
+472,ICMA,Incomati Catchment Management Agency,G,2011-12-02
+473,Rotary Zwolle,Rotary Club Zwolle,N,2011-12-02
+474,Wetlands International,Wetlands International,N,2011-12-05
+475,Both ENDS,Boh ENDS,N,2011-12-05
+476,Uttaran,Uttaran,N,2011-12-05
+477,JJS,Jagrata Juba Shangha,N,2011-12-05
+478,AOSED,An Organization for Socio-Economic Development,N,2011-12-05
+479,DORP,Development Organisation of the Rural Poor,N,2011-12-05
+480,SLOPB,Stichting Land Ontwikkelings Project Bangladesh ,N,2011-12-05
+481,WaterAid Bangladesh,WaterAid Bangladesh,N,2011-12-05
+482,DOJ,Diocese of Jinja,N,2011-12-05
+483,Gemeente Zwolle,Gemeente Zwolle,G,2011-12-05
+484,Gemeente Dalfsen,Gemeente Dalfsen,G,2011-12-05
+485,Weebale,Weebale Foundation,N,2011-12-05
+486,SamSamWater,SamSamWater,N,2011-12-06
+487,Walking for Water 2012,Walking for Water international 2012,N,2011-12-06
+488,Red TIC Bolivia,Red TIC Bolivia,N,2011-12-06
+489,Local Council of Gedaref,Local Council municipality Gedaref City,G,2011-12-12
+490,RotaryNL,Rotary Netherlands WASH projects,N,2011-12-12
+491,Nkhoma Hospital ,Nkhoma Church of Central Africa Presbyterian Hospital ,N,2011-12-13
+492,HADEFO,Hope Again Development Foundation,N,2011-12-19
+493,R5,International group of 5 Rotary Clubs  Represented in the Netherlands,N,2011-12-19
+494,PRfekt Kontor,PRfekt Kontor AB,C,2011-12-19
+495,Instituto EDUCA,Instituto de Fomento de una EducaciÃ³n de Calidad ,N,2011-12-20
+496,CCAP Livingstonia Synod,"Church of Central Africa Presbyterian (CCAP), Synod of Livingstonia ",N,2011-12-20
+498,SWI,Safe water International,N,2011-12-20
+499,"CHC, Mangochi Diocese","Catholic Health Commission, Mangochi Diocese",N,2011-12-22
+500,CHC Diocese of Chickwawa,Catholic Health Commission - Diocese of Chikwawa,N,2011-12-23
+501,GSB,Grupo Saneamento Bilibiza,N,2011-12-28
+502,Blue Peter,Blue Peter Foundation,N,2011-12-28
+503,GKP Foundation,Global Knowledge Partnership Foundation,K,2011-12-29
+504,FundaciÃ³n CTIC,FundaciÃ³n CTIC,N,2012-01-02
+505,IMTAvH,Instituto de Medicina Tropical Alexander von Humboldt,N,2012-01-02
+506,Nexus Heritage,Nexus Heritage - SRI Ltd,C,2012-01-02
+507,ASTIS,University of Queensland,K,2012-01-03
+509,RDH,Rumphi District Hospital ,G,2012-01-04
+510,SKIW,Stichting Kennisuitwisseling IndustriÃ«le Watertechnologie,N,2012-01-06
+511,Le Pont,Stichting Le Pont,N,2012-01-06
+512,Grand Popo,Gemeente Grand Popo,G,2012-01-06
+513,ComÃ©,Gemeente ComÃ©,G,2012-01-06
+514,Apetectra,Ngo Apetectra,N,2012-01-06
+515,AthiemÃ©,Gemeente AthiemÃ©,G,2012-01-06
+516,FundaciÃ³n HoPe,Asociacion Civil FundaciÃ³n HoPe Holanda PerÃº,N,2012-01-09
+517,Diocese of Maroua-Mokolo,Diocese of Maroua-Mokolo,N,2012-01-12
+518,NEWAH,NEWAH,N,2012-01-12
+519,LWF Nepal,The Lutheran World Federation Nepal,N,2012-01-12
+520,AFORD Foundation,Aid For Development,N,2012-01-12
+521,GYAM,Ghana Young Artisans Movement,N,2012-01-12
+522,CLIP,Community Life Improvement Programme,N,2012-01-13
+523,Presby,Presby Water Project,N,2012-01-13
+524,UDS,University for Development Studies,K,2012-01-13
+526,WUZDA,Wuni Zaligu Development Association,N,2012-01-16
+527,AMREF Ethiopia,African Medical and Research Foundation,N,2012-01-17
+528,ECC-SDCOH,Ethiopian Catholic Church -Social and Devt. Coordinating Office of Harare,N,2012-01-17
+529,WaterAid Ethiopia,WaterAid Ethiopia,N,2012-01-17
+530,MetaMeta,MetaMeta,N,2012-01-17
+531,HOAREC,Horn of Africa Regional Environment Center,N,2012-01-18
+532,FAWEU,Forum for African Women Educationalists Uganda,N,2012-01-19
+533,Ave Maria,Ave Maria Vocational Training & Youth Development Centre,N,2012-01-19
+534,HNU,Health Need Uganda,N,2012-01-19
+535,Mango Tree,Mango Tree,C,2012-01-19
+536,APROSSA,Afrique Verte Burkina,N,2012-01-19
+537,RWECO,Rwenzori Consortium for Civic Competence,N,2012-01-20
+538,IDH,The IDH Sustainable Trade Initiative,N,2012-01-20
+539,Mars Chocolate,,C,2012-01-20
+540,ECOM,ECOM Agroindustrial Dorp. Ltd.,C,2012-01-20
+541,EMSOLAM,Emprendedores Solidarios de Lambayeque,N,2012-01-20
+542,Onbegrensd Ondernemen,Stichting Onbegrensd Ondernemen,N,2012-01-20
+543,NOSIM,NOSIM Women's Organisation,N,2012-01-24
+544,ADS-Nyanza,ACK DEVELOPMENT SERVICES (ADS)-NYANZA,N,2012-01-24
+545,Sujol,,N,2012-01-24
+546,NIA,Neighbourhood Initiaves Alliance,N,2012-01-24
+547,BCAS,Bangladesh Centre for Advanced Studies,K,2012-01-24
+548,WBC ,WASH Benin Consortium,N,2012-01-25
+549,Mzuzu Diocese CHC,Mzuzu Diocese Catholic Health Commission,N,2012-01-25
+550,Lumanti,Lumanti,N,2012-01-25
+551,DIO GOASO,DIO GOASO,C,2012-01-26
+554,Gobierno Santa Cruz,Gobierno AutÃ³nomo Departamental Santa Cruz,G,2012-01-26
+555,ACDEP,Association of Church Development Projects,N,2012-01-26
+556,NewEnergy,NewEnergy,N,2012-01-27
+557,INTAGRAD,Integrated Action for Community Development ,N,2012-01-27
+558,HEWASA,Health for Water and Sanitation,N,2012-01-27
+559,JESE,JESE,N,2012-01-27
+561,Rotary Enschede,,N,2012-01-30
+562,Rotary Enschede Zuid,,N,2012-01-30
+563,Bathmen de Schipbeek,Rotaryclub Bathmen de Schipbeek,N,2012-01-30
+564,Stichting Dipjoti Nepal ,,N,2012-01-30
+565,PNE BÃ©nin,Partenariat National de l'Eau du BÃ©nin,G,2012-01-31
+566,ZOA Ethiopia,ZOA Ethiopia,N,2012-01-31
+567,HSHC,Help Self Help Centre,N,2012-01-31
+568,PROTOS-BÃ©nin,PROTOS-BÃ©nin,N,2012-02-01
+569,AED,AED,N,2012-02-01
+570,ELRECO,,N,2012-02-01
+571,PROMUC,PromociÃ³n de la Mujer y la Comunidad,N,2012-02-02
+572,Coordinadora Rural,Coord. Org. Camp. e Inst. Agrarias del PerÃº,N,2012-02-02
+573,ALPHALOG,ALPHALOG,N,2012-02-02
+574,NYRC,Ndola Youth Resource Centre,N,2012-02-02
+575,FIT,FIT Resources Ltd.,N,2012-02-02
+576,Nairobits ,Nairobits Trust ,N,2012-02-03
+577,EAA Benin,Eau et Assainissement pour l'Afrique,K,2012-02-06
+578,RAE PERÃš,Red de Agricultura EcolÃ³gica del PerÃº,N,2012-02-06
+579,IDMA,Instituto de Desarrollo y Medio Ambiente,N,2012-02-06
+580,Centro Ideas,,N,2012-02-06
+581,IMAGEN,Instituto de Medio Ambiente y GÃ©nero para el Desarrollo,N,2012-02-06
+582,CEAR,Centro de Apoyo Rural,N,2012-02-06
+583,UNHCO,Uganda National Health Consumers Organisation,N,2012-02-07
+584,IAA,Instituto para una Alternativa Agraria,N,2012-02-07
+585,OWA,One World Africa,N,2012-02-08
+586,CareerMate,CareerMate Zambia,N,2012-02-08
+587,ZARD,Zambian Association for Research and Development,N,2012-02-08
+588,ZACODE,Zambia College of Distance Education,N,2012-02-08
+590,Gemeente Bussum,Gemeente Bussum,G,2012-02-10
+591,Mukuba University,Mukuba University Zambia,K,2012-02-10
+592,ANPE PERÃš,AsociaciÃ³n Nacional de Productores EcolÃ³gicos PERÃš,N,2012-02-16
+593,FATIMA School,FATIMA Girls Secondary School,G,2012-02-17
+594,Caritas High School,Caritas High School ,K,2012-02-17
+595,St. Pauls High School,St. Pauls High School,G,2012-02-17
+596,SNCP,Shokut Naretoi Community Project,N,2012-02-17
+597,GRAT,Groupe de Recherches et d'Applications Techniques,N,2012-02-17
+598,Riverain Basic School,Riverain Basic School,K,2012-02-17
+599,FAWEZA,Forum For African Women Educationalists of Zambia,N,2012-02-18
+600,RC Leerdam,Rotary Club Leerdam,N,2012-02-21
+601,GTM,Grarbet Tehadiso Mahber,N,2012-02-21
+602,LIGHT FOR THE WORLD,LIGHT FOR THE WORLD Netherlands,N,2012-02-21
+603,Kitwe Basic School,Kitwe Basic School Zambia,K,2012-02-22
+604,ACK WRCCS,Anglican Church of kenya - Western Region Christian Community Services,N,2012-02-23
+605,eHomemakers,eHomemakers,N,2012-02-28
+606,HOMENET ,HOMENET Philippines,N,2012-02-28
+607,Makaia,CorporaciÃ³n Makaia AsesorÃ­a Internacional,N,2012-02-28
+608,WML,Waterleiding Maatschappij Limburg,C,2012-02-29
+609,ITF,International Transformation Foundation,N,2012-03-01
+610,Mars Chocolate NAFF,Mars Chocolate North America Farmers First,C,2012-03-09
+612,NUNUNA,Federation NUNUNA-LEO,C,2012-03-12
+613,FADEFSO,FÃ©dÃ©ration des Associations pour le DÃ©veloppement ,N,2012-03-12
+614,AFD,Action For Development,N,2012-03-12
+615,URPM,Union RÃ©gionale des Producteurs de Mangue ,N,2012-03-12
+616,APPS,L'Association des Producteurs de Pomme,N,2012-03-12
+617,CFTS,Coordination des femmes transformatrices - SKO,N,2012-03-12
+618,3AG,Association d'Aide et d'Appui aux groupements,N,2012-03-14
+619,CRCR Sikasso,ComitÃ© RÃ©gional de Concertation des Ruraux,N,2012-03-15
+620,IHG,The International Heritage Group,N,2012-03-15
+621,UGPPK,Union des Groupements de Productrices de Produits de KaritÃ©,N,2012-03-19
+622,Mlambe Foundation,Mlambe Foundation,N,2012-03-20
+623,African Heritage ,African Heritage Ltd,C,2012-03-20
+625,Ethiopia WASH Alliance,Ethiopia WASH Alliance,N,2012-03-26
+626,FNZ,FEDERATION NIAN ZWE,C,2012-03-26
+628,URWA,URWA,N,2012-03-26
+629,ARAFD,Association Recherche Action Femme et DÃ©veloppement,N,2012-03-26
+630,GAAS,GAAS,N,2012-03-26
+631,HELVETAS Mali,HELVETAS Mali,N,2012-03-26
+632,CAEB,CAEB,N,2012-03-27
+633,PROTOS Mali,PROTOS Mali,N,2012-03-27
+634,Wetlands Int Mali,Wetlands International Mali ,N,2012-03-27
+635,CADEP JMA,"Centro andino de educacion y promocion \Jose Maria Arguedas\"" """,N,2012-03-27
+636,CESIP,Centro de Estudios Sociales y Publicaciones,N,2012-03-27
+638,AMREF Uganda,AMREF Uganda,N,2012-03-28
+639,Stichting Ortega,,N,2012-03-28
+640,KYFA,Kisumu Youth Football Association,N,2012-03-29
+641,WorldCoaches ,,C,2012-03-29
+643,FABIO,First African Bicycle Information Organization,N,2012-03-29
+644,Rotary club Hoorn,,N,2012-04-04
+645,LACCODEF,Lango Child and Community Development Federation,N,2012-04-05
+646,Hope Alive Uganda,Hope Alive Uganda,N,2012-04-16
+647,RUAF,RUAF,N,2012-04-17
+648,DCAM/BETHESDA,DÃ©veloppement Communautaire et Assainissement du Milieu,N,2012-04-19
+649,Helvetas BÃ©nin,Helvetas Swiss Intercooperation BÃ©nin,N,2012-04-20
+650,BoldSteps Ghana,BoldSteps Foundation Ghana,N,2012-04-20
+651,Rural Women Foundation,Rural Women Foundation,N,2012-04-24
+652,Ghana WASH Alliance ,Ghana WASH Alliance,N,2012-04-24
+653,Prinsentuin,St. ROC West Brabant,K,2012-04-24
+655,BUPDOS,Bureau des Projets de DÃ©veloppement et des Oeuvres Sociales ,N,2012-05-01
+656,Heritage consultant,"Donald Henson, Heritage consultant",C,2012-05-01
+657,ASE,ASE,N,2012-05-01
+659,PEU,PRESBY EDUCATIONAL UNITS ,N,2012-05-02
+660,CEBEDES,"Centre BÃ©ninois pour lâ€™Environnement, le DÃ©veloppement Economique et Social",N,2012-05-03
+661,Bangladesh WASH Alliance,Bangladesh WASH Alliance,N,2012-05-09
+662,Rokana Basic School,Rokana Basic School,N,2012-05-09
+663,Stichting Farda,Stichting Farda,N,2012-05-09
+664,Stichting Water4Everyone ,Stichting Water4Everyone ,N,2012-05-09
+665,HP,Hope for the Poorest,N,2012-05-11
+666,Basisschool de Akker,Christelijke Dalton Basisschool de Akker,K,2012-05-15
+667,Venhuisschool,,K,2012-05-15
+668,NMDHR,Network Movement for Democracy and Human Rights ,N,2012-05-15
+669,FE Y ALEGRIA 44,PROYECTO EDUCACION RURAL FE Y ALEGRIA 44 - CUSCO,N,2012-05-15
+670,Kenya WASH Alliance,,N,2012-05-16
+671,DHMIS,DISTRICT HEALTH MANAGEMENT INFORMATION SYSTEMS,N,2012-05-16
+672,GNC,General Nursing Council of Zambia,G,2012-05-20
+675,CHAG,Christiah Health Association Of Ghana,N,2012-05-21
+676,1liter,1liter,N,2012-05-22
+677,TAREA,"Tarea, AsociaciÃ³n de Publicaciones Educativas",N,2012-05-25
+678,VEI,Vitens Evides International,C,2012-05-29
+679,Water for life,Water for life,N,2012-05-29
+680,NETWAS Uganda,NETWAS Uganda,N,2012-05-29
+681,Send@Drop Foundation,,N,2012-05-29
+682,UQ,"School of Social Science, University of Queensland",K,2012-05-30
+683,Caritas Gulu,Caritas Gulu Archdiocese,N,2012-05-30
+684,ALVF Antenne ExtrÃªme-Nord,Asso. Lutte Contre Violence Femmes Antenne Extreme,N,2012-05-30
+685,BrandPit,BrandPit,C,2012-05-31
+686,UNHCR Cameroon,The UN Refugee Agency,N,2012-06-01
+687,MLM,Mbombela Local Municipality,G,2012-06-04
+688,Designi,Designi,C,2012-06-05
+689,UNICEF Nederland,National Committee for the United Nations Childrens Fund in the Netherlands,N,2012-06-06
+692,Rotary Club Nakuru,,N,2012-06-12
+693,RDRS Bangladesh,RDRS Bangladesh,N,2012-06-13
+694,WASH RCNN,"Water, Sanitation and Hygiene - Resource Centre Network Nepal",N,2012-06-13
+695,ILIDP,Ilkerin Loita Integral Development Programme,N,2012-06-20
+696,Cetinje,Old Royal Capital of Cetinje,G,2012-06-25
+697,Waterbedrijf Groningen,Waterbedrijf Groningen,C,2012-06-27
+699,Waterschap Hunze en Aa's,Waterschap Hunze en Aa's,G,2012-06-27
+700,APÄ€ CANAL S.A. Galati,"ProtejÄm Apa, ProtejÄm Viata!",C,2012-06-27
+701,ITPC,International Treatment Preparedness Coalition,N,2012-06-27
+702,NSWP,Global Network of Sex Work Projects,N,2012-06-27
+703,MSMGF,Global Forum on MSM & HIV ,N,2012-06-27
+704,INPUD,International Network of People who Use Drugs,N,2012-06-27
+705,COC,COC Nederland,N,2012-06-27
+706,AFEW,AIDS Foundation East-West,N,2012-06-28
+707,Mainline,Mainline foundation,N,2012-06-28
+708,GNP+,THE GLOBAL NETWORK OF PEOPLE LIVING WITH HIV,N,2012-06-28
+709,Aids Fonds,Stichting Aids Fonds - Soa Aids Nederland,N,2012-06-28
+710,ACEM,Association of Christian Educators in Malawi,N,2012-06-28
+712,EEA,Energy Efficiency Agency of Moldova,G,2012-07-04
+713,EU in Moldova,EU Delegation to the Republic of Moldova,K,2012-07-04
+714,MoEc of Moldova,Ministry of Economy fo Republic of Moldova,G,2012-07-04
+715,Shumanay Hakimyat,Hakimyat of Shumanay District,G,2012-07-09
+716,Muynak Hakimyat,Hakimyat of Muynak District,G,2012-07-09
+717,MOH Uzbekistan,Ministry of Health Uzbekistan,G,2012-07-09
+718,MOE,Ministry of Education,G,2012-07-09
+719,Mahala Fund,Mahala Fund,G,2012-07-09
+720,Kanlikul Hakimyat,Hakimyat of Kanlikul District,G,2012-07-09
+721,Council of Ministers,Council of Ministers of the Republic of Karakalpakstan,G,2012-07-09
+722,ZELS,Association of the Units of Local Self-government of Republic of Macedonia,N,2012-07-09
+723,AKM,Association of Kosovo Municipalities,N,2012-07-10
+724,CALM,Congress of Local Authorities from Moldova,N,2012-07-10
+725,NALAS,Network of Associations of Local Authorities of South-East Europe,N,2012-07-10
+726,Home of Hope ,Home of Hope Trust,N,2012-07-10
+727,CIDI,Community Integrated Development Initiatives,N,2012-07-16
+728,UNTFHS,United Nations Trust Fund for Human Security,G,2012-07-16
+729,MNREP,Ministry of Natural Resources and Environmental Protection of Belarus,G,2012-07-18
+730,RIPPLE,RIPPLE,N,2012-07-19
+731,EU in Kyrgyzstan,Delegation of the European Union to the Kyrgyz Republic ,G,2012-07-19
+732,KOEE,Kenya Organization for Environmental Education,N,2012-07-20
+733,ARC,The Alliance of Religions and Conservation,N,2012-07-20
+737,The Global Fund,"The Global Fund to Fight AIDS, Tuberculosis and Malaria",K,2012-07-25
+738,UNESCO,"United Nations Educational, Scientific and Cultural Organization",G,2012-07-25
+739,United Nations Volunteers,United Nations Volunteers,G,2012-07-25
+740,Ministry of Health,Ministry of Health of the Republic of Uzbekistan ,G,2012-07-25
+741,Stichting Furaha,Stichting Furaha,N,2012-07-26
+742,Ebukoolo Primary School,"Ebukoolo Primary School, Emuhaya, Kenya",K,2012-07-26
+743,Kibera Primary School,"Kibera Primary School in Nairobi, Kenya",K,2012-07-26
+744,ACT,African Conservation Trust,N,2012-07-27
+745,GAiN,Global Aid Network (GAiN) Nederland,N,2012-07-27
+746,USAID,U.S. Agency for International Development,G,2012-07-27
+747,FHI 360,Family Health International ,N,2012-07-27
+748,IMC,International Medical Corps,N,2012-07-27
+750,NID,Namibia Institute for Democracy ,N,2012-07-27
+751,Unicef Namibia,Unicef Namibia,N,2012-07-27
+752,Jhpiego,Jhpiego,N,2012-07-30
+753,CDC Foundation,CDC Foundation,N,2012-07-30
+754,MoHSW Tanzania,Ministry of Health and Social Welfare Tanzania,G,2012-07-30
+755,mHealth Alliance,mHealth Alliance,N,2012-07-30
+756,mHealth Tanzania,mHealth Tanzania Partnership,N,2012-07-30
+757,NCCK,NATIONAL COUNCIL OF CHURCHES OF KENYA,N,2012-07-30
+758,ICCO Alliance,ICCO Alliance,N,2012-07-31
+759,LiveBuild,Stichting LiveBuild,N,2012-07-31
+760,Unesco Centrum Nederland,Unesco Centrum Nederland,N,2012-08-01
+761,SecondMuse,SecondMuse,C,2012-08-02
+762,Kawempe Home Care,Kawempe Home Care,N,2012-08-02
+763,Microsoft Research,Microsoft Research,C,2012-08-02
+764,IDI,Infectious Diseases Institute ,N,2012-08-02
+765,HIPS,Health Initiatives for the Private Sector ,N,2012-08-02
+766,TRAC FM,TRAC FM,N,2012-08-02
+767,MobileActive,MobileActive,N,2012-08-02
+768,UN Global Pulse,UN Global Pulse,G,2012-08-02
+769,Malaria Consortium,Malaria Consortium,N,2012-08-02
+770,inSCALE,Innovations at Scale for Community Access and Lasting Effects ,N,2012-08-02
+771,Scyfy,Scyfy Technologies,C,2012-08-02
+772,War Child Nederland,War Child Nederland,N,2012-08-02
+773,PACE,Program for Accessible Health Communication and Education,N,2012-08-02
+774,Butterfly Works,Butterfly Works,N,2012-08-02
+775,Save Health for Uganda ,Save for Health Uganda ,N,2012-08-02
+777,Techreturns,Techreturns,N,2012-08-02
+778,WWF Uganda,World Wide Fund for Nature (WWF) - Uganda,N,2012-08-02
+779,Unicef Uganda,Unicef Uganda,N,2012-08-02
+780,Merck & co,Merck & co,C,2012-08-02
+781,Aids Information Centre,AIDS Information Centre,N,2012-08-02
+782,UNDESA,United Nations Department of Economic and Social Affairs ,G,2012-08-02
+783,ECOSOC,ECOSOC,G,2012-08-02
+784,Airtel Uganda,Airtel Uganda,C,2012-08-02
+785,GIZ,Deutsche Gesellschaft fÃ¼r Internationale Zusammenarbeit (GIZ) GmbH,G,2012-08-02
+786,Lira Municipal Council,LMC,G,2012-08-02
+787,KIT,Koninklijk Instituut voor de Tropen (KIT) / KIT Royal Tropical Institute,K,2012-08-02
+788,Uwezo,Uwezo,N,2012-08-02
+789,Dutch Embassy Uganda,The Royal Dutch Embassy in Kampala Uganda,G,2012-08-02
+790,Base Technologies,Base Technologies,C,2012-08-02
+791,Barefoot Power Uganda,Barefoot Power Uganda,C,2012-08-02
+792,VU University Amsterdam,Vrije Universiteit Amsterdam/ VU University Amsterdam,K,2012-08-02
+793,Johanna Donk Stichting,De Johanna Donk-Grote Stichting,N,2012-08-06
+795,PHREB,Promoting Human Rights and Education in Bangladesh,N,2012-08-08
+796,CED,CED,N,2012-08-09
+797,Academy for Educ. Dev.,Academy for Educational Development ,N,2012-08-13
+798,NIMR,National Institute for Medical Research,K,2012-08-13
+799,USG PEPFAR,The U.S. President's Emergency Plan for AIDS Relief,G,2012-08-13
+800,Hope Clinic Lukuli,Hope Clinic Lukuli Uganda,N,2012-08-13
+801,Hivos Twaweza ,Hivos Twaweza ,N,2012-08-13
+802,UNICEF Kenya,UNICEF Kenya,N,2012-08-13
+803,Raising Voices,Raising Voices,N,2012-08-13
+804,Living Goods,Living Goods,N,2012-08-13
+805,Johns Hopkins University,Johns Hopkins University,K,2012-08-15
+806,ATTI,Africa Technology & Transparency Initiative ,N,2012-08-15
+807,Mzumbe University,Mzumbe University,K,2012-08-15
+808,Research Africa,Research Africa,C,2012-08-15
+809,Unilever Uganda,Unilever Uganda,C,2012-08-15
+810,Darma Amal Bakti Found.,Darma Amal Bakti Foundation,N,2012-08-16
+812,Don Bosco,Don Bosco Youth Technical Institute,K,2012-08-17
+813,SWET,Story Workshop Education ,N,2012-08-17
+814,Friendship,Friendship,N,2012-08-17
+815,WvW 2013,Wandelen voor Water 2013,N,2012-08-17
+816,CREATA,Centre for Regeneration and Empowerment of Africa Through Africa,N,2012-08-21
+817,Dupoto,Dupoto-e-Maa,N,2012-08-22
+818,MTG,Moving the goalposts,N,2012-08-23
+819,World Health Organization,World Health Organization,K,2012-08-23
+820,UNFPA,United Nations Population Fund,N,2012-08-23
+821,ACODE,Advocates Coalition for Development and Environment ,N,2012-08-27
+822,Rotary Club Duiven,Rotary Club Duiven,N,2012-08-29
+823,CABDA,Community Asset Building and Development Action,N,2012-08-30
+824,Waterdragers voor Afrika,Waterdragers voor Afrika,N,2012-08-30
+825,SPYN,Stichting SPYN,N,2012-09-03
+826,Tusaidiane,Stichting Tusaidiane,N,2012-09-03
+827,Government of RF,Government of the Russian Federation,G,2012-09-04
+828,EWB-SFP,Engineers Without Borders - USA San Francisco Professional Chapter,N,2012-09-04
+829,Walking for Water 2013,Walking for Water international 2013,N,2012-09-05
+830,TYSA,Trans Nzoia Youth Sports Association,N,2012-09-06
+831,Nepal WASH Alliance,Nepal WASH Alliance,N,2012-09-07
+832,~Akvo.org Demo,~Akvo.org Demonstration,N,2012-09-11
+833,GEF,Global Environment Facility,K,2012-09-13
+837,Pumping is Life Ghana,Pumping is Life Ghana,N,2012-09-18
+838,RC Appingedam-Delfzijl,RC Appingedam-Delfzijl,N,2012-09-18
+839,RC Eems-Dollard,RC Eems-Dollard,N,2012-09-18
+840,Rotary Club Cluster,"Rotary Club AppingedamDelfzijl, Eems Dollard",N,2012-09-18
+841,Monash University,Monash University,K,2012-09-18
+842,The Asia Research Centre,The Asia Research Centre,K,2012-09-18
+843,NAS,Nautical Archaeology Society,N,2012-09-18
+844,Institute of Archaeology,Institute of Archaeology,G,2012-09-18
+845,JAS ArqueologÃ­a S.L.U.,JAS ArqueologÃ­a S.L.U.,C,2012-09-18
+846,ICRAF CÃ´te d'Ivoire,International Centre for Research in Agroforestry,K,2012-09-25
+847,IPASC,Institut Panafricain de Sante Communautaire RDC,N,2012-09-25
+848,The Well Foundation NL,The Well Foundation Nederland,N,2012-09-26
+849,Rotary De Rottemeren,Rotary De Rottemeren,N,2012-09-27
+850,Rotary Chestfield,Rotary Chestfield,N,2012-09-27
+851,Lake Victoria South W.S.B,Lake Victoria South Water Services Board,G,2012-10-02
+852,Siaya and Bondo W.S.C,Siaya and Bondo Water and Sanitation Company,N,2012-10-02
+853,Bondo Municipal Council,Bondo Municipal Council,G,2012-10-02
+854,Bondo Multi stakeholder,"Bondo Multi stakeholder forum, Bondo Community Based Organizations",N,2012-10-02
+856,UN-HABITAT,United Nations Human Settlements Programme (UN-HABITAT),N,2012-10-02
+857,Government of Kenya,Government of Kenya,G,2012-10-02
+858,South Nyanza Water and SC,South Nyanza Water and Sanitation Company,N,2012-10-02
+859,Homa Bay MC,Homa Bay Municipal Council,G,2012-10-02
+860,Homa Bay Multi SF,Homa Bay Multi SF/CBO/C,N,2012-10-02
+861,Gusii Water & SC,Gusii Water and Sanitation Company,G,2012-10-02
+862,Kisii MC,Kisii Municipal Council,G,2012-10-02
+863,Kisii MSF,"Kisii Multi stakeholder forum, Community Based Organizations, Community",G,2012-10-02
+864,Gov - Uganda,Government of Uganda,G,2012-10-03
+865,DWD,Directorate of Water Development,G,2012-10-03
+867,KMSF,"Kyotera Multi stakeholder forum, Kyotera",N,2012-10-03
+868,DEL,Dabenco Enterprises Ltd,C,2012-10-03
+869,MTC,Mutukula Town Council,G,2012-10-03
+870,MMSF /MCBA/ MC,"Mutukula Multi stakeholder forum, Mutukula Community Based Organizations",N,2012-10-03
+871,NWSC,National Water and Sewerage Corporation,G,2012-10-03
+872,NTC,Nyendo Town Council,G,2012-10-03
+873,NMSF / NCBO,"Nyendo Multi stakeholder forum, Nyendo Community Based Organizations,",N,2012-10-03
+874,MS FEIL EL,MS FEIL Engineering Ltd,C,2012-10-03
+875,ILRF,"Irrigated Land Reclamation Fund, under the Ministry of Finance",G,2012-10-12
+876,World Bank,World Bank,K,2012-10-12
+877,European Commission,European Commission,G,2012-10-12
+878,Open Society Foundation,Open Society Foundation,N,2012-10-12
+879,RC Vorden-Zutphen,RC Vorden-Zutphen,N,2012-10-16
+880,KIWASCO,Kisumu Water and Sewerage Company Ltd,C,2012-10-17
+881,SNV Kenya,Netherlands Development Organisation,N,2012-10-19
+882,Netherlands Embassy Kenya,Embassy of the Kingdom of the Netherlands,G,2012-10-19
+883,WSUP,Water & Sanitation for the Urban Poor,N,2012-10-19
+884,KEWI,Kenya Water Institute,G,2012-10-19
+885,Aquanet,PWN Consultants for water enterprise development,C,2012-10-22
+886,AHBT-University,al-Hussein Bin Talal University,K,2012-10-22
+887,Twaweza ,Twaweza ,N,2012-10-24
+888,MoWI,Ministry of Water and Irrigation,G,2012-10-24
+889,MOPHS Kenya,Ministry of Public Health & Sanitation,G,2012-10-24
+890,UAP,Udhruh Archaeological Project,N,2012-10-26
+891,MoBioM,MoBioM,N,2012-10-30
+892,Coprokazan,CoopÃ©rative des Productrices de Beurre de KaritÃ© de ZantiÃ©bougou,N,2012-10-30
+893,@mkoullel,@mkoullel,N,2012-10-30
+894,Cyber-Kenetic4dev,Cyber-Kenetic4dev,N,2012-10-30
+895,UWASNET,Ugandan Water and Sanitation NGO Network,N,2012-10-30
+896,UNICEF Ghana,UNICEF Ghana,N,2012-10-31
+897,WaterAid Mali,WaterAid Mali,N,2012-11-01
+900,GP/EHA,GP/EHA,N,2012-11-01
+901,Mali WASH Alliance,Mali WASH Alliance,N,2012-11-01
+902,Government of Uzbekistan,The Cabinet of Ministers of the Republic of Uzbekistan,G,2012-11-06
+903,Djizak Khokimiyat,Khokimiyat (Local Administrative Office) of Djizak region,G,2012-11-06
+904,Namangan Khokimiyat,Khokimiyat (Local Administrative Office) of Namangan region,G,2012-11-06
+905,Indie Group and Co,Indie Group and Co,C,2012-11-06
+907,PROSPORT Ltd ,,C,2012-11-08
+908,UNICEF,UNICEF,N,2012-11-08
+909,SEPDA,SEPDA,N,2012-11-12
+910,Rotary Club Baarn Soest,Rotary Club Baarn-Soest met RC Soestdijk en RC Laren Blaricum,N,2012-11-12
+911,FIPAG,Fundo de Investimento e PatrimÃ³nio de Abastecimento de Ãgua,G,2012-11-12
+912,SRHR Alliance,Sexual and Reproductive Health and Rights Alliance,N,2012-11-13
+913,ICS,ICS,N,2012-11-19
+914,AmLab,Amsterdam Laboratory,N,2012-11-19
+915,Heritage Without Borders,Heritage Without Borders,N,2012-11-20
+916,Ancient Merv Project,Ancient Merv Project,K,2012-11-20
+917,Muleba T.C,Muleba Town Council,G,2012-11-20
+919,Bugembe Town Council,Bugembe Town Council,G,2012-11-20
+920,Busoga Trust,Busoga Trust,N,2012-11-20
+921,PEPS-C,Producer enterprises promotion service centre,N,2012-11-20
+922,Government of Tanzania,Government of Tanzania,G,2012-11-20
+923,Bukoba Municipal Council,Bukoba Municipal Council,G,2012-11-20
+924,KADETFU,Kagera Development & Credit Revolving Trust Fund,N,2012-11-20
+925,HUYAWA,Hudumu Ya Watoto (HUYAWA),N,2012-11-20
+926,Muleba Urban Water Supply,Muleba Urban Water Supply Authority,G,2012-11-20
+927,Jandu Plumbers Co. LTD,Jandu Plumbers Co. LTD,C,2012-11-20
+930,BUWASA,Bukoba Urban Water Supply Authority,G,2012-11-20
+931,Efam And Mex Group,Efam And Mex Group,C,2012-11-20
+932,Tukwale Enterprises ,Tukwale Enterprises Co. LTD,C,2012-11-20
+933,Champion Engineering  ,Champion Engineering Co. Ltd,C,2012-11-20
+935,Bunda Town Council,Bunda Town Council,G,2012-11-21
+936,Missenyi Town Council,Missenyi Town Council,G,2012-11-21
+937,ISA,International Sports Alliance,N,2012-11-21
+938,Heritage Watch,Heritage Watch,N,2012-11-21
+939,Sport for Development,Sport for Development,N,2012-11-22
+940,Village of Kyzyl Rovat,The Rural Citizens Council of the village of Kyzyl Rovat,N,2012-11-22
+941,Village of Kazakhdarya,The Rural Citizens Council of the village of Kazakhdarya,N,2012-11-22
+942,WOLREC,Women's Legal Resource Centre,N,2012-11-27
+943,Safe Health Uganda,Safe Health Uganda,N,2012-11-27
+944,Pidim Foundation,Pidim Foundation,N,2012-11-27
+945,SANNAM,Southern African Network of Nurses and Midwives,N,2012-11-27
+946,Cordaid Urban Matters,Cordaid Urban Matters / Smart Solutions for Slums,N,2012-11-27
+947,MWA,MWA,N,2012-11-28
+948,Right To Play,,N,2012-11-30
+949,Cordaid Healthcare,Cordaid Healthcare,N,2012-12-03
+950,Cordaid Entrepreneurship,Cordaid Entrepreneurship,N,2012-12-03
+951,RC Noord Veluwe,Rotary Noord Veluwe,N,2012-12-03
+952,VERC,Village Edcuation Resource Center ,N,2012-12-03
+953,Cordaid Investments,Cordaid Investments,N,2012-12-03
+954,Comixmul,Comixmul Cooperativa Mixta Mujeres Unidas Limitado,C,2012-12-03
+955,Cordaid Womens Leadership,Cordaid Women's Leadership,N,2012-12-03
+956,Czech MFA,The Ministry of Foreign Affairs of the Czech Republic,G,2012-12-03
+957,Banja la Mtsogolo,Banja la Mtsogolo,N,2012-12-04
+958,Kalabash Ghana,Kalabash Ghana,N,2012-12-04
+959,Cordaid Child & Education,Cordaid Child & Education,N,2012-12-04
+960,Cordaid Extractives,Cordaid Extractives,N,2012-12-04
+961,Cordaid Disaster Response,Cordaid Disaster Response,N,2012-12-04
+962,Cordaid Nederland,Cordaid Nederland,N,2012-12-04
+964,Rotary Doorn,Rotary Doorn,N,2012-12-04
+965,Afghan Women Network,Afghan Women Network (AWN),N,2012-12-05
+966,IBIS Ghana,IBIS in Ghana,N,2012-12-07
+967,ACE,Archaeology in Contemporary Europe,K,2012-12-10
+968,WMD,NV Waterleiding Mij Drenthe en Inowa,C,2012-12-11
+969,Akvo FLOW,Akvo FLOW,N,2012-12-13
+970,CSA,Center for the Study of Adolescence,N,2012-12-13
+971,Caritas Lebanon,Caritas Lebanon,N,2012-12-21
+972,RACIDA,Rural Agency for Community Development and Assistance,N,2012-12-21
+973,Sam's Kledingactie,Sam's Kledingactie,C,2012-12-21
+976,Cordaid Juba,Cordaid Juba,N,2013-01-02
+978,UCOET,Unity Community Organization and Enlightenment Trust,N,2013-01-02
+979,Justice&Peace Commission,Justice & Peace Commission of Catholic Diocese of Malakal,N,2013-01-02
+980,Presbyterian Church Melut,Presbyterian Church in Melut,N,2013-01-02
+981,Centre P & D studies,Centre for Peace and Development Studies at Juba University,K,2013-01-02
+983,AMA,Assistance Mission for Africa (AMA),N,2013-01-02
+984,Sudan Council of Churches,SCC,N,2013-01-02
+986,SSHURSA,South Sudan Human Rights Society for Advocacy (SSHURSA),N,2013-01-02
+987,ERADA,Equatoria Rehabilitation and Development Association,N,2013-01-02
+988,SSLS,South Sudan Law Society,N,2013-01-02
+990,SUN Community involvement,SUN Community involvement ,N,2013-01-02
+991,Virgin Active Sports ,Virgin Active Sports School/Academy ,C,2013-01-02
+992,Dream Goals,Dream Goals,N,2013-01-02
+993,FNV Formaat,FNV Formaat,C,2013-01-02
+994,SA Project Developer TOHI,South African Project Developer TOHI,C,2013-01-02
+996,Villa Rosa,Villa Rosa residentsâ€™ platform ,C,2013-01-03
+997,Sainte Marie,Sainte Marie residentsâ€™ platform ,C,2013-01-03
+998,Cerdel,Cerdel,N,2013-01-03
+1000,BLTP,Burundi Leadership Training Program,N,2013-01-03
+1001,Kadtuntaya Foundation,Kadtuntaya Foundation Incorporated,N,2013-01-03
+1003,Sembrar Sartawi,Sembrar Sartawi,N,2013-01-03
+1004,African Development Bank,African Development Bank,C,2013-01-03
+1005,RUFI Rural Finance Initia,RUFI Rural Finance Initiative,C,2013-01-03
+1006,Dia Vikas Capital Private,Dia Vikas Capital Private,N,2013-01-03
+1009,NEEDS India,Network For Enterprise Enhancement And Development Support,N,2013-01-04
+1010,BVHA,Bihar Voluntary Health Association,N,2013-01-04
+1011,VHAI,Voluntary Health Association of India,N,2013-01-04
+1012,Africa Alive,Africa Alive,N,2013-01-09
+1013,EU in Kenya,Delegation of the European Union to Kenya,N,2013-01-10
+1014,SAIPEH,Support Activities In Poverty Eradication and Health,N,2013-01-10
+1015,YONECO,Youth Net and Counselling,N,2013-01-10
+1018,SEWA Bharat,Self Employed Women's Association Bharat,N,2013-01-14
+1019,Restless Dev India,Restless Development India,N,2013-01-14
+1020,Dalit,Dalit,N,2013-01-14
+1021,AIMS Bangladesh,Aesthetical and Integrated Media Service Bangladesh,C,2013-01-14
+1022,Gano Milan Foundation,Gano Milan Foundation,N,2013-01-14
+1023,Mukti Foundation,Mukti Foundation,N,2013-01-14
+1024,PIDS Pakistan,Participatory Integrated Development Society,N,2013-01-15
+1025,CAVWOC,Centre for Alternatives for Victimized Women and Children,N,2013-01-15
+1026,Awaz Foundation Pakistan,Awaz Foundation Pakistan: Centre for Development Services,N,2013-01-15
+1027,CH Chandraghona,Christian Hospital Chandraghona,N,2013-01-16
+1029,RHSTEP,"Reproductive Health Services, Training and Education Program",N,2013-01-16
+1030,FPAB,Family Planning Association of Bangladesh,N,2013-01-16
+1031,Dushtha Shasthya Kendra,Dushtha Shasthya Kendra,N,2013-01-16
+1032,WSP,Water and Sanitation Program,N,2013-01-16
+1033,MPW Liberia ,Ministry of Public Works Liberia,G,2013-01-16
+1034,PFAG,Professional Football Association of Ghana,N,2013-01-17
+1035,YECE,Youth Empowerment and Civic Education,N,2013-01-17
+1036,RWPF Pakistan,Rutgers WPF Pakistan,N,2013-01-17
+1039,FPAM,Family Planning Association of Malawi,N,2013-01-22
+1040,NAYA,Network for Adolescent and Youth of Africa,N,2013-01-24
+1042,CEICOM,CEICOM,N,2013-01-24
+1043,Rutgers WPF,Rutgers WPF,N,2013-01-25
+1044,CHOICE,CHOICE for Youth and Sexuality,N,2013-01-25
+1045,Government of Luxembourg,Government of Luxembourg,G,2013-01-25
+1046,PWN,PWN,C,2013-01-25
+1047,WaterAid America,WaterAid America,N,2013-01-31
+1048,CARE,CARE ,N,2013-01-31
+1049,Living Water Int.,Living Water International,N,2013-01-31
+1050,WSA,Water and Sanitation for Africa,N,2013-01-31
+1051,Unicef Congo Brazzaville,Unicef Congo Brazzaville,N,2013-01-31
+1052,Stedenband Tilburg Same,Stedenband Tilburg Same Tanzania,N,2013-02-01
+1053,Catholic Diocese of Same,Catholic Diocese of Same,N,2013-02-01
+1054,Aguayuda,Aguayuda,N,2013-02-01
+1055,PSTC,Population Services and Training Center,N,2013-02-04
+1056,KSDP,Kenya Sports for Development Partnership,N,2013-02-04
+1057,Jurome B.V.,Jurome B.V.,C,2013-02-06
+1058,Naga Foundation,Naga Foundation,N,2013-02-07
+1059,Ghana Urban Water Limited,Ghana Urban Water Limited,C,2013-02-09
+1060,Football for Water,Football for Water,N,2013-02-09
+1061,WASH Liberia,WASH Liberia,G,2013-02-10
+1062,Kenya Wildlife Service,Kenya Wildlife Service,G,2013-02-12
+1063,Liberia WASH Training,Liberia WASH Training,N,2013-02-12
+1064,UOF,Universal Outreach Foundation,N,2013-02-13
+1065,Wateraid Liberia,Wateraid Liberia,N,2013-02-13
+1066,Concern Worldwide Liberia,Concern Worldwide Liberia,N,2013-02-13
+1067,ERS,Empowerment Rehabilitation Services,N,2013-02-13
+1068,FAAL Inc,Foundation for All Ages Liberia Inc.,N,2013-02-13
+1069,Tetra Tech,Tetra tech,N,2013-02-13
+1070,AEL,Association of Evangelicals of Liberia,N,2013-02-13
+1071,NWSHPC,National Water Sanitation and Hygiene Promotion Committee,G,2013-02-13
+1072,RIDA,Rural Integrated Development Agency,N,2013-02-13
+1073,CIPORD ,Christian Impact Program for Rural Development Inc.,N,2013-02-13
+1074,ECREP,Evangelical Children Rehabilitation Program ,N,2013-02-13
+1075,WSP Liberia,World Sanitation Programme,N,2013-02-13
+1076,EQUIP Liberia,EQUIP,N,2013-02-13
+1077,WHH/SIRHC,Welthungerhilfe /SIRHC Program,N,2013-02-13
+1078,Plan,Plan (Int) Liberia,N,2013-02-13
+1080,UNICEF Liberia,United Nations Children's Fund Liberia,N,2013-02-13
+1081,MOE/SHD,Ministry of Education/School health Division,G,2013-02-13
+1082,CHF,Cooperative Housing Foundation,N,2013-02-13
+1083,CODES,Community Development Services ,N,2013-02-13
+1084,LICH,LIBERIA CARE HUMANITY INC,N,2013-02-13
+1088,Oxfam Liberia,Oxfam Liberia,N,2013-02-13
+1089,RVWSB / Naivawass,Rift Valley Water Services Board ,G,2013-02-14
+1090,Jaap lengkeek SRA,"Jaap Lengkeek Scientific Research and Advice; Tourism, Heritage, Landscape",K,2013-02-14
+1091,Revenue Watch Institute,Revenue Watch Institute,K,2013-02-15
+1092,Publish What You Pay,Publish What You Pay,K,2013-02-15
+1093,RWH for Food Security,Rainwater Harvesting for Food Security,N,2013-02-15
+1094,World Vision Mexico,World Vision Mexico,N,2013-02-18
+1095,Improve International,Improve International,N,2013-02-18
+1096,SFPB,Stichting Fondsenwerving Pacung Bali,N,2013-02-22
+1097,Wageningen University,"Wageningen University, Cultural Geography Group",K,2013-02-25
+1098,NHTV,NHTV Breda University of Applied Sciences,K,2013-02-25
+1099,Cordaid Food Security,Cordaid Food Security,N,2013-02-27
+1100,NPO/RRAA,Norwegian Project Office/Rural Rehabilitation Association for Afghanistan,N,2013-02-27
+1101,MADAM Sierra Leone,MADAM Sierra Leone,N,2013-02-28
+1103,Broederlijk Delen,Broederlijk Delen,N,2013-02-28
+1105,African Monitor,African Monitor,N,2013-03-07
+1106,Casa de la Mujer,Casa de la Mujer,N,2013-03-07
+1108,SSPAS,Servicio Pasionista,N,2013-03-07
+1109,Fusalmo,Fusalmo,N,2013-03-07
+1110,Fundasal,FundaciÃ³n SalvadoreÃ±a de Desarrollo y Vivienda MÃ­nima,N,2013-03-07
+1111,Centro BartolomÃ© Casas,Centro BartolomÃ© de las Casas,N,2013-03-07
+1113,Zinedine Zidane,Zinedine Zidane,C,2013-03-07
+1114,Winrock International,Winrock International,N,2013-03-08
+1115,Skills Plus ,"Skills Plus,Uganda ",N,2013-03-13
+1116,LAUPI,Local Areas Uprise Initiative,N,2013-03-13
+1118,OCBO,Orphans Community Based Organisation,N,2013-03-13
+1119,SAVO,Ssuubi ly'Abato Voluntary Organisation,N,2013-03-13
+1120,Masaka District Local Gov,Masaka District Local Governement,G,2013-03-13
+1121,NMC,Ntungamo Municipal Council,G,2013-03-13
+1123,STARGO,Strengthening Aquatic Resources Governance,N,2013-03-13
+1124,GRM,Golden Rule Mission,N,2013-03-13
+1125,MTB,Mutukula Town Board,G,2013-03-13
+1126,REAP,Renewed Efforts to Alleviate Poverty,N,2013-03-13
+1127,KTC,Kyotera Town Council,G,2013-03-13
+1128,MTC,MAYUGE TOWN COUNCIL,G,2013-03-13
+1129,RAWESE,Rawese Uganda ,N,2013-03-13
+1130,Bukakata S/C ,Bukakata sub county local government,G,2013-03-13
+1131,UMU,Uganda Martyrs University Outreach Directorate,K,2013-03-13
+1132,KCDC,Kyamate child Devt centre,N,2013-03-13
+1133,BMCTC,Buwama Multipurpose Community Telecentre,N,2013-03-13
+1134,BSC,BUWAMA SUB-COUNTY,G,2013-03-13
+1135,MRSM,Mountain Rescue Service Montenegro,N,2013-03-13
+1136,CMRS,Croatian Mountain Rescue Service,N,2013-03-13
+1137,CCC - Dubrovnik,Croatian Chamber of Commerce - Country office Dubrovnik,C,2013-03-13
+1138,NTO Montenegro,National Tourism Organization Montenegro,G,2013-03-13
+1139,UNICEF Mozambique,UNICEF Mozambique,N,2013-03-18
+1140,DNA Mozambique,Ministry of Public Works & Housing  - DNA ,G,2013-03-18
+1141,Min. Education Mozambique,Ministry of Education Mozambique,G,2013-03-18
+1142,MJD Mozambique,Ministry of Youth & Sport Mozambique,G,2013-03-18
+1143,PSI-Liberia,Population Services International- Liberia,N,2013-03-19
+1146,NORAD,Norwegian Agency for Development Cooperation,G,2013-03-26
+1147,MoD Kosovo,"Ministry of Diaspora, Kosovo",G,2013-03-26
+1148,IOM,International Organization for Migration,N,2013-03-26
+1149,Restless Dev Uganda,Restless Development Uganda ,N,2013-03-27
+1150,ARI,Aliansi Remaja Independen,N,2013-03-27
+1151,WvW 2014,Wandelen voor Water 2014,N,2013-03-27
+1152,Ardhanary Institute,Ardhanary Institute,K,2013-04-02
+1153,Yayasan Pelita Ilmu,Yayasan Pelita Ilmu,N,2013-04-02
+1154,PMI,PMI Kota Jakarta Timur/Indonesian Red Cross East Jakarta Branch,N,2013-04-02
+1155,SIKOK Foundation,SIKOK Foundation,N,2013-04-02
+1156,RIFKA ANNISA,RIFKA ANNISA,N,2013-04-02
+1157,CMM PKBI Jakarta,Centra Mitra Muda Perkumpulan Keluarga Berencana Indonesia DKI JAKARTA,N,2013-04-02
+1158,ISEE,Interkerkelijke Stichting EthiopiÃ«/Eritrea,N,2013-04-02
+1159,PKBI Daerah Lampung,PKBI Daerah Lampung,N,2013-04-08
+1160,IPPA Yogyakarta Chapter,Indonesia Planned Parenthood Association Yogyakarta Chapter,N,2013-04-08
+1161,Stichting Oost Afrika,Stichting Oost Afrika,N,2013-04-09
+1162,Achmea Foundation,Achmea Foundation,N,2013-04-09
+1163,WDA,Wolaitta Development Association,N,2013-04-09
+1164,GeRT,Geo-ecological Research Team,K,2013-04-12
+1165,GKAS Uzbekistan,The State Committee for Architecture and Construction of Uzbekistan,G,2013-04-17
+1166,TCCAF,The Coca-Cola Africa Foundation (TCCAF),C,2013-04-17
+1167,GETF,Global Environment & Technology Foundation (GETF),N,2013-04-17
+1168,FH,Food for the Hungry,N,2013-04-17
+1169,Hilton Foundation,Conrad N. Hilton Foundation,N,2013-04-17
+1170,Acacia Water,Acacia Water,K,2013-04-18
+1171,World Vision,World Vision,N,2013-04-23
+1172,GINKS,Ghana Information Network For  Knowledge Sharing,N,2013-04-24
+1173,SPIR,Samaritan's Purse International Relief,N,2013-04-29
+1174,Maak Ethiopie Gezonder,Stichting Maak Ethiopie Gezonder,N,2013-05-01
+1175,St Luke Hospital,St Luke Hospital - Public Health Department,G,2013-05-01
+1176,CCI Uzbekistan,Chamber of Commerce and Industry of Uzbekistan,N,2013-05-03
+1177,DOT,Digital Opportunity Trust (DOT),C,2013-05-09
+1178,Liberia WASH Consortium,,N,2013-05-10
+1179,Nazava Water Filters,Nazava Water Filters,C,2013-05-12
+1180,Sticht Grenzeloos Salland,Stichting Grenzeloos Salland,N,2013-05-12
+1181,DENIOS,DENIOS,C,2013-05-16
+1182,Peepoople Kenya,Peepoople Kenya,N,2013-05-27
+1183,ANADER,ANADER,N,2013-05-30
+1184,SEK Budapest,SEK Budapest International School,K,2013-05-31
+1185,RHU,Reproductive Health Uganda,N,2013-05-31
+1186,Government of Liberia,,G,2013-05-31
+1187,Istituto Comprensivo,Istituto Comprensivo Sant' Antonino,K,2013-06-03
+1188,BS Beatrixschool Nunspeet,BS Beatrixschool Nunspeet,K,2013-06-03
+1189,CCDN,Centre for Community Development Nepal,N,2013-06-04
+1190,INF Nepal Mugu Programme,"International Nepal Fellowship Nepal, Mugu Programme",N,2013-06-04
+1191,UN Women,United Nations Entity for Gender Equality and the Empowerment of Women,N,2013-06-06
+1193,FH Kenya,Food for the Hungry - Kenya,N,2013-06-10
+1194,CARE - Kenya,CARE International in Kenya ,N,2013-06-10
+1195,MWA - Kenya,Millennium Water Alliance-Kenya Program (MWA-KP),N,2013-06-10
+1196,World Vision Kenya,World Vision Kenya (WVK),N,2013-06-10
+1197,CRS - Kenya,Catholic Relief Services,N,2013-06-10
+1198,World Vision Ethiopia,World Vision - Ethiopia,N,2013-06-11
+1199,CRS - Ethiopia,Catholic Relief Services - Ethiopia,N,2013-06-11
+1200,Mission Support Group,"Mission Support Group, St. John and St. Philip Church",N,2013-06-11
+1202,STAD,Support Trust for African Development,N,2013-06-11
+1207,NWB Fonds,Nederlandse Waterschapsbank Fonds,G,2013-06-18
+1209,WSHD,Waterschap Hollandse Delta,G,2013-06-18
+1210,ATWSSE,Adama Town Water Supply and Sewerage Enterprise,G,2013-06-18
+1211,AgentschapNL,AgentschapNL,G,2013-06-18
+1213,Municipality of Jenin,Municipality of Jenin,G,2013-06-24
+1214,PHG,Palestinian Hydrology Group for Water & Environmental Resources Development,N,2013-06-24
+1215,EWSA,"Energy, Water and Sanitation Authority",G,2013-06-24
+1216,FEPEAR,Forum des Exploitants PrivÃ©s des Systemes d'Eau er Assainissement au Rwanda,N,2013-06-24
+1217,Arthavida Foundation,Arthavida Foundation,N,2013-06-24
+1218,Stichting Waterhelp,Stichting Waterhelp,N,2013-06-24
+1219,Waterschap Aa en Maas,Waterschap Aa en Maas,G,2013-06-24
+1221,Dunea NV,Dunea NV,C,2013-06-24
+1223,Hatenboer Water BV,Hatenboer Water BV,C,2013-06-24
+1224,MUWASA,Musoma Urban Water supply and Sewerage Authority,G,2013-06-24
+1225,TNO,Nederlandse Organisatie voor toegepast natuurwetenschappelijk onderzoek TNO,N,2013-06-24
+1226,NestlÃ© S.A.,NestlÃ© S.A.,C,2013-06-24
+1227,Alterra,Alterra,K,2013-06-24
+1228,Min. Agriculture Colombia,Ministry of Agriculture and Rural Development (MADR),G,2013-06-24
+1229,FNC,Colombia Coffee Growers Federation,N,2013-06-24
+1230,KAA,Kosovo Anti-Corruption Agency,G,2013-06-24
+1231,Internews Kosova,Internews Kosova,N,2013-06-24
+1232,SDC Kosovo,Swiss Agency for Development and Cooperation Kosovo,G,2013-06-24
+1233,Harar Water Authority,Harar Water and Sewage Authority,G,2013-06-24
+1234,Harari People State,Harari People regional State,G,2013-06-24
+1235,Heineken Ethiopia,Heineken Breweries SC,C,2013-06-24
+1236,MS Consultancy,MS Consultancy,C,2013-06-24
+1237,Royal HaskoningDHV,Enhancing Society Together,C,2013-06-24
+1238,Mzuzu City Council,Mzuzu City Council,G,2013-06-24
+1239,North Region Water Board,Northern Regio Water Board,G,2013-06-24
+1240,Plan Nederland,Plan Nederland,N,2013-06-24
+1241,Cordaid Security/Justice,Cordaid Security & Justice,N,2013-06-24
+1272,Catholic Diocese of Malak,Catholic Diocese of Malakal,N,2013-06-24
+1273,OFP OrganizaciÃ³n Femenina,OFP OrganizaciÃ³n Femenina Popular,N,2013-06-24
+1274,Le Partenariat Paix & Pro,Le Partenariat Paix & ProspÃ©ritÃ© Ã  St Martin -3PSM,N,2013-06-24
+1275,ASOSEPRODI,ASOSEPRODI,N,2013-06-24
+1276,LOFEPACO,LOFEPACO,N,2013-06-24
+1277,FOPAC - NK,FOPAC - NK,N,2013-06-24
+1278,Finance South Sudan Limit,Finance South Sudan Limited,C,2013-06-24
+1279,The League of Pastoralist,The League of Pastoralist Women of Kenya  LPWK,N,2013-06-24
+1280,ASN  Bank,ASN  Bank,C,2013-06-24
+1281,Caritas Mbuji Mayi,Caritas Mbuji Mayi,N,2013-06-24
+1282,CorporaciÃ³n de Investigac,CorporaciÃ³n de InvestigaciÃ³n y AcciÃ³n Social y Eco,N,2013-06-24
+1283,International Institute o,International Institute of Rural Reconstruction,K,2013-06-24
+1284,IIED,IIED,K,2013-06-24
+1285,Jana Vikas,Jana Vikas,N,2013-06-24
+1286,CORDAID H&W,CORDAID H&W,N,2013-06-24
+1287,Stichting PharmAccess Int,Stichting PharmAccess International,N,2013-06-24
+1291,CEMCI,CEMCI,N,2013-06-24
+1292,Caritas Switzerland,Caritas Switzerland,N,2013-06-24
+1293,Plateforme Haitienne Deve,Plateforme Haitienne Develop. Alternatif (PAPDA),N,2013-06-24
+1294,ICCO Kampala,ICCO Kampala,N,2013-06-24
+1295,Christian Aid Sierra Leon,Christian Aid Sierra Leone,N,2013-06-24
+1296,Tata institute of Social ,Tata institute of Social Studies - TISS,K,2013-06-24
+1297,Cordaid Memisa,Cordaid Memisa,N,2013-06-24
+1298,Euretco,Euretco,C,2013-06-24
+1301,Justice and Peace Malakal,Justice and Peace Malakal,N,2013-06-24
+1302,International Institute o,International Institute of Rural Reconstruction,N,2013-06-24
+1303,Maguindanaon Development ,"Maguindanaon Development Foundation, Inc. (MDFI)",N,2013-06-24
+1305,Tilburg University - Scho,Tilburg University - School of Humanities - TSH,K,2013-06-24
+1306,Postcode Lottery,Dutch Postcode Lottery,C,2013-06-24
+1307,Caritas Liban,Caritas Liban,N,2013-06-24
+1308,The Episcopal Conference ,The Episcopal Conference of Malawi (ECM),N,2013-06-24
+1310,Tambayan Center for Child,Tambayan Center for Childrens Rights Inc,N,2013-06-24
+1311,SHO,SHO,G,2013-06-24
+1312,TFM Consult,TFM Consult,C,2013-06-24
+1313,Christian Brothers Develo,Christian Brothers Development Office,C,2013-06-24
+1314,Vredeseilanden NZW,Vredeseilanden NZW,N,2013-06-24
+1315,SEEDS FCRA,SEEDS FCRA,N,2013-06-24
+1316,Global Network of CSOs fo,Global Network of CSOs for Disaster Risk Reduction,N,2013-06-24
+1317,ASAP Africa Limited,ASAP Africa Limited,N,2013-06-24
+1318,Caritas South Sudan,Caritas South Sudan,N,2013-06-24
+1319,Catholic Diocese of Wau,Catholic Diocese of Wau,C,2013-06-24
+1320,"APDIK, asbl","APDIK, asbl",N,2013-06-24
+1321,EAA,EAA,N,2013-06-24
+1322,Women Inc.,Women Inc.,N,2013-06-24
+1323,Swisscontact,Swisscontact,N,2013-06-24
+1324,Concern Universal Banglad,Concern Universal Bangladesh,N,2013-06-24
+1325,CFSC-MW,CFSC-MW,N,2013-06-24
+1326,IRATAM,"Institut de Recherche, dâ€™Appui Technique en AmÃ©nagement du Milieu",N,2013-06-24
+1328,Observatoire de la ParitÃ©,Observatoire de la ParitÃ©,N,2013-06-24
+1330,CAFOD,CAFOD,N,2013-06-24
+1331,ADEPAE,ADEPAE,N,2013-06-24
+1332,South Sudan Action Networ,South Sudan Action Network on Small Arms: SSANSA,N,2013-06-24
+1333,AADA,AADA,N,2013-06-24
+1334,AHDS,Afghan Health and Development Services,N,2013-06-24
+1335,Organization of Afghan Mi,Organization of Afghan Midwives (OAM),N,2013-06-24
+1336,HNTPO AFGH,HNTPO AFGH,N,2013-06-24
+1337,PRM SL,Peace and Reconciliation Movement Sierra Leone,N,2013-06-24
+1338,PPASL,PPASL,N,2013-06-24
+1340,AAP SUD KIVU- ASBL,AAP SUD KIVU- ASBL,N,2013-06-24
+1341,CORDAID BUKAVU-ASBL (ACTU,CORDAID BUKAVU-ASBL (ACTUAL),N,2013-06-24
+1342,Cordaid Kinderstem,Cordaid Kinderstem,N,2013-06-24
+1343,Salone Microfinance Trust,Salone Microfinance Trust,N,2013-06-24
+1344,CORDAID EXPLOITATIE,CORDAID EXPLOITATIE,N,2013-06-24
+1345,SEND Sierra Leone,SEND Sierra Leone,N,2013-06-24
+1346,CORDAID SO,CORDAID SO,N,2013-06-24
+1347,Stichting Karti,Stichting Karti,N,2013-06-24
+1348,ASPRODE,ASPRODE,N,2013-06-24
+1349,DELICE - Droits De l'Enfa,DELICE - Droits De l'Enfant: un livre pour chaque,N,2013-06-24
+1351,PANOS ETHIOPIA,PANOS ETHIOPIA,K,2013-06-24
+1352,ALVF Cordaid,ALVF Cordaid,N,2013-06-24
+1353,AFEM-SK,AFEM-SK,N,2013-06-24
+1354,European Union,European Union,G,2013-06-24
+1355,Cordaid HaÃ¯ti,Cordaid HaÃ¯ti,N,2013-06-24
+1358,Cordaid Mensen in Nood,Cordaid Mensen in Nood,N,2013-06-24
+1359,Caritas Bangladesh,Caritas Bangladesh,N,2013-06-24
+1360,Cordaid Disaster Risk Red,Cordaid Disaster Risk Reduction and Emergency Aid,N,2013-06-24
+1361,Pastoral Verapaz,Pastoral Social CÃ¡ritas DiÃ³cesis de la Verapaz,N,2013-06-24
+1362,ComitÃ© Protos Haiti -  CP,ComitÃ© Protos Haiti -  CPH,N,2013-06-24
+1363,NASFAM,NASFAM,N,2013-06-24
+1364,CERN/CENCO,CERN/CENCO,N,2013-06-24
+1365,SCA: Swedish Committee fo,SCA: Swedish Committee for Afghanistan,N,2013-06-24
+1366,Health Development and Pe,Health Development and Performance (HDP),N,2013-06-24
+1367,Uganda Catholic Secretari,Uganda Catholic Secretariat - Soc. Serv. and Dev.,N,2013-06-24
+1370,CILC,CILC,N,2013-06-24
+1371,VNG INT,VNG INT,N,2013-06-24
+1372,SchuldHulp Maatje,SchuldHulp Maatje,N,2013-06-24
+1376,AWA,AWA,N,2013-06-24
+1377,ASSEJA Maroua,ASSEJA Maroua,N,2013-06-24
+1379,EGPAF,EGPAF,N,2013-06-24
+1380,Dokters van de Wereld (MD,Dokters van de Wereld (MDM),N,2013-06-24
+1381,EPVI,EPVI,N,2013-06-24
+1382,CORDAID RDC,CORDAID RDC,N,2013-06-24
+1383,BDOM KINSHASA,BDOM KINSHASA,N,2013-06-24
+1384,CARITAS CONGO,CARITAS CONGO,N,2013-06-24
+1385,BDOM Bukavu,BDOM Bukavu,N,2013-06-24
+1386,Memisa Belgie,Memisa Belgie,N,2013-06-24
+1387,Catholic Organization for,Catholic Organization for Relief & Devt South Suda,N,2013-06-24
+1388,Stichting Interplast Holl,Stichting Interplast Holland,N,2013-06-24
+1389,Interact Worldwide,Interact Worldwide,N,2013-06-24
+1391,GPDI Gayo Pastoral Develo,GPDI Gayo Pastoral Development Initiative,N,2013-06-24
+1392,Intl. Inst. of Rural Reco,Intl. Inst. of Rural Reconstruction (IIRR),N,2013-06-24
+1393,Community Initiative Faci,Community Initiative Facilitation and Assistance,N,2013-06-24
+1395,PACIDA,PACIDA,N,2013-06-24
+1396,ACORD,ACORD,N,2013-06-24
+1397,RECIC,RECIC,N,2013-06-24
+1399,MFT,MFT,N,2013-06-24
+1400,African Water Facility,African Water Facility,G,2013-06-24
+1402,SANA International,SANA International,N,2013-06-24
+1403,Umande Trust,Umande Trust,N,2013-06-24
+1404,HDSR,Hoogheemraadschap De Stichtse Rijnlanden,G,2013-06-24
+1407,MCK Municipal Council of ,MCK Municipal Council of Kisumu,G,2013-06-24
+1408,Le Komite Lojman Katye Vi,Le Komite Lojman Katye Vila Roza,N,2013-06-24
+1409,CERDeL,CERDeL,N,2013-06-24
+1410,IHDI,Institut Haitien de Developpement Integral,N,2013-06-24
+1411,Kasek Tijo,Kasek Tijo,G,2013-06-24
+1412,Catholic Diocese of Tombu,Catholic Diocese of Tombura-Yambio,N,2013-06-24
+1413,CINEP,CINEP,N,2013-06-24
+1414,Kalvi Kendra,Kalvi Kendra,N,2013-06-24
+1415,Catholic Relief Services ,Catholic Relief Services (CRS) South Sudan,N,2013-06-24
+1416,MEDICI CON L'AFRICA CUAMM,MEDICI CON L'AFRICA CUAMM,N,2013-06-24
+1417,PASALI Philippines Founda,"PASALI Philippines Foundation, Inc.",N,2013-06-24
+1418,Emek Shaveh,Emek Shaveh,N,2013-06-24
+1419,FONDECO,FONDECO,C,2013-06-24
+1421,Fundacion Sartawi,Fundacion Sartawi,N,2013-06-24
+1422,Cordaid Microkrediet,Cordaid Microkrediet,N,2013-06-24
+1423,ARD SIERRA L.,ARD SIERRA L.,N,2013-06-24
+1425,Tinh Thuong (TYM fund),Tinh Thuong (TYM fund),C,2013-06-24
+1427,UWC Maastricht,United World College Maastricht,K,2013-06-28
+1428,Basisschool Zonnewijzer,Basisschool de Zonnewijzer,K,2013-06-28
+1429,UNESCO-IHE,UNESCO-IHE,G,2013-06-28
+1430,Soc Trang Water Supply,Soc Trang Water Supply Company Limited,C,2013-06-28
+1431,P.C. Soc Trang Province,People's Committee of Soc Trang Province,G,2013-06-28
+1432,SAWACO,Saigon Water Corporation ,C,2013-06-28
+1433,P.C. Tra Vinh Provice,People's Committee of Tra Vinh Province,G,2013-06-28
+1434,Tra Vinh Water Supply,Tra Vinh Water Supply and Drainage One Member limited company,C,2013-06-28
+1435,Can Tho University,Research Institute for Climate Change - Can Tho University,K,2013-06-28
+1437,Ruud Stoop Culture School,Ruud Stoop Culture School,N,2013-07-01
+1438,Fonds Duurzaam Water,Fonds Duurzaam Water,G,2013-07-04
+1439,EU Delegation to BiH,Delegation of the European Union to Bosnia and Herzegovina,G,2013-07-09
+1440,MoD BiH,Ministry of Defense of Bosnia and Herzegovina,G,2013-07-09
+1441,OSCE mission to BiH,Organization for Security and Co-operation in Europe,G,2013-07-09
+1442,Leids Universiteits Fonds,Leids Universiteits Fonds,N,2013-07-10
+1443,Walking for Water 2014,Walking for Water international 2014,N,2013-07-11
+1444,Bodleian Library,Bodleian Library,G,2013-07-12
+1445,NWO Science4Arts,NWO Science4Arts,G,2013-07-12
+1446,RMV,National Museum of Ethnology,G,2013-07-12
+1447,CHARISMA MOLAB,MOLAB the mobile facilities for in situ non-invasive measurements,G,2013-07-12
+1448,Rotary Chelmsford Phoenix,Rotary Chelmsford Phoenix,N,2013-07-16
+1449,CSO Samopomich,Civil Society Organisation â€œSamopomichâ€ (Self-Help),N,2013-07-16
+1450,SCNP Uzbekistan,SCNP Uzbekistan,G,2013-07-19
+1451,"Association Enfants, Jeun","Association Enfants, Jeunes et Avenir    ASSEJA",N,2013-07-19
+1452,Bureau de Nutrition et DÃ©,Bureau de Nutrition et DÃ©veloppement (BND),N,2013-07-19
+1453,Caritas India,Caritas India,N,2013-07-19
+1454,PREDA Foundation Inc.,PREDA Foundation Inc.,N,2013-07-19
+1455,Palli Gana Unnayan Kendra,Palli Gana Unnayan Kendra (PGUK),N,2013-07-19
+1456,BINA SWADAYA,BINA SWADAYA,N,2013-07-19
+1457,Xavier Institute of Manag,Xavier Institute of Management,K,2013-07-19
+1458,DIO BANGASSOU,DIO BANGASSOU,C,2013-07-19
+1459,Catholic Diocese of Chipa,Catholic Diocese of Chipata,N,2013-07-19
+1460,Fund. Salvadorena de Desa,Fund. Salvadorena de Desarrollo y Vivienda Minima,N,2013-07-19
+1461,Himalayan Action Research,Himalayan Action Research Centre,N,2013-07-19
+1462,DIO MAROUA-Comite Diocesa,DIO MAROUA-Comite Diocesain de Developpement (CDD),C,2013-07-19
+1463,ARCH BUKAVU,ARCH BUKAVU,N,2013-07-19
+1464,CHAZ - Churches Health As,CHAZ - Churches Health Association of Zambia,N,2013-07-19
+1465,DIO BATOURI,DIO BATOURI,N,2013-07-19
+1467,SYNERGIA,SYNERGIA,N,2013-07-19
+1468,Isis International Women',Isis International Women's Inform. & Communication,N,2013-07-19
+1469,Caritas Moroto,Caritas Moroto,N,2013-07-19
+1470,SOCADIDO,SOCADIDO,N,2013-07-19
+1471,VETERIMED,VETERIMED,N,2013-07-19
+1472,VARD-SYLHET,VARD-SYLHET,N,2013-07-19
+1473,UNNATI,UNNATI,N,2013-07-19
+1475,Institut Panos Europe,Institut Panos Europe,N,2013-07-19
+1476,NMJD Network Movement for,NMJD Network Movement for Justice & Development,N,2013-07-19
+1478,DENIVA,DENIVA,N,2013-07-19
+1479,CFE ETH Cheshire Foundati,CFE ETH Cheshire Foundation Ethiopia,N,2013-07-19
+1480,Transcultural Psychosocia,Transcultural Psychosocial Organisation (TPO) Ugan,N,2013-07-19
+1481,ENDA ETHIOPIA,ENDA ETHIOPIA,N,2013-07-19
+1482,PTSM Obispado de San Marc,PTSM Obispado de San Marcos,N,2013-07-19
+1483,CORDAID Burundi,CORDAID Burundi,N,2013-07-19
+1484,SER,SER,N,2013-07-19
+1485,AWRC,AWRC,N,2013-07-19
+1486,Empowerment of Children a,Empowerment of Children and Human Rights Org  ECHO,N,2013-07-19
+1488,MEMISA Programme DGD BELG,MEMISA Programme DGD BELGIE,N,2013-07-19
+1489,Centre Ubuntu Isange,Centre Ubuntu Isange,N,2013-07-19
+1490,Indonesia Untuk Transform,Indonesia Untuk Transformasi Social (INSIST),N,2013-07-19
+1491,SOS SAHEL,SOS SAHEL,N,2013-07-19
+1492,PAMOJA TRUST,PAMOJA TRUST,N,2013-07-19
+1493,Microfinance Council of t,"Microfinance Council of the Philippines, Inc.",N,2013-07-19
+1494,ODHAG,ODHAG,N,2013-07-19
+1495,Stakeholder Democracy Net,Stakeholder Democracy Network        SDN,N,2013-07-19
+1496,CORDAID CONGO,CORDAID CONGO,N,2013-07-19
+1497,NAVSARJAN TRUST,NAVSARJAN TRUST,N,2013-07-19
+1498,CONGCOOP,CONGCOOP,N,2013-07-19
+1499,RIO,RIO,N,2013-07-19
+1500,CCAJAR,CCAJAR,N,2013-07-19
+1501,SOPRAD-RUYIGI,SOPRAD-RUYIGI,N,2013-07-19
+1503,Catholic Relief Services ,Catholic Relief Services (CRS),N,2013-07-19
+1504,Asociacion para la Preven,Asociacion para la Prevencion del Delito    APREDE,N,2013-07-19
+1505,WLP,WLP,N,2013-07-19
+1506,ISD Institute for Sustain,ISD Institute for Sustainable Development,N,2013-07-19
+1507,Fundacion San Andres,Fundacion San Andres,N,2013-07-19
+1508,CEMUJER,CEMUJER,N,2013-07-19
+1509,FADEMYPE,FADEMYPE,N,2013-07-19
+1510,Groupe d Appui au Develop,Groupe d Appui au Developpement Rural - GADRU,N,2013-07-19
+1511,Zambia Land Alliance,Zambia Land Alliance,N,2013-07-19
+1512,SIDEP Samburu Integrated ,SIDEP Samburu Integrated Development Program,N,2013-07-19
+1513,PDNK Pastoralist Developm,PDNK Pastoralist Development Network of Kenya,N,2013-07-19
+1514,NPDO,NPDO,N,2013-07-19
+1515,Leonard Cheshire Disabili,Leonard Cheshire Disability and Development Progr,N,2013-07-19
+1516,YAYASAN KARINA,YAYASAN KARINA,N,2013-07-19
+1517,WOMEN Dutch Gender Platfo,WOMEN Dutch Gender Platform,N,2013-07-19
+1518,Rimansi Organization for ,"Rimansi Organization for Asia and the Pacific, Inc",N,2013-07-19
+1519,Reseau Haki na Amani (RHA,Reseau Haki na Amani (RHA),N,2013-07-19
+1522,FundaciÃ³n Salvador del Mu,FundaciÃ³n Salvador del Mundo     FUSALMO,N,2013-07-19
+1523,COPAE,COPAE,N,2013-07-19
+1525,Afghan Women for Afghan W,Afghan Women for Afghan Women (AWAW),N,2013-07-19
+1526,NONM,NONM,N,2013-07-19
+1527,CORDAID RCA,CORDAID RCA,N,2013-07-19
+1529,NOVOC,NOVOC,N,2013-07-19
+1530,ASSOMESCA,ASSOMESCA,N,2013-07-19
+1531,Asociacion Grupo CEIBA,Asociacion Grupo CEIBA,N,2013-07-19
+1532,Diocese de Mahagi-Nioka,Diocese de Mahagi-Nioka,C,2013-07-19
+1533,Integrated Rural Developm,Integrated Rural Development Service Organis IRDSO,N,2013-07-19
+1534,WISE,WISE,N,2013-07-19
+1535,ABF,ABF,N,2013-07-19
+1536,CHINDU,CHINDU,N,2013-07-19
+1537,Stichting Luanda Jinja,Stichting Luanda Jinja,N,2013-07-19
+1538,AIDEnvironment,AIDEnvironment,N,2013-07-19
+1539,Shivi Development Society,Shivi Development Society,N,2013-07-19
+1540,MEWODA,MEWODA,N,2013-07-19
+1541,Stichting Ecologische Lan,Stichting Ecologische Landbouw projecten Ghana (EL,N,2013-07-19
+1542,Pastoral de la Tierra/Pas,Pastoral de la Tierra/Pastoral Social Diocesis de,G,2013-07-19
+1543,Justitia et Pax Nederland,Justitia et Pax Nederland,N,2013-07-19
+1545,PEFO,PEFO,N,2013-07-19
+1546,Social Welfare Society,Social Welfare Society,N,2013-07-19
+1547,Stichting Kapatiran,Stichting Kapatiran,N,2013-07-19
+1549,Don Bosco Anbu Illam Chen,Don Bosco Anbu Illam Chennai,N,2013-07-19
+1550,Niger Delta Environment &,Niger Delta Environment &Relief Foundation NIDEREF,N,2013-07-19
+1551,Pastoralist Women for Hea,Pastoralist Women for Health and Education PWHE,N,2013-07-19
+1552,Alcaldia Municipal de Mej,Alcaldia Municipal de Mejicanos,G,2013-07-19
+1553,BBO,BBO,K,2013-07-19
+1555,AgriProFocus,AgriProFocus,G,2013-07-19
+1556,Stichting Medisch Werk Mu,Stichting Medisch Werk Mumbai,N,2013-07-19
+1557,Stichting Upendo Daima Ne,Stichting Upendo Daima Nederland,N,2013-07-19
+1558,Upendo Daima Tanzania,Upendo Daima Tanzania,N,2013-07-19
+1559,Stichting Bebo Bakery,Stichting Bebo Bakery,N,2013-07-19
+1560,Rotaryclub Scherpenzeel/W,Rotaryclub Scherpenzeel/Woudenberg,G,2013-07-19
+1561,Rotaryclub de Bertoua,Rotaryclub de Bertoua,G,2013-07-19
+1562,Partnership Africa Canada,Partnership Africa Canada,N,2013-07-19
+1563,Stromme Microfinance East,Stromme Microfinance East Africa Ltd.,N,2013-07-19
+1564,"MIND Media, Information a","MIND Media, Information and Narrative Development",N,2013-07-19
+1565,Training And Research Sup,Training And Research Support Centre TARSC,N,2013-07-19
+1566,Cordaid Zimbabwe,Cordaid Zimbabwe,N,2013-07-19
+1567,International Civil Socie,International Civil Society Action Network ICAN,N,2013-07-19
+1569,Organisation Mondiale con,Organisation Mondiale contre la Torture OMCT,N,2013-07-19
+1570,Caritas Jacmel,Caritas Jacmel,N,2013-07-19
+1571,AEPA Action for Environme,AEPA Action for Environmental Public Advocacy,N,2013-07-19
+1572,Stichting Text to Change,Stichting Text to Change,N,2013-07-19
+1573,Skills for Southern Sudan,Skills for Southern Sudan,N,2013-07-19
+1574,International Commission ,International Commission of Jurists,N,2013-07-19
+1575,CODAS CARITAS GAROUA,CODAS CARITAS GAROUA,N,2013-07-19
+1576,Het Nederlandse Rode Krui,Het Nederlandse Rode Kruis,N,2013-07-19
+1577,Stichting Sight for the P,Stichting Sight for the Poor (SFP),N,2013-07-19
+1578,Birds Heal,Birds Heal,G,2013-07-19
+1579,TOHI (Strauss & Co),TOHI (Strauss & Co),C,2013-07-19
+1580,Idepro Desarrollo Empresa,Idepro Desarrollo Empresarial,N,2013-07-19
+1581,Hope Agency for Relief an,Hope Agency for Relief and Development,N,2013-07-19
+1582,PALLISHREE,PALLISHREE,N,2013-07-19
+1583,CPI Children Peace Initia,CPI Children Peace Initiative Kenya,N,2013-07-19
+1584,Care for the Poor,Care for the Poor,N,2013-07-19
+1585,SiLNoRF,SiLNoRF,N,2013-07-19
+1586,Healthy Entrepreneurs,Healthy Entrepreneurs,C,2013-07-19
+1587,Fontaine Isoko,Fontaine Isoko,N,2013-07-19
+1588,Tribal Education on Ecolo,Tribal Education on Ecological System,N,2013-07-19
+1589,TLDFI,TLDFI,N,2013-07-19
+1590,AlcaldÃ­a de Soyapango,AlcaldÃ­a de Soyapango,G,2013-07-19
+1591,Credisol OPDF,Credisol OPDF,C,2013-07-19
+1592,IADH,IADH,N,2013-07-19
+1593,GASIN Gas Alert for Susta,GASIN Gas Alert for Sustainable Initiative,N,2013-07-19
+1594,CASEC TURGEAU,CASEC TURGEAU,G,2013-07-19
+1595,Shariatpur Development So,Shariatpur Development Society,N,2013-07-19
+1596,"Actions pour les Droits, ","Actions pour les Droits, l'Environnement et la Vie",N,2013-07-19
+1597,Collaborative for Peace,Collaborative for Peace,N,2013-07-19
+1598,GADET-PENTAGON,GADET-PENTAGON,N,2013-07-19
+1599,CESVI,CESVI,N,2013-07-19
+1600,Open Society Foundation-L,Open Society Foundation-London,N,2013-07-19
+1601,Caritas des Gonaives Spec,Caritas des Gonaives Speciale,N,2013-07-19
+1602,Lembaga Pengembangan Tekn,Lembaga Pengembangan Teknologi Pedesaan,N,2013-07-19
+1603,Institut de Technologie e,Institut de Technologie et d Animation ITECA,N,2013-07-19
+1604,Haiti Survie,Haiti Survie,N,2013-07-19
+1605,Commission Episcopale Nat,Commission Episcopale Nationale Justice et Paix,N,2013-07-19
+1606,Women Development Group,Women Development Group,N,2013-07-19
+1607,Colectivo Ecologista Madr,Colectivo Ecologista Madre Selva,N,2013-07-19
+1609,IMAN,IMAN,N,2013-07-19
+1610,REDMICROH,REDMICROH,N,2013-07-19
+1611,Tierra Digna,Tierra Digna,N,2013-07-19
+1612,The Norbertine Fathers So,The Norbertine Fathers Society Indara,G,2013-07-19
+1613,Communaute des Municipali,Communaute des Municipalites d.l. Region d Palmes,G,2013-07-19
+1614,Action for Children (AFC),Action for Children (AFC),N,2013-07-19
+1615,Action pour la Paix et la,Action pour la Paix et la Concorde,N,2013-07-19
+1616,Beza Youth Health and Cou,Beza Youth Health and Counseling Center,N,2013-07-19
+1617,Succeed-Global,Succeed-Global,N,2013-07-19
+1618,Programme pour une Altern,Programme pour une Alternative de Justice - PAJ,N,2013-07-19
+1619,Trocaire Haiti,Trocaire Haiti,N,2013-07-19
+1620,GENET,GENET,N,2013-07-19
+1621,Erasmus MC Rotterdam,Erasmus MC Rotterdam,K,2013-07-19
+1622,I+Solutions,I+Solutions,N,2013-07-19
+1623,Stichting Stop Aids Now,Stichting Stop Aids Now,N,2013-07-19
+1624,Stichting SYPO,Stichting SYPO,N,2013-07-19
+1625,SYPO Uganda Ltd,SYPO Uganda Ltd,N,2013-07-19
+1626,AT Osborne,AT Osborne,C,2013-07-19
+1629,Wereld Waternet,Wereld Waternet,N,2013-07-19
+1631,Swiss TPH,Swiss TPH,K,2013-07-19
+1632,CITY OF CAPE TOWN,CITY OF CAPE TOWN,G,2013-07-19
+1633,Inyanda Youth Network,Inyanda Youth Network,G,2013-07-19
+1634,AHI,AHI,C,2013-07-19
+1635,SHO,SHO,N,2013-07-19
+1636,Cordaid Bond Zonder Naam,Cordaid Bond Zonder Naam,N,2013-07-19
+1637,Sirigu Initiative for Sus,Sirigu Initiative for Sustainable Development,N,2013-07-19
+1638,OCADES - Caritas Burkina ,OCADES - Caritas Burkina EA Caritas Sahel,N,2013-07-19
+1639,SIPRI,SIPRI,K,2013-07-19
+1640,HADAAF,HADAAF,N,2013-07-19
+1641,BoP inc.,BoP inc.,C,2013-07-19
+1642,WWN,WWN,N,2013-07-19
+1643,Foyer st. Marie,Foyer st. Marie,N,2013-07-19
+1644,XCOOP,XCOOP,C,2013-07-19
+1645,A 01,A 01,C,2013-07-19
+1646,Ineke Feitz Stichting,Ineke Feitz Stichting,N,2013-07-19
+1647,Plataforma Urbana Guatama,Plataforma Urbana Guatamala,G,2013-07-19
+1648,Progynist,Progynist,N,2013-07-19
+1649,Woreda 01,Woreda 01,G,2013-07-19
+1650,Woreda Urban Development ,Woreda Urban Development Committee,G,2013-07-19
+1651,Private donor(s),Private donor(s),C,2013-07-19
+1652,Dutch institutional donor,Dutch institutional donor(s),G,2013-07-19
+1653,Institutional donor(s),Institutional donor(s),G,2013-07-19
+1654,Other donor(s),Other donor(s),N,2013-07-19
+1655,Minkels BV.,Minkels BV.,C,2013-07-19
+1656,NIEHOFF WERNING & KOOIJ,NIEHOFF WERNING & KOOIJ,C,2013-07-19
+1658,TaYA,Talent Youth Association,N,2013-07-25
+1659,Cordaid DRM Program,Cordaid DRM Program,N,2013-07-25
+1660,Irish Aid,,G,2013-08-01
+1661,Tearfund Liberia,,N,2013-08-01
+1662,STT Lithuania,Special Investigation Service of the Republic of Lithuania,N,2013-08-08
+1663,AFSRT,AGENCY FOR SUSTAINABLE RURAL TRANSFORMATION,N,2013-08-12
+1664,I-Network,I-Network,N,2013-08-13
+1665,ELECU,Education Local Expertise Centre Uganda,N,2013-08-13
+1666,LINK TO PROGRESS,LINK TO PROGRESS,N,2013-08-14
+1667,WfP Uganda,Water For People Uganda,N,2013-08-14
+1668,NAWASSCO,Nakuru Water and Sanitation Services Company Limited,C,2013-08-14
+1669,Rotary Club Nijmegen,Rotary Club Nijmegen,N,2013-08-21
+1670,Rotary Club Nijmegen-Zuid,Rotary Club Nijmegen-Zuid,N,2013-08-21
+1671,Rotary Club Etten-Leur,Rotary Club Etten-Leur,N,2013-08-21
+1672,Rotary Club Reeuwijk,Rotary Club Reeuwijk,N,2013-08-22
+1673,Trondheim Int. School,Trondheim International School,K,2013-08-28
+1674,EC Ma Ndryshe,Emancipimi Civil Ma Ndryshe,N,2013-08-28
+1675,NAC Moldova,"National Anticorruption Centre, Republic of Moldova",G,2013-08-28
+1676,CIP,Centro Internacional de la Papa,N,2013-08-29
+1677,Wienco (Ghana) Limited,Wienco (Ghana) Limited,C,2013-08-29
+1678,SADA,Savannah Accelerated Development Authority,N,2013-09-03
+1679,Rebel Group,Rebel Group Advisory BV,C,2013-09-03
+1680,Stichting HoPe,Stichting HoPe,N,2013-09-04
+1683,Aspire Egypt,Aspire Experiential Business Solution,C,2013-09-13
+1684,YEP Water,Young Expert Programme Water,K,2013-09-13
+1685,Stichting Welzijn Wajir,Stichting Welzijn Wajir,N,2013-09-16
+1686,NWP,NWP,N,2013-09-17
+1687,Benin WASH Alliance,Benin WASH Alliance,N,2013-09-23
+1689,European Research Council,European Research Council (ERC),K,2013-09-24
+1690,Witteveen + Bos,Witteveen + Bos,C,2013-09-24
+1691,WASPA,Water Services Provider Association,C,2013-09-26
+1692,HaÃ«lla Stichting,HaÃ«lla Stichting,N,2013-10-01
+1693,FUSP,Frisian Urban Sanitation Program,N,2013-10-15
+1694,Water of Life,Water of Life Liberia Inc.,N,2013-10-15
+1695,Rotary Club Tiel,Rotary Club Tiel,N,2013-11-05
+1697,CREARE Foundation,CREARE Foundation,N,2013-11-06
+1698,RCE,Rijksdienst voor het Cultureel Erfgoed,G,2013-11-06
+1699,Caritas Relief,Caritas Relief,N,2013-11-06
+1700,CARITAS PAKISTAN,CARITAS PAKISTAN,N,2013-11-06
+1701,DOC UDP Daughters of Char,DOC UDP Daughters of Charity (Urban Development Pr,G,2013-11-06
+1702,Fight for Hunger (FFH),Fight for Hunger (FFH),N,2013-11-06
+1703,HELPAGE INTERNATIONAL,HELPAGE INTERNATIONAL,N,2013-11-06
+1704,CARE NEDERLAND,CARE NEDERLAND,N,2013-11-06
+1705,Dhaka Ahsania Mission (DA,Dhaka Ahsania Mission (DAM),N,2013-11-06
+1706,Instituto Dominicano de D,Instituto Dominicano de Desarrollo Integral  IDDI,N,2013-11-06
+1707,VECO UGANDA,VECO UGANDA,N,2013-11-06
+1708,Catholic Relief Services ,Catholic Relief Services Philippines  CRS PHIL,N,2013-11-06
+1709,Green Mindanao Associatio,"Green Mindanao Association, Inc  (GMAI)",N,2013-11-06
+1710,Instituto de PromociÃ³n So,Instituto de PromociÃ³n Social y Desarrollo de Hond,N,2013-11-06
+1712,DAG,DAG,N,2013-11-06
+1713,KLMC,KLMC,N,2013-11-06
+1714,WASASA,WASASA,C,2013-11-06
+1715,CENSAT AGUA VIVA,CENSAT AGUA VIVA,N,2013-11-06
+1716,MANGOCHI,MANGOCHI,N,2013-11-06
+1717,Peace Equity Access for C,Peace Equity Access for Community Empowerment Foun,N,2013-11-06
+1718,MOJE,MOJE,N,2013-11-06
+1719,OK,OK,C,2013-11-06
+1721,Appropriate Technology In,Appropriate Technology India,N,2013-11-06
+1722,PROCOMES,PROCOMES,N,2013-11-06
+1723,Endurance Youth Associati,Endurance Youth Association      EYA,N,2013-11-06
+1724,Pastoral de la Mujer Arqu,Pastoral de la Mujer ArquidiÃ³cesis de los Altos,N,2013-11-06
+1725,Cameroon Young Jurists Le,Cameroon Young Jurists Legal Resource Centre,N,2013-11-06
+1726,DCI UGANDA,DCI UGANDA,N,2013-11-06
+1727,Family Planning Organizat,Family Planning Organization of the Phillippines,N,2013-11-06
+1728,APDA Afar Pastoralist Dev,APDA Afar Pastoralist Development Association,N,2013-11-06
+1729,Caritas Internationalis,Caritas Internationalis,G,2013-11-06
+1730,Procure Interdiocesaine M,Procure Interdiocesaine Mission Catholique,G,2013-11-06
+1731,Corporacion para el Desar,Corporacion para el Desarrollo del Oriente-Comprom,N,2013-11-06
+1732,Stichting LOS,Stichting LOS,N,2013-11-06
+1734,Rotaryclub De Bilt-Biltho,Rotaryclub De Bilt-Bilthoven,G,2013-11-06
+1735,Ogaden Welfare and Develo,Ogaden Welfare and Development Association,N,2013-11-06
+1736,Society of Franciscan Ser,Society of Franciscan Servants of Mary,G,2013-11-06
+1737,Stichting FairWork,Stichting FairWork,N,2013-11-06
+1738,Lions Clubs Indonesia Mul,Lions Clubs Indonesia Multiple District 307,G,2013-11-06
+1739,Rotaryclub Hilversum-West,Rotaryclub Hilversum-West,N,2013-11-06
+1741,Dharma Amal Bakti Foundat,Dharma Amal Bakti Foundation,N,2013-11-06
+1743,Bawku Hospital eye depart,Bawku Hospital eye department,G,2013-11-06
+1744,Bisdom Roermond,Bisdom Roermond,G,2013-11-06
+1745,Lubumbashi champignon pro,Lubumbashi champignon project,N,2013-11-06
+1746,Stichting Bangalore,Stichting Bangalore,N,2013-11-06
+1747,AFSR,AFSR,N,2013-11-06
+1749,Integrated Youth Voluntee,Integrated Youth Volunteer Foundation (IYVF),N,2013-11-06
+1750,Stichting Zenji Treasures,Stichting Zenji Treasures,N,2013-11-06
+1751,Justice Africa South Suda,Justice Africa South Sudan,N,2013-11-06
+1752,CJR 1325,CJR 1325,N,2013-11-06
+1753,The Coalition Factory,The Coalition Factory,C,2013-11-06
+1754,PILARH OPDF,PILARH OPDF,C,2013-11-06
+1755,Lions Club Schouwen-Duive,Lions Club Schouwen-Duiveland,G,2013-11-06
+1756,Regional Institute for So,Regional Institute for Social Enterprise RISE,N,2013-11-06
+1757,Keepers Zambia Foundation,Keepers Zambia Foundation,N,2013-11-06
+1758,Association for Rural Com,Association for Rural Community Development- ARCOD,N,2013-11-06
+1759,Youth Council for Develop,Youth Council for Development Alternatives,N,2013-11-06
+1760,Stichting Pater Schlooz,Stichting Pater Schlooz,N,2013-11-06
+1761,Rural Youth Association,Rural Youth Association,N,2013-11-06
+1762,Music Crossroads Malawi,Music Crossroads Malawi,N,2013-11-06
+1764,Ladies' Circle Bossche Pa,Ladies' Circle Bossche Parels 65,N,2013-11-06
+1765,Friends of Lake Turkana,Friends of Lake Turkana,N,2013-11-06
+1767,Ten Foundation,Ten Foundation,N,2013-11-06
+1768,Holy Family Hansenorium,Holy Family Hansenorium,N,2013-11-06
+1769,Stichting Jong Talent Eth,Stichting Jong Talent EthiopiÃ«,N,2013-11-06
+1770,Young Talent Ethiopia,Young Talent Ethiopia,N,2013-11-06
+1771,Stichting Vrienden van Ha,Stichting Vrienden van Haiti Westvoorne,N,2013-11-06
+1772,Stichting Knowing Emergin,Stichting Knowing Emerging Powers,K,2013-11-06
+1773,UnYphil-Women Inc.,UnYphil-Women Inc.,N,2013-11-06
+1774,"CDJP, DiocÃ¨se de  Muyinga","CDJP, DiocÃ¨se de  Muyinga",C,2013-11-06
+1775,Codrington College,Codrington College,G,2013-11-06
+1776,ADIS,ADIS,N,2013-11-06
+1777,Kongolese en Angolese Sti,Kongolese en Angolese Stichting Talentueux KAST,N,2013-11-06
+1778,Stichting The Hunger Proj,Stichting The Hunger Project Nederland,N,2013-11-06
+1779,The Hunger Project India,The Hunger Project India,N,2013-11-06
+1780,Stichting Keihan,Stichting Keihan,N,2013-11-06
+1781,Borko Health Services Pri,Borko Health Services Private Corporation,C,2013-11-06
+1782,Stichting HomePlan,Stichting HomePlan,N,2013-11-06
+1784,Stichting Young in Prison,Stichting Young in Prison,N,2013-11-06
+1785,Stichting Child in Need I,Stichting Child in Need Institute,N,2013-11-06
+1786,Child in Need Institute,Child in Need Institute,N,2013-11-06
+1787,Baran Foundation,Baran Foundation,N,2013-11-06
+1788,SOS Information Juridique,SOS Information Juridique Multisectorielle,N,2013-11-06
+1789,Inner Wheel club Nijmegen,Inner Wheel club Nijmegen,C,2013-11-06
+1790,Stichting Saidia Helpt Su,Stichting Saidia Helpt Sumve,N,2013-11-06
+1791,Stichting Samenwerking Li,Stichting Samenwerking Lions Nederland-IndonesiÃ«,N,2013-11-06
+1792,Retrak,Retrak,N,2013-11-06
+1793,SPRODETA,SPRODETA,N,2013-11-06
+1794,UNICEF Malawi,UNICEF Malawi,G,2013-11-06
+1795,Stichting Samenwonen-Same,Stichting Samenwonen-Samenleven,N,2013-11-06
+1796,Un Techo Para Mi Pais,Un Techo Para Mi Pais,N,2013-11-06
+1797,EVE Organisation for Wome,EVE Organisation for Women Development,N,2013-11-06
+1798,PHB Development,PHB Development,C,2013-11-06
+1799,FUNDESER,FUNDESER,N,2013-11-06
+1800,University of Zimbabwe- C,University of Zimbabwe- CEPHI Overheads,K,2013-11-06
+1801,OpenOil,OpenOil,N,2013-11-06
+1802,Fondation Architectes de ,Fondation Architectes de L'Urgence,N,2013-11-06
+1803,Stichting St. GabriÃ«ls Ho,Stichting St. GabriÃ«ls Hospital Malawi,N,2013-11-06
+1804,CARE France,CARE France,N,2013-11-06
+1805,Dhaka Ashania Mission,Dhaka Ashania Mission,N,2013-11-06
+1806,AVSF,AVSF,N,2013-11-06
+1807,Foro Nacional por Colombi,Foro Nacional por Colombia,N,2013-11-06
+1808,Office f. the Coordinatio,Office f. the Coordination of Humanitarian Affairs,N,2013-11-06
+1809,Stichting De Elfde Vestig,Stichting De Elfde Vestiging,N,2013-11-06
+1810,Development Action for Ma,Development Action for Marginalised Rural Areas,N,2013-11-06
+1811,Dutch foundation(s),Dutch foundation(s),N,2013-11-06
+1812,UGEAFI,UGEAFI,N,2013-11-06
+1813,Wise Justice Fellow,Wise Justice Fellow,K,2013-11-06
+1814,Blue Square,Blue Square,C,2013-11-06
+1815,Green Soil Bag Company,Green Soil Bag Company,C,2013-11-06
+1816,HMB Profit Locks & Tools ,HMB Profit Locks & Tools en Relaties,C,2013-11-06
+1817,Caritas Developpement Gom,Caritas Developpement Goma,N,2013-11-06
+1819,Zorg en Zekerheid,Zorg en Zekerheid,C,2013-11-27
+1820,St. Georges Intl. School,St. Georges Intl. School,K,2013-12-17
+1821,ORFED,ORFED,N,2013-12-18
+1822,FootballPlus,Yayasan Sepakbola Plus Indonesia,N,2013-12-18
+1823,Susteq,Susteq,N,2013-12-18
+1824,ACF,Action Contre la Faim,N,2013-12-18
+1825,FAWEMA,Forum for African women educationalists in Malawi,N,2013-12-20
+1826,CBC Health Services,Cameroon Baptist Convention Health Services,N,2013-12-23
+1827,Rotary Club Ambt Almelo,"Rotary Club Ambt Almelo, district 1560",N,2014-01-06
+1828,DME,"Environment, Water, Climate and Energy Department ",G,2014-01-09
+1829,Healthy Vine,Stichting The Healthy Vine Trust,N,2014-01-10
+1830,SSG Foundation,Savitridevi Shivnarain Gupta Foundation,N,2014-01-10
+1831,NCS-SADCO,"Nekemte Catholic Secretariat, Social and Development Coordination Office",N,2014-01-17
+1832,FFU,Football Federation of Ukraine,N,2014-01-24
+1833,MYSU,Ministry of Youth and Sports of Ukraine,G,2014-01-24
+1834,UNOSDP,United Nations Office on Sport for Development and Peace,G,2014-01-24
+1835,Projekta,"Stichting Projekta, organization for women and development",N,2014-01-27
+1836,NYEWASCO,Nyeri Water and Sewerage Company,N,2014-01-27
+1837,Dhaka WASA,Dhaka Water Supply and Sewerage Authority,C,2014-01-28
+1838,Dutch Embassy Bangladesh,Dutch Embassy Bangladesh,G,2014-01-28
+1839,NAIVAWASS,Naivasha Water and Sanitation Company ,C,2014-01-28
+1841,DFID,Department for International Development UK,G,2014-01-28
+1842,Mombasa Water,Mombasa Water and Sewerage Company,C,2014-01-28
+1843,MDF Training&Consultancy,MDF Training&Consultancy,C,2014-01-28
+1844,SaafConsult,SaafConsult,C,2014-01-28
+1845,The Good Shepherd,The Good Shepherd Foundation,N,2014-01-28
+1846,WWF Netherlands,,N,2014-01-28
+1847,WS Noorderzijlvest,Waterschap Noorderzijlvest,G,2014-01-28
+1848,Credito con Educacion Rur,Credito con Educacion Rural CRECER,C,2014-01-28
+1849,DIO MZUZU,DIO MZUZU,C,2014-01-28
+1850,CBCP Caritas Filipinas Fo,CBCP Caritas Filipinas Foundation (NASSA),N,2014-01-28
+1852,ARCBLA,ARCBLA,N,2014-01-28
+1853,COPED,COPED,N,2014-01-28
+1855,SWAA-BURUNDI,SWAA-BURUNDI,N,2014-01-28
+1856,Diocese of Kabale,Diocese of Kabale,N,2014-01-28
+1857,Social Development Commit,Social Development Committee of Haifa (SDC),N,2014-01-28
+1858,Card Inc.,Card Inc.,N,2014-01-28
+1859,Theatre Day Productions,Theatre Day Productions,N,2014-01-28
+1860,VERC,VERC,N,2014-01-28
+1861,Palestinian Center for Pe,Palestinian Center for Peace and Democracy - PCPD,N,2014-01-28
+1862,Corporacion Sisma Mujer,Corporacion Sisma Mujer,N,2014-01-28
+1863,Social Action Center Lega,Social Action Center Legazpi (SAC),G,2014-01-28
+1864,Stg. IKV Pax Christi,Stg. IKV Pax Christi,N,2014-01-28
+1867,Palestinian Counseling Ce,Palestinian Counseling Center - PCC,N,2014-01-28
+1868,NCS- HD,NCS- HD,N,2014-01-28
+1869,MAAN Development Center,MAAN Development Center,N,2014-01-28
+1870,InReturn East Africa Fund,InReturn East Africa Fund 1,C,2014-01-28
+1872,CASHPOR,CASHPOR,N,2014-01-28
+1873,Aavishkaar India Micro Ve,Aavishkaar India Micro Venture Capital Fund,C,2014-01-28
+1874,Quy Tro Von Cho Nguoi Lao,Quy Tro Von Cho Nguoi Lao Dong Ngheo Tu TaoViecLam,C,2014-01-28
+1875,Corporacion para el Desar,Corporacion para el Desarrollo Humano (HUMANIZAR),N,2014-01-28
+1876,CorporaciÃ³n Espacios de M,CorporaciÃ³n Espacios de Mujer,N,2014-01-28
+1877,SAMHITA,SAMHITA,N,2014-01-28
+1878,Caritas Kotido,Caritas Kotido,N,2014-01-28
+1879,LAV,LAV,N,2014-01-28
+1880,JCI Nederland,JCI Nederland,N,2014-01-28
+1881,SHU,SHU,N,2014-01-28
+1882,COCOMACIA,COCOMACIA,N,2014-01-28
+1883,Trung tam Tu van Nguon lu,Trung tam Tu van Nguon luc Tai chinh vi mo Doanh n,N,2014-01-28
+1884,TANGRAM Zorgadviseurs,TANGRAM Zorgadviseurs,C,2014-01-28
+1886,MMFM,MMFM,G,2014-01-28
+1887,Rotaryclub Oosterbeek Kab,Rotaryclub Oosterbeek Kabeljauw,G,2014-01-28
+1888,Stichting Ortega,Stichting Ortega,N,2014-01-28
+1889,Lionsclub Roosendaal West,Lionsclub Roosendaal Westhoek,G,2014-01-28
+1890,Stichting Mode Met Een Mi,Stichting Mode Met Een Missie,G,2014-01-28
+1891,MELANIA,MELANIA,G,2014-01-28
+1892,ASK Training and Learning,ASK Training and Learning PVT LTD,N,2014-01-28
+1893,Stichting Vrienden van Ny,Stichting Vrienden van Nyakibale Hospital Oeganda,G,2014-01-28
+1894,Stichting Palestijnse Isl,Stichting Palestijnse Islamieten in Nederland,N,2014-01-28
+1895,ASKV Steunpunt Vluchtelin,ASKV Steunpunt Vluchtelingen,N,2014-01-28
+1896,CEDNA,CEDNA,G,2014-01-28
+1897,Caritas Archdiocese of Ju,Caritas Archdiocese of Juba,C,2014-01-28
+1898,Huys link community Initi,Huys link community Initiative,N,2014-01-28
+1899,Stichting Leergeld Apeldo,Stichting Leergeld Apeldoorn Voorst,N,2014-01-28
+1900,Stichting NiÃ±os de Guatem,Stichting NiÃ±os de Guatemala Nederland,G,2014-01-28
+1901,Stichting TitanE,Stichting TitanE,N,2014-01-28
+1902,Stichting Vilcabamba,Stichting Vilcabamba,G,2014-01-28
+1903,Stichting Goede Werken Gl,Stichting Goede Werken Glorieux,G,2014-01-28
+1904,Rotaryclub Scherpenzeel-W,Rotaryclub Scherpenzeel-Woudenberg,G,2014-01-28
+1905,IXQIK,IXQIK,N,2014-01-28
+1906,Afghan Midwives Associati,Afghan Midwives Association (AMA),N,2014-01-28
+1908,MicroSave Africa,MicroSave Africa,C,2014-01-28
+1909,Ministry for Foreign Affa,Ministry for Foreign Affairs,G,2014-01-28
+1910,Plan de DÃ©veloppement Int,Plan de DÃ©veloppement IntegrÃ© - PDI,N,2014-01-28
+1911,AfroEuro Foundation,AfroEuro Foundation,N,2014-01-28
+1912,Triple Jump Innovation Fu,Triple Jump Innovation Fund B.V.,N,2014-01-28
+1913,KAYAN,KAYAN,N,2014-01-28
+1914,The Rural Fund BV,The Rural Fund BV,C,2014-01-28
+1915,AsociaciÃ³n Mujer Tejedora,AsociaciÃ³n Mujer Tejedora del Desarrollo AMUTED,N,2014-01-28
+1916,Payment Planning Partner,Payment Planning Partner,N,2014-01-28
+1917,FOROLAC FR,FOROLAC FR,N,2014-01-28
+1918,Sphere India,Sphere India,N,2014-01-28
+1919,SME Impact Fund BV,SME Impact Fund BV,C,2014-01-28
+1920,ICJP,ICJP,N,2014-01-28
+1921,Stichting The True Vine,Stichting The True Vine,N,2014-01-28
+1922,Grameen Foundation,Grameen Foundation,N,2014-01-28
+1923,Asmaa Society for Develop,Asmaa Society for Development,N,2014-01-28
+1924,AFDOM,AFDOM,N,2014-01-28
+1925,Adva Center,Adva Center,N,2014-01-28
+1926,Belojosh Foundation,Belojosh Foundation,N,2014-01-28
+1927,Rotary Club Apeldoorn,Rotary Club Apeldoorn,N,2014-01-28
+1928,RSS-GAVI,RSS-GAVI,N,2014-01-28
+1929,CONAPAC,CONAPAC,N,2014-01-28
+1930,AsociaciÃ³n Sinergia No'j,AsociaciÃ³n Sinergia No'j,N,2014-01-28
+1931,ASADHO,ASADHO,N,2014-01-28
+1932,Association for Arab Yout,Association for Arab Youth - Baladna,N,2014-01-28
+1933,Action d'Espoir Cordaid,Action d'Espoir Cordaid,N,2014-01-28
+1936,WPP Stichting Women Peace,WPP Stichting Women Peacemakers Program,N,2014-01-28
+1937,South Sudan Red Cross,South Sudan Red Cross,N,2014-01-28
+1938,South Sudan Development A,South Sudan Development Agency (SSUDA),N,2014-01-28
+1939,Stichting Human Security ,Stichting Human Security Collective,N,2014-01-28
+1940,CISANET,CISANET,N,2014-01-28
+1941,SADAKA REUT  Arab Jewish ,SADAKA REUT  Arab Jewish Youth Partnership,N,2014-01-28
+1942,Progression Capital Afric,Progression Capital Africa,C,2014-01-28
+1943,Stichting Ghaned for Heat,Stichting Ghaned for Heatlh,N,2014-01-28
+1945,Caritas Manila,Caritas Manila,N,2014-01-28
+1946,FOPAKO,FOPAKO,N,2014-01-28
+1947,ODWaCE,ODWaCE,N,2014-01-28
+1948,JRS MENA,JRS MENA,N,2014-01-28
+1949,CooP-Africa,CooP-Africa,N,2014-01-28
+1951,Stichting Flor Ayuda,Stichting Flor Ayuda,N,2014-01-28
+1952,Asociacion Guatemalteca d,Asociacion Guatemalteca desarrollo Integral AGDI,N,2014-01-28
+1954,Brothers of Good Works,Brothers of Good Works,N,2014-01-28
+1955,OXUS RDC,OXUS RDC,C,2014-01-28
+1956,The Sudd Institute,The Sudd Institute,K,2014-01-28
+1957,UNYDA Upper Nile Youth De,UNYDA Upper Nile Youth Development Association,N,2014-01-28
+1958,Stichting SOKPO,Stichting SOKPO,N,2014-01-28
+1959,Groupe d'Acteurs de Micro,Groupe d'Acteurs de Microfinance du Kivu - GAMF,N,2014-01-28
+1960,Guichet d'Economie Locale,Guichet d'Economie Locale du Sud Kivu - GEL,N,2014-01-28
+1961,Caritas Syria,Caritas Syria,N,2014-01-28
+1962,ENVIU B.V.,ENVIU B.V.,N,2014-01-28
+1963,Youth on the Move,Youth on the Move,N,2014-01-28
+1964,CNAC Conf. Nat. Assoc. de,CNAC Conf. Nat. Assoc. des Cafeiculteurs du Burund,N,2014-01-28
+1965,Child Hope Restoration Mi,Child Hope Restoration Mission - CHORM,N,2014-01-28
+1966,Organization of Human Wel,Organization of Human Welfare - OHW,N,2014-01-28
+1967,Skills Training And Rehab,Skills Training And Rehabilitation Society STARS,N,2014-01-28
+1968,Org. f. Sustainable Integ,Org. f. Sustainable Integrated Development - OSID,N,2014-01-28
+1969,Twiga Ventures (U) Limite,Twiga Ventures (U) Limited,C,2014-01-28
+1970,the Culture and Free Thou,the Culture and Free Thought Association CFTA,N,2014-01-28
+1971,Euskal Fondoa,Euskal Fondoa,N,2014-01-28
+1973,Association DUSHIREHAMWE,Association DUSHIREHAMWE,N,2014-01-28
+1974,Stichting Favela Painting,Stichting Favela Painting,N,2014-01-28
+1975,WWF Zambia,WWF Zambia,N,2014-02-03
+1977,Dutch Foreign Affairs ICE,International Cultural Policy Unit of Dutch Ministry,G,2014-02-25
+1978,ABHC,Archdiocese of Blantyre Health Commission ,N,2014-02-26
+1979,Inowa Prima Consult,Inowa Prima Consult,N,2014-02-26
+1980,Sarakasi Trust,Sarakasi Trust,N,2014-03-03
+1981,Kuona Trust,Kuona Trust Centre for Visual Arts,N,2014-03-05
+1982,Blue Planet Network,Blue Planet Network,N,2014-03-05
+1983,Lifeline,International Lifeline Fund,N,2014-03-05
+1984,Africa AHEAD,Africa Applied Health Education and Development,N,2014-03-05
+1985,Stedenband Dordt-Bamenda,Stichting stedenband Dordrecht-Bamenda,N,2014-03-05
+1986,IAP,Instituto de Arqueologia e PaleociÃªncias da Universidade Nova de Lisboa,K,2014-03-10
+1988,MR&C,Maritime Research & Consultancy (MR&C),K,2014-03-10
+1989,Texas A&M University,Texas A&M University,K,2014-03-10
+1990,PAWA 254,PAWA 254 Arts and Culture Center,N,2014-03-12
+1990,PAWA 254,PAWA 254 Arts and Culture Center,N,2014-03-12
+1991,Dutch Embassy Suriname,Embassy of the Kingdom of the Netherlands in Paramaribo,G,2014-03-14
+1991,Dutch Embassy Suriname,Embassy of the Kingdom of the Netherlands in Paramaribo,G,2014-03-14
+1992,Kibii Foundation,Kibii Foundation,N,2014-03-14
+1992,Kibii Foundation,Kibii Foundation,N,2014-03-14
+1993,Grand Challenges Canada ,Grand Challenges Canada ,G,2014-03-17
+1993,Grand Challenges Canada ,Grand Challenges Canada ,G,2014-03-17
+1994,SNV Mali,,N,2014-03-17
+1994,SNV Mali,,N,2014-03-17
+1995,CEEA,Conseil Eau et Environnement Assistance,C,2014-03-17
+1995,CEEA,Conseil Eau et Environnement Assistance,C,2014-03-17
+1996,Villa Zapakara Foundation,Villa Zapakara Foundation,N,2014-03-18
+1996,Villa Zapakara Foundation,Villa Zapakara Foundation,N,2014-03-18
+1997,ETKF,Empower Together Kenya Foundation,N,2014-03-20
+1997,ETKF,Empower Together Kenya Foundation,N,2014-03-20
+1998,UNICEF Mali,,N,2014-03-20
+1998,UNICEF Mali,,N,2014-03-20
+1999,Dutch Embassy S-A,Dutch Embassy South Africa,G,2014-03-25
+1999,Dutch Embassy S-A,Dutch Embassy South Africa,G,2014-03-25
+2000,Twist,Twist Theatre Development Projects,N,2014-03-25
+2000,Twist,Twist Theatre Development Projects,N,2014-03-25
+2001,ISS Catering,ISS Catering,C,2014-03-25
+2001,ISS Catering,ISS Catering,C,2014-03-25
+2002,Vrienden van Proven,Vrienden van Proven,N,2014-03-28
+2002,Vrienden van Proven,Vrienden van Proven,N,2014-03-28
+2004,Waterschap Zuiderzeeland,Waterschap Zuiderzeeland,G,2014-04-03
+2004,Waterschap Zuiderzeeland,Waterschap Zuiderzeeland,G,2014-04-03
+2005,OWMEB,Oromia Water Mineral and Energy Bureau,G,2014-04-03
+2005,OWMEB,Oromia Water Mineral and Energy Bureau,G,2014-04-03
+2006,Waterschap Vallei & Eem,Waterschap Vallei & Eem,G,2014-04-03
+2006,Waterschap Vallei & Eem,Waterschap Vallei & Eem,G,2014-04-03
+2007,ASTU,Adama Science and Technology University,K,2014-04-03
+2007,ASTU,Adama Science and Technology University,K,2014-04-03
+2008,BTWSSSE,Bishoftu Urban (Town) Water Supply and Sewerage Service Enterprise,G,2014-04-03
+2008,BTWSSSE,Bishoftu Urban (Town) Water Supply and Sewerage Service Enterprise,G,2014-04-03
+2009,WEB,Water- en Energiebedrijf Bonaire N.V.,G,2014-04-03
+2009,WEB,Water- en Energiebedrijf Bonaire N.V.,G,2014-04-03
+2010,Al-Ma'mal Foundation,Al-Ma'mal Foundation for Contemporary Art,N,2014-04-09
+2010,Al-Ma'mal Foundation,Al-Ma'mal Foundation for Contemporary Art,N,2014-04-09
+2011,Van Abbemuseum,Van Abbemuseum,G,2014-04-09
+2011,Van Abbemuseum,Van Abbemuseum,G,2014-04-09
+2012,Acte SEPT Bamako,Acte SEPT Bamako,N,2014-04-15
+2012,Acte SEPT Bamako,Acte SEPT Bamako,N,2014-04-15
+2013,EFES Association,EFES Association,N,2014-04-15
+2013,EFES Association,EFES Association,N,2014-04-15
+2014,Dutch Embassy Mali,Dutch Embassy Mali,G,2014-04-15
+2014,Dutch Embassy Mali,Dutch Embassy Mali,G,2014-04-15
+2015,Essakane Production,Essakane Production,N,2014-04-15
+2015,Essakane Production,Essakane Production,N,2014-04-15
+2016,Vatikan Turkiye Buyukelci,Vatikan Turkiye Buyukelciligi Caritas Unitesi,N,2014-04-28
+2017,Bataris Formation Center,Bataris Formation Center,N,2014-04-28
+2018,CETEC,CETEC,N,2014-04-28
+2019,GGEM Micro Finance Servic,GGEM Micro Finance Services Limited,C,2014-04-28
+2020,CONCIUDADANIA,CONCIUDADANIA,N,2014-04-28
+2021,Mary Joy Development Asso,Mary Joy Development Association - MJATD,N,2014-04-28
+2022,Cadecom,Cadecom,C,2014-04-28
+2023,CECA,CECA,N,2014-04-28
+2025,ASK Traing and Learning P,ASK Traing and Learning Pvt Ltd,N,2014-04-28
+2026,Center for International ,Center for International Forestry Research CIFOR,K,2014-04-28
+2027,ECAP,ECAP,N,2014-04-28
+2028,CEMIRIDE PROJECT,CEMIRIDE PROJECT,N,2014-04-28
+2029,Cordaid Kenya D. Risk Red,Cordaid Kenya D. Risk Reduction Program,N,2014-04-28
+2031,EKHC,EKHC,N,2014-04-28
+2032,Yayasan Pusaka Indonesia,Yayasan Pusaka Indonesia,N,2014-04-28
+2033,MADA al-Carmel,MADA al-Carmel,K,2014-04-28
+2034,CEHRD,CEHRD,N,2014-04-28
+2035,Nekemte Catholic Secretar,Nekemte Catholic Secretariat,G,2014-04-28
+2036,Cordaid K&E,Cordaid K&E,N,2014-04-28
+2037,Stichting Schoolproject E,Stichting Schoolproject EthiopiÃ«,G,2014-04-28
+2038,Stichting Geron,Stichting Geron,N,2014-04-28
+2039,Stichting Mitra,Stichting Mitra,G,2014-04-28
+2040,Christian Aid Income Acco,Christian Aid Income Account,N,2014-04-28
+2042,St. Ecologische Landbouw ,St. Ecologische Landbouw Projecten Ghana ELPG,N,2014-04-28
+2043,Stichting SchoolSupport4A,Stichting SchoolSupport4Afghanistan (S4A),N,2014-04-28
+2044,Dalia Association Palesti,Dalia Association Palestine,N,2014-04-28
+2045,Stichting NamastÃ© India,Stichting NamastÃ© India,N,2014-04-28
+2046,Jabalpur Diocese Social S,Jabalpur Diocese Social Service Society (JDSSS),N,2014-04-28
+2047,CIDSE,CIDSE,G,2014-04-28
+2048,Swadhikar,Swadhikar,N,2014-04-28
+2049,Horn of Africa Developmen,Horn of Africa Development Initiative - HODI,N,2014-04-28
+2050,AMFIU,AMFIU,N,2014-04-28
+2051,Stichting Ghana Haarlem,Stichting Ghana Haarlem,N,2014-04-28
+2052,Convergemujeres,Convergemujeres,N,2014-04-28
+2053,Wholesale Microfinance Fa,Wholesale Microfinance Facility (Limited) Ghana,C,2014-04-28
+2054,Association for Rural and,Association for Rural and Urban Needy,N,2014-04-28
+2055,Ecological Christian Orga,Ecological Christian Organisation - ECO - Uganda,N,2014-04-28
+2056,Israel Social TV (ISTV),Israel Social TV (ISTV),N,2014-04-28
+2057,Isha L'Isha Haifa Feminis,Isha L'Isha Haifa Feminist Center,N,2014-04-28
+2058,Stichting Care Karnataka,Stichting Care Karnataka,N,2014-04-28
+2059,SURABI,SURABI,N,2014-04-28
+2060,Yayasan Trapesia,Yayasan Trapesia,N,2014-04-28
+2061,Rural Action Against Hung,Rural Action Against Hunger (RAAH),N,2014-04-28
+2062,ProPortion Foundation,ProPortion Foundation,C,2014-04-28
+2063,Odisha Forum for Social A,Odisha Forum for Social Action - OROSA,N,2014-04-28
+2064,Stichting Dag van Respect,Stichting Dag van Respect,N,2014-04-28
+2065,FairPen Foundation,FairPen Foundation,N,2014-04-28
+2066,VSF - Belgium,VSF - Belgium,N,2014-04-28
+2067,Rural Missionaires of the,Rural Missionaires of the Philippines,N,2014-04-28
+2068,SIDA,SIDA,G,2014-04-28
+2069,NIMD,NIMD,G,2014-04-28
+2070,Khilesh Chaturvedi,Khilesh Chaturvedi,C,2014-04-28
+2071,Adventist Health Services,Adventist Health Services,C,2014-04-28
+2072,Ethiopian Evangelical Chu,Ethiopian Evangelical Church Mekane Yesus,N,2014-04-28
+2073,Rumphi Hospital,Rumphi Hospital,G,2014-04-28
+2074,Caritas member(s),Caritas member(s),N,2014-04-28
+2075,Environmental Health and ,Environmental Health and Safety Network  - EHSNET,N,2014-04-28
+2077,UNICEF RCA,UNICEF RCA,N,2014-04-28
+2078,RTENN Petroleum,RTENN Petroleum,N,2014-04-28
+2079,Leadership Initiative for,Leadership Initiative for Transformation & Empower,N,2014-04-28
+2080,UNIDO,UNIDO,N,2014-04-28
+2081,SIDREH,SIDREH,N,2014-04-28
+2082,Stichting EFIM Foundation,Stichting EFIM Foundation,N,2014-04-28
+2083,Arthacharya/Arthavida,Arthacharya/Arthavida,N,2014-04-28
+2084,Waterschap Hollandse Delt,Waterschap Hollandse Delta,N,2014-04-28
+2085,Stichting Partnership Fou,Stichting Partnership Foundation,N,2014-04-28
+2086,TVET,TVET,G,2014-04-28
+2087,MHDR,MHDR,N,2014-04-28
+2088,Stichting Byounique,Stichting Byounique,N,2014-04-28
+2089,Byounique Trust Malawi,Byounique Trust Malawi,N,2014-04-28
+2090,Isis-Women's Internationa,Isis-Women's International Cross Cultural Exchange,N,2014-04-28
+2092,Anton Jurgens Fonds,Anton Jurgens Fonds,N,2014-04-28
+2094,John D. and Catherine T. ,John D. and Catherine T. MacArthur Foundation,N,2014-04-28
+2095,Swiss Agency for Developm,Swiss Agency for Development and Cooperation(SDC),G,2014-04-28
+2096,Ambassade de France Ã  La ,Ambassade de France Ã  La Haye,G,2014-04-28
+2097,Department for Internatio,Department for International Development  (DFID),G,2014-04-28
+2098,St. Maryâ€™s Health Centre,St. Maryâ€™s Health Centre,N,2014-04-28
+2099,The Tiruchy Don Bosco Soc,The Tiruchy Don Bosco Society,N,2014-04-28
+2100,Forwardzone,Forwardzone,C,2014-04-29
+2100,Forwardzone,Forwardzone,C,2014-04-29
+2101,SPACE Bangladesh,Society for Peopleâ€™s Actions in Change and Equity Bangladesh,N,2014-05-01
+2101,SPACE Bangladesh,Society for Peopleâ€™s Actions in Change and Equity Bangladesh,N,2014-05-01
+2102,ADRA Vanuatu,Adventist Development and Relief Agency Vanuatu,N,2014-05-05
+2102,ADRA Vanuatu,Adventist Development and Relief Agency Vanuatu,N,2014-05-05
+2103,UNICEF Pacific,United Nations Childrenâ€™s Fund - Office for Pacific Island Countries,K,2014-05-08
+2103,UNICEF Pacific,United Nations Childrenâ€™s Fund - Office for Pacific Island Countries,K,2014-05-08
+2104,Gemeente Gorinchem,Gemeente Gorinchem,G,2014-05-13
+2104,Gemeente Gorinchem,Gemeente Gorinchem,G,2014-05-13
+2105,NEARCH,New scenarios for a community-involved archaeology,K,2014-05-19
+2105,NEARCH,New scenarios for a community-involved archaeology,K,2014-05-19
+2106,DFAT,Australian Government Foreign affairs and trade,G,2014-05-20
+2106,DFAT,Australian Government Foreign affairs and trade,G,2014-05-20
+2107,ADRA Australia,The Adventist Development and Relief Agency,N,2014-05-20
+2107,ADRA Australia,The Adventist Development and Relief Agency,N,2014-05-20
+2108,ADRA New Zealand,The Adventist Development and Relief Agency (ADRA),N,2014-05-20
+2108,ADRA New Zealand,The Adventist Development and Relief Agency (ADRA),N,2014-05-20
+2109,MFAT, New Zealand Ministry of Foreign Affairs and Trade,G,2014-05-20
+2109,MFAT, New Zealand Ministry of Foreign Affairs and Trade,G,2014-05-20
+2110,Zim Zam B.V.,Zim Zam B.V.,C,2014-05-22
+2110,Zim Zam B.V.,Zim Zam B.V.,C,2014-05-22
+2111,IFC,International Finance Cooporation,N,2014-05-22
+2111,IFC,International Finance Cooporation,N,2014-05-22
+2112,IDA,International Developmnet Association,N,2014-05-22
+2112,IDA,International Developmnet Association,N,2014-05-22
+2113,IDA,International Developmnet Association,N,2014-05-22
+2113,IDA,International Developmnet Association,N,2014-05-22
+2115,TI-Kenya,TRANSPARENCY INTERNATIONAL - KENYA,N,2014-05-22
+2115,TI-Kenya,TRANSPARENCY INTERNATIONAL - KENYA,N,2014-05-22
+2116,AWF,African Wildlife Foundation,N,2014-05-22
+2116,AWF,African Wildlife Foundation,N,2014-05-22
+2117,IBRD,International Bank for Reconstruction and Development,C,2014-05-22
+2117,IBRD,International Bank for Reconstruction and Development,C,2014-05-22
+2118,MIGA,Multilateral Investment Guarantee Agency,C,2014-05-22
+2118,MIGA,Multilateral Investment Guarantee Agency,C,2014-05-22
+2119,AIM,Amsterdam Initiative against Malnutrition,N,2014-05-23
+2119,AIM,Amsterdam Initiative against Malnutrition,N,2014-05-23
+2120,Festival sur le Niger,Fondation Festival sur le Niger,N,2014-05-27
+2120,Festival sur le Niger,Fondation Festival sur le Niger,N,2014-05-27
+2121,GNWP,Ghana Netherlands WASH Programme,C,2014-05-28
+2121,GNWP,Ghana Netherlands WASH Programme,C,2014-05-28
+2122,UASD,UnitÃ© d'archÃ©ologie de la ville de Saint-Denis,K,2014-05-28
+2122,UASD,UnitÃ© d'archÃ©ologie de la ville de Saint-Denis,K,2014-05-28
+2123,CHS/UGOT,Department of Historical Studies - University of Gothenburg,K,2014-05-28
+2123,CHS/UGOT,Department of Historical Studies - University of Gothenburg,K,2014-05-28
+2124,104,Le CENTQUATRE-PARIS,K,2014-05-28
+2124,104,Le CENTQUATRE-PARIS,K,2014-05-28
+2125,Archaeology Data Service,The Archaeology Data Service,K,2014-05-28
+2125,Archaeology Data Service,The Archaeology Data Service,K,2014-05-28
+2126,AMU,Instytut Prahistorii - Uniwersytet im. Adama Mickiewicza w Poznaniu,K,2014-05-28
+2126,AMU,Instytut Prahistorii - Uniwersytet im. Adama Mickiewicza w Poznaniu,K,2014-05-28
+2127,AUth,The Department of Archaeology - Aristotle University of Thessaloniki ,K,2014-05-28
+2127,AUth,The Department of Archaeology - Aristotle University of Thessaloniki ,K,2014-05-28
+2128,Culture Lab,Culture Lab,C,2014-05-28
+2128,Culture Lab,Culture Lab,C,2014-05-28
+2129,DAI,Deutsches ArchÃ¤ologisches Institut,K,2014-05-28
+2129,DAI,Deutsches ArchÃ¤ologisches Institut,K,2014-05-28
+2130,IBC,"Istituto per i beni artistici, culturali, naturali della regione Emilia-Rom",G,2014-05-28
+2130,IBC,"Istituto per i beni artistici, culturali, naturali della regione Emilia-Rom",G,2014-05-28
+2131,Incipit - CSIC,Instituto de Ciencias del Patrimonio,K,2014-05-28
+2131,Incipit - CSIC,Instituto de Ciencias del Patrimonio,K,2014-05-28
+2132,Inrap,Institut national de recherches archÃ©ologiques prÃ©ventives,K,2014-05-28
+2132,Inrap,Institut national de recherches archÃ©ologiques prÃ©ventives,K,2014-05-28
+2133,Jan van Eyck academie,Jan van Eyck academie,K,2014-05-28
+2133,Jan van Eyck academie,Jan van Eyck academie,K,2014-05-28
+2134,GNWP / TA,Ghana Netherlands WASH Programme,C,2014-06-02
+2134,GNWP / TA,Ghana Netherlands WASH Programme,C,2014-06-02
+2135,CIE,Center for International Heritage Activities,K,2014-06-03
+2135,CIE,Center for International Heritage Activities,K,2014-06-03
+2136,Aquaquest,Aquaquest,C,2014-06-11
+2136,Aquaquest,Aquaquest,C,2014-06-11
+2137,ARCADIS,ARCADIS,C,2014-06-11
+2137,ARCADIS,ARCADIS,C,2014-06-11
+2138,We Consult Mozambique,We Consult Mozambique,C,2014-06-11
+2138,We Consult Mozambique,We Consult Mozambique,C,2014-06-11
+2139,Solidaridad,Solidaridad,N,2014-06-11
+2139,Solidaridad,Solidaridad,N,2014-06-11
+2140,Universiteit Twente - ITC,Universiteit Twente - ITC,K,2014-06-11
+2140,Universiteit Twente - ITC,Universiteit Twente - ITC,K,2014-06-11
+2141,Adolfo Miguel Martins,Adolfo Miguel Borges Pinheiro da Silveira Martins,K,2014-06-16
+2141,Adolfo Miguel Martins,Adolfo Miguel Borges Pinheiro da Silveira Martins,K,2014-06-16
+2142,UOFX,Institute of Archaeology - University of Oxford,K,2014-06-16
+2142,UOFX,Institute of Archaeology - University of Oxford,K,2014-06-16
+2143,Stichting Chance to Dance,Chance to Dance,N,2014-06-30
+2143,Stichting Chance to Dance,Chance to Dance,N,2014-06-30
+2144,Dutch Embassy Indonesia,"Embassy of the Kingdom of the Netherlands in Jakarta, Indonesia",G,2014-06-30
+2144,Dutch Embassy Indonesia,"Embassy of the Kingdom of the Netherlands in Jakarta, Indonesia",G,2014-06-30
+2145,SCEZ,Stichting Cultureel Erfgoed Zeeland,G,2014-07-01
+2145,SCEZ,Stichting Cultureel Erfgoed Zeeland,G,2014-07-01
+2146,Dutch Embassy Egypt,"Embassy of the Kingdom of the Netherlands in Cairo, Egypt",G,2014-07-01
+2146,Dutch Embassy Egypt,"Embassy of the Kingdom of the Netherlands in Cairo, Egypt",G,2014-07-01
+2147,Cimatheque,Cimatheque - Alternative Film Centre,C,2014-07-01
+2147,Cimatheque,Cimatheque - Alternative Film Centre,C,2014-07-01
+2148,Nat. Museum Afghanistan,National Museum of Afghanistan,G,2014-07-01
+2148,Nat. Museum Afghanistan,National Museum of Afghanistan,G,2014-07-01
+2149,Townhouse Gallery,Townhouse Gallery,K,2014-07-01
+2149,Townhouse Gallery,Townhouse Gallery,K,2014-07-01
+2150,WvW 2015,Wandelen voor Water 2015,N,2014-07-07
+2150,WvW 2015,Wandelen voor Water 2015,N,2014-07-07
+2151,Walking for Water 2015,Walking for Water International 2015,N,2014-07-07
+2151,Walking for Water 2015,Walking for Water International 2015,N,2014-07-07
+2152,TFK,Interprofession Table FiliÃ¨re KaritÃ© ,N,2014-07-14
+2152,TFK,Interprofession Table FiliÃ¨re KaritÃ© ,N,2014-07-14
+2153,GPN,Geo Professionals Nederland,C,2014-07-15
+2153,GPN,Geo Professionals Nederland,C,2014-07-15
+2154,Mergor in Mosam,Mergor in Mosam,K,2014-07-15
+2154,Mergor in Mosam,Mergor in Mosam,K,2014-07-15
+2155,WIMA-AWN,Werkgroep Archeologische Meettechnieken voor Archeologie,K,2014-07-15
+2155,WIMA-AWN,Werkgroep Archeologische Meettechnieken voor Archeologie,K,2014-07-15
+2156,Welthungerhilfe,Welthungerhilfe,N,2014-07-18
+2156,Welthungerhilfe,Welthungerhilfe,N,2014-07-18
+2157,HELVETAS Nepal,HELVETAS Nepal,N,2014-07-21
+2157,HELVETAS Nepal,HELVETAS Nepal,N,2014-07-21
+2158,Intercooperation Pakistan,Intercooperation Pakistan,N,2014-07-21
+2158,Intercooperation Pakistan,Intercooperation Pakistan,N,2014-07-21
+2159,Asasah,Asasah,N,2014-07-21
+2159,Asasah,Asasah,N,2014-07-21
+2160,Nirdhan Utthan Bank Ltd,Nirdhan Utthan Bank Limited,C,2014-07-21
+2160,Nirdhan Utthan Bank Ltd,Nirdhan Utthan Bank Limited,C,2014-07-21
+2161,ACP EU Water Facility,"African,Caribbean & Pacific Group of States - European Union Water Facility",G,2014-07-21
+2161,ACP EU Water Facility,"African,Caribbean & Pacific Group of States - European Union Water Facility",G,2014-07-21
+2162,APWO,Association of Private Water Operators,C,2014-07-21
+2162,APWO,Association of Private Water Operators,C,2014-07-21
+2163,MWE, Ministry of Water and Environment Uganda,G,2014-07-21
+2163,MWE, Ministry of Water and Environment Uganda,G,2014-07-21
+2164,nUws,nUws,N,2014-07-21
+2164,nUws,nUws,N,2014-07-21
+2165,WSDF-N,Water and Sanitation Development Facility,G,2014-07-21
+2165,WSDF-N,Water and Sanitation Development Facility,G,2014-07-21
+2166,WWF Indonesia,WWF Indonesia,N,2014-07-24
+2166,WWF Indonesia,WWF Indonesia,N,2014-07-24
+2167,ICMC ZWITSERLAND,ICMC ZWITSERLAND,N,2014-07-24
+2168,ASEDE,ASEDE,N,2014-07-24
+2169,Stichting Oikos,Stichting Oikos,N,2014-07-24
+2170,CTF,CTF,N,2014-07-24
+2171,FONDESURCO,FONDESURCO,N,2014-07-24
+2172,Merti Integrated Developm,Merti Integrated Development Programme (MIDP),N,2014-07-24
+2173,Blind People's Associatio,Blind People's Association of India BPA,N,2014-07-24
+2174,ADPC,ADPC,K,2014-07-24
+2175,CARITAS SRBIJE I CRNE GOR,CARITAS SRBIJE I CRNE GORRE,N,2014-07-24
+2176,St. Geef de kinderen van ,St. Geef de kinderen van Mpongwe een toekomst,N,2014-07-24
+2177,Stichting Shared Vision,Stichting Shared Vision,N,2014-07-24
+2178,Cordaid Sector Programma ,Cordaid Sector Programma NL,N,2014-07-24
+2179,Foundation Give the child,Foundation Give the children of Mpongwe a future,N,2014-07-24
+2180,Ayani BV,Ayani BV,N,2014-07-24
+2181,Luxembourg,Luxembourg,N,2014-07-24
+2182,CIFA Ethiopia,CIFA Ethiopia,N,2014-07-24
+2183,Undugu Vriendenkring Nede,Undugu Vriendenkring Nederland,N,2014-07-24
+2184,Astrid Uganda Foundation,Astrid Uganda Foundation,N,2014-07-24
+2185,SSS - Cordaid Scholarschi,SSS - Cordaid Scholarschip,N,2014-07-24
+2186,Acoke Rural Development I,Acoke Rural Development Initiatives,N,2014-07-24
+2187,Dire Dawa Astedader Mahib,Dire Dawa Astedader Mahiberesebe Mere Ye-Adega sig,N,2014-07-24
+2188,World Hope International,World Hope International,N,2014-07-24
+2189,Shared Vision Foundation,Shared Vision Foundation,N,2014-07-24
+2190,Synergie des Femmes SPR,Synergie des Femmes SPR,N,2014-07-24
+2191,PREGESCO,PREGESCO,N,2014-07-24
+2192,Agentschap NL,Agentschap NL,G,2014-07-24
+2193,Affordable Housing Insitu,Affordable Housing Insitute,N,2014-07-24
+2194,Stichting Microjustice4Al,Stichting Microjustice4All,N,2014-07-24
+2195,Microjusticia Bolivia,Microjusticia Bolivia,N,2014-07-24
+2196,Fundacion Paz-Holandesa,Fundacion Paz-Holandesa,N,2014-07-24
+2197,Asociacion PAZ-Holandesa,Asociacion PAZ-Holandesa,N,2014-07-24
+2198,Yayasan Bina Tani Sejahte,Yayasan Bina Tani Sejahtera,N,2014-07-24
+2199,Informal South Pty Ltd,Informal South Pty Ltd,C,2014-07-24
+2200,Musoni,Musoni,C,2014-07-24
+2201,Stichting Dokter Harrie v,Stichting Dokter Harrie van den Brekel,N,2014-07-24
+2202,Children's Fund of Malawi,Children's Fund of Malawi,N,2014-07-24
+2203,USAID,USAID,N,2014-07-24
+2204,Health Poverty Action,Health Poverty Action,N,2014-07-24
+2205,Caritas Senegal,Caritas Senegal,N,2014-07-24
+2206,Caritas Tajikistan,Caritas Tajikistan,N,2014-07-24
+2207,Christian Community Devel,Christian Community Development Programme (CCDP),N,2014-07-24
+2208,Caritas Bishop's Conferen,Caritas Bishop's Conference Bosnia and Herzegovina,N,2014-07-24
+2209,HELP Business Development,HELP Business Development and Advisory Services,N,2014-07-24
+2210,The Centre for Alternativ,The Centre for Alternative Dispute Resolution CADR,N,2014-07-24
+2211,Stichting Bisschoppelijke,Stichting Bisschoppelijke Vastenaktie Nederland,N,2014-07-24
+2212,Cardno Emerging Markets,Cardno Emerging Markets (Australia) Pty Ltd. ,C,2014-07-24
+2212,Cardno Emerging Markets,Cardno Emerging Markets (Australia) Pty Ltd. ,C,2014-07-24
+2213,FXB-India Suraksha,FXB-India Suraksha,N,2014-07-24
+2213,FXB-India Suraksha,FXB-India Suraksha,N,2014-07-24
+2214,St. Iberius N. S.,St. Iberius National School,K,2014-08-01
+2214,St. Iberius N. S.,St. Iberius National School,K,2014-08-01
+2216,PRA Bangladesh,PRA Promoting Society â€“ Bangladesh,N,2014-08-01
+2216,PRA Bangladesh,PRA Promoting Society â€“ Bangladesh,N,2014-08-01
+2217,Stichting Batashi,Stichting Batashi,N,2014-08-01
+2217,Stichting Batashi,Stichting Batashi,N,2014-08-01
+2218,SNV Burkina Faso,SNV Burkina Faso,N,2014-08-05
+2218,SNV Burkina Faso,SNV Burkina Faso,N,2014-08-05
+2219,SEIU Nepal,Sector Efficiency Improvement Unit ,G,2014-08-11
+2219,SEIU Nepal,Sector Efficiency Improvement Unit ,G,2014-08-11
+2220,Rotary District 1570,Rotary District 1570,N,2014-08-12
+2220,Rotary District 1570,Rotary District 1570,N,2014-08-12
+2221,Van Heck Group,Van Heck Group,C,2014-08-13
+2221,Van Heck Group,Van Heck Group,C,2014-08-13
+2222,SNV Zambia,,N,2014-08-13
+2222,SNV Zambia,,N,2014-08-13
+2223,UNICEF Ethiopia,,N,2014-08-14
+2223,UNICEF Ethiopia,,N,2014-08-14
+2224,Stichting KEK,Stichting Kinderen een Kans!,N,2014-08-14
+2224,Stichting KEK,Stichting Kinderen een Kans!,N,2014-08-14
+2225,GAIN,Global Alliance for Improved Nutrition,N,2014-08-15
+2225,GAIN,Global Alliance for Improved Nutrition,N,2014-08-15
+2226,Bless AgriFood Laboratory,Bless Agri Food Laboratory Services PLC,C,2014-08-15
+2226,Bless AgriFood Laboratory,Bless Agri Food Laboratory Services PLC,C,2014-08-15
+2227,Rijk Zwaan,Rijk Zwaan,C,2014-08-15
+2227,Rijk Zwaan,Rijk Zwaan,C,2014-08-15
+2228,Faida MaLi,Faida MaLi,C,2014-08-15
+2228,Faida MaLi,Faida MaLi,C,2014-08-15
+2229,DSM,Royal DSM,C,2014-08-15
+2229,DSM,Royal DSM,C,2014-08-15
+2230,PHSL,Phillips Healthcare Services Ltd,C,2014-08-15
+2230,PHSL,Phillips Healthcare Services Ltd,C,2014-08-15
+2231,Kinangop Dairy Ltd,Kinangop Dairy Ltd,C,2014-08-15
+2231,Kinangop Dairy Ltd,Kinangop Dairy Ltd,C,2014-08-15
+2232,SPAR International,SPAR International,C,2014-08-15
+2232,SPAR International,SPAR International,C,2014-08-15
+2233,AkzoNobel,AkzoNobel,C,2014-08-15
+2233,AkzoNobel,AkzoNobel,C,2014-08-15
+2234,Intertek,Intertek,C,2014-08-15
+2234,Intertek,Intertek,C,2014-08-15
+2235,UK FCO,Foreign and Commonwealth Office of the United Kingdom,G,2014-08-21
+2235,UK FCO,Foreign and Commonwealth Office of the United Kingdom,G,2014-08-21
+2236,First Climate,First Climate Markets AG,C,2014-08-26
+2236,First Climate,First Climate Markets AG,C,2014-08-26
+2237,AgSri,AgSri Agricultural Services Private Limited,C,2014-08-26
+2237,AgSri,AgSri Agricultural Services Private Limited,C,2014-08-26
+2238,PIND Foundation,Foundation for Partnership Initiatives in the Niger Delta,N,2014-08-27
+2238,PIND Foundation,Foundation for Partnership Initiatives in the Niger Delta,N,2014-08-27
+2240,Sal Consult,Sal Consult,C,2014-09-01
+2240,Sal Consult,Sal Consult,C,2014-09-01
+2241,MIGA Bolivia,Movimiento de IntegraciÃ³n GastronÃ³mico Boliviano ,N,2014-09-01
+2241,MIGA Bolivia,Movimiento de IntegraciÃ³n GastronÃ³mico Boliviano ,N,2014-09-01
+2242,The GoodWater Company,GoodWater,C,2014-09-02
+2242,The GoodWater Company,GoodWater,C,2014-09-02
+2243,MIDM,Moving Into Dance Mophatong,N,2014-09-03
+2243,MIDM,Moving Into Dance Mophatong,N,2014-09-03
+2244,ISH/ Stichting Balls,ISH/ Stichting Balls,N,2014-09-03
+2244,ISH/ Stichting Balls,ISH/ Stichting Balls,N,2014-09-03
+2245,Jacana Media,Jacana Media,C,2014-09-03
+2245,Jacana Media,Jacana Media,C,2014-09-03
+2246,Big Entertainment,Big Entertainment,C,2014-09-03
+2246,Big Entertainment,Big Entertainment,C,2014-09-03
+2247,Erasmus Huis,Erasmus Huis Culture Centre,G,2014-09-03
+2247,Erasmus Huis,Erasmus Huis Culture Centre,G,2014-09-03
+2248,Zimmerman & Zimmerman,,C,2014-09-05
+2248,Zimmerman & Zimmerman,,C,2014-09-05
+2249,Public Works Liberia,Ministry of Public Works Liberia,G,2014-09-05
+2249,Public Works Liberia,Ministry of Public Works Liberia,G,2014-09-05
+2250,Red Cross NL,,N,2014-09-05
+2250,Red Cross NL,,N,2014-09-05
+2251,Ecorys ,,C,2014-09-05
+2251,Ecorys ,,C,2014-09-05
+2252,UNDP Uzbekistan,United Nations Development Programme in Uzbekistan,G,2014-09-05
+2252,UNDP Uzbekistan,United Nations Development Programme in Uzbekistan,G,2014-09-05
+2253,Government of Uzbekistan,The Cabinet of Ministers of the Republic of Uzbekistan,G,2014-09-05
+2253,Government of Uzbekistan,The Cabinet of Ministers of the Republic of Uzbekistan,G,2014-09-05
+2254,LSM Rumah Impian,LSM Rumah Impian (Dream House),N,2014-09-12
+2254,LSM Rumah Impian,LSM Rumah Impian (Dream House),N,2014-09-12
+2255,Anak Wayang Indonesia,Anak Wayang Indonesia (AWI),N,2014-09-12
+2255,Anak Wayang Indonesia,Anak Wayang Indonesia (AWI),N,2014-09-12
+2256,PARFUND,PARFUND,N,2014-09-12
+2256,PARFUND,PARFUND,N,2014-09-12
+2257,One dollar for music,One dollar for music,N,2014-09-12
+2257,One dollar for music,One dollar for music,N,2014-09-12
+2258,Setara,Yayasan Setara,N,2014-09-12
+2258,Setara,Yayasan Setara,N,2014-09-12
+2259,EKI Dance,Eksotika Karmawhibhangga,N,2014-09-15
+2259,EKI Dance,Eksotika Karmawhibhangga,N,2014-09-15
+2260,Busia County Government,,G,2014-09-15
+2260,Busia County Government,,G,2014-09-15
+2261,Kitui County Government,,G,2014-09-15
+2261,Kitui County Government,,G,2014-09-15
+2262,Kisumu County Government,,G,2014-09-15
+2262,Kisumu County Government,,G,2014-09-15
+2263,Kajiado County Government,,G,2014-09-15
+2263,Kajiado County Government,,G,2014-09-15
+2264,Isiolo County Government,,G,2014-09-15
+2264,Isiolo County Government,,G,2014-09-15
+2265,Turkana County Government,,G,2014-09-15
+2265,Turkana County Government,,G,2014-09-15
+2266,Maji Milele,,N,2014-09-15
+2266,Maji Milele,,N,2014-09-15
+2267,Trukajaya,Trukajaya,N,2014-09-16
+2267,Trukajaya,Trukajaya,N,2014-09-16
+2268,Inclusive Business Fund,Inclusive Business Fund,N,2014-09-17
+2268,Inclusive Business Fund,Inclusive Business Fund,N,2014-09-17
+2269,YAPHI,YAPHI,N,2014-09-17
+2269,YAPHI,YAPHI,N,2014-09-17
+2270,Water Action,Water Action,N,2014-09-18
+2271,HELVETAS BF,HELVETAS BF,N,2014-09-18
+2272,ASRADEC,ASRADEC,N,2014-09-18
+2273,HCS,HCS,N,2014-09-18
+2274,DAKUPA,DAKUPA,N,2014-09-18
+2275,H & E Associates,H & E Associates,C,2014-09-18
+2276,IRHA,IRHA,N,2014-09-18
+2277,VDS,VDS,N,2014-09-18
+2278,Schrijf-Schrijf,Schrijf-Schrijf,C,2014-09-18
+2279,SKAT,SKAT,C,2014-09-18
+2280,RWSN,RWSN,N,2014-09-18
+2281,Warner,Warner,C,2014-09-18
+2282,ZIMMERMAN,ZIMMERMAN,C,2014-09-18
+2283,RAAS,RAAS,N,2014-09-18
+2284,PAKHUISZWIJGER,PAKHUISZWIJGER,C,2014-09-18
+2285,SEARNET,SEARNET,N,2014-09-18
+2286,RHCC / CECEP - Mali,RHCC / CECEP - Mali,N,2014-09-18
+2287,SETADE,SETADE,C,2014-09-18
+2288,BERA,BERA,C,2014-09-18
+2289,DIRO Center,DIRO Center,K,2014-09-18
+2290,DIRO Center,DIRO Center,K,2014-09-18
+2291,Develop4Value,Develop4Value,C,2014-09-18
+2292,HIER Klimaatbureau,HIER Klimaatbureau,N,2014-09-18
+2293,IFAD,IFAD,N,2014-09-18
+2294,Swiss Re,Swiss Re,C,2014-09-18
+2295,Fondation Ensemble,Fondation Ensemble,N,2014-09-18
+2296,Partners voor Water,Partners voor Water,G,2014-09-18
+2297,Waterschap Velt en Vecht,Waterschap Velt en Vecht,G,2014-09-18
+2298,CEFAC,CEFAC,C,2014-09-18
+2299,Future Water,Future Water,C,2014-09-18
+2300,Rainbow Collection,Rainbow Collection,C,2014-09-18
+2301,Helvetas Ethiopia,Helvetas Ethiopia,N,2014-09-18
+2302,PETALS Foundation,PETALS Foundation,N,2014-09-18
+2303,WSUP,Water and Sanitation for the Urban Poor,N,2014-09-19
+2303,WSUP,Water and Sanitation for the Urban Poor,N,2014-09-19
+2304,RVO,Rijksdiens voor Ondernemend Nederland,G,2014-09-19
+2304,RVO,Rijksdiens voor Ondernemend Nederland,G,2014-09-19
+2305,GA West Municipality,Ga West Municipal Assembly,G,2014-09-19
+2305,GA West Municipality,Ga West Municipal Assembly,G,2014-09-19
+2306,HFC Bank,HFC Boafo Micro-finance Services Ltd,C,2014-09-19
+2306,HFC Bank,HFC Boafo Micro-finance Services Ltd,C,2014-09-19
+2307,SNAPE,Service National des Points d'Eau ,G,2014-09-22
+2307,SNAPE,Service National des Points d'Eau ,G,2014-09-22
+2308,CONIWAS,Coalition of NGOs in water and sanitation ,N,2014-09-23
+2308,CONIWAS,Coalition of NGOs in water and sanitation ,N,2014-09-23
+2309,EPA,Environmental Protection Agency,G,2014-09-23
+2309,EPA,Environmental Protection Agency,G,2014-09-23
+2310,WRC,Water Resources Commission ,G,2014-09-23
+2310,WRC,Water Resources Commission ,G,2014-09-23
+2311,PURC,Public Utility Regulatory Commission,G,2014-09-23
+2311,PURC,Public Utility Regulatory Commission,G,2014-09-23
+2312,Ghana ProNet,Ghana Global Professional Network ,N,2014-09-23
+2312,Ghana ProNet,Ghana Global Professional Network ,N,2014-09-23
+2313,Min. of Water Resources,"Ministry of Water Resources, Works and Housing ",G,2014-09-23
+2313,Min. of Water Resources,"Ministry of Water Resources, Works and Housing ",G,2014-09-23
+2314,IWA,International Water Association ,N,2014-09-23
+2314,IWA,International Water Association ,N,2014-09-23
+2315,GWCL,Ghana Water Company Limited,G,2014-09-23
+2315,GWCL,Ghana Water Company Limited,G,2014-09-23
+2316,EU-ACP,"European Union - Africa, Carribean, Pacific",G,2014-09-23
+2316,EU-ACP,"European Union - Africa, Carribean, Pacific",G,2014-09-23
+2317,SECAR,St. Eustatius Center for Archaeological Research,N,2014-09-24
+2317,SECAR,St. Eustatius Center for Archaeological Research,N,2014-09-24
+2318,Scubaqua,Scubaqua Dive Center,C,2014-09-24
+2318,Scubaqua,Scubaqua Dive Center,C,2014-09-24
+2319,Dutch Embassy Ghana,"Dutch Embassy in Accra, Ghana",G,2014-09-25
+2319,Dutch Embassy Ghana,"Dutch Embassy in Accra, Ghana",G,2014-09-25
+2320,Min of Edu of Afghanistan,Ministry of Education of Afghanistan,G,2014-10-01
+2321,MIC of Afghanistan,Ministry of information and Culture of Afghanistan,G,2014-10-01
+2322,New AFIR Architects,New AFIR Architects,C,2014-10-01
+2323,Berenschot,Berenschot,C,2014-10-01
+2324,WakaWaka,WakaWaka Foundation,N,2014-10-03
+2325,DG Eau Benin,Direction GÃ©nÃ©rale de l'Eau Benin,G,2014-10-07
+2326,Dutch Embassy in Benin,"Dutch Embassy in Cotonou, Benin",G,2014-10-07
+2329,Min Basnet,Min Basnet,C,2014-10-07
+2330,Africa Interactive Kenya,Africa Interactive Kenya,N,2014-10-07
+2331,Pat the Child,Pat the Child,N,2014-10-08
+2332,Water Mission Int.,Water Mission International,N,2014-10-08
+2333,CWSA,Community Water & Sanitation Agency,G,2014-10-09
+2334,SkyFox,Skyfox Ltd Fast and Secure Transactions,C,2014-10-09
+2335,CARITAS KAOLACK,CARITAS KAOLACK,N,2014-10-14
+2336,NEF,NEF,N,2014-10-14
+2337,JKUATES ,JKUAT Enterprises Ltd,K,2014-10-16
+2338,Rotary Club of Selkirk,Rotary Club of Selkirk,N,2014-10-16
+2339,FEDWASUN,"Federation of Drinking Water and Sanitation,Nepal",N,2014-10-18
+2340,Friends Service Council,"Friends Service Council, Nepal",N,2014-10-18
+2341,Sahakarmi Samaj,"Sahakarmi Samaj,Nepal",N,2014-10-18
+2342,TLMI,The Leprosy Mission Myanmar,N,2014-10-20
+2343,GWCL,Ghana Water Company Limited,C,2014-10-20
+2344,Women Win,,N,2014-10-22
+2345,VAP,Vijana Amani Pamoja,N,2014-10-22
+2346,Polycom,Polycom Development Project,N,2014-10-23
+2347,CMD,Centre for Multiparty Democrazy,N,2014-10-23
+2348,Saferworld,,N,2014-10-23
+2349,IMLU,Independent Medico-Legal Unit,N,2014-10-23
+2350,GOAL Kenya,,N,2014-10-23
+2351,Sanergy Ltd,,N,2014-10-23
+2352,WWF Kenya,WWF Kenya,N,2014-10-23
+2353,Imarisha Naivasha,,N,2014-10-23
+2354,WRMA,Water Resources Management Authority,G,2014-10-23
+2355,NZV,Noorderzijlvest,G,2014-10-23
+2356,ACC,African Conservation Centre,N,2014-10-23
+2357,DNSP-HAB,Direction Nationale de la SantÃ© Publique du BÃ©nin,G,2014-10-26
+2358,Laikipia Wildlife Forum,Laikipia Wildlife Forum,N,2014-10-27
+2359,CongresoBPPM,II Congreso Internacional de Buenas PrÃ¡cticas Patrimonio Mundial,K,2014-10-28
+2360,FA,Financial Access Capital Partners,C,2014-10-29
+2361,SCOPEinsight East Africa,,C,2014-10-29
+2362,LUANAR,Lilongwe University of Agriculture & Natural Resources,K,2014-10-30
+2363,De Kootje FundatiÃ«n,Stichting De Kootje FundatiÃ«n,N,2014-10-30

--- a/akvo/scripts/projects.csv
+++ b/akvo/scripts/projects.csv
@@ -1,0 +1,2011 @@
+id,proj_title,currency,value,update_count,publishing_status,status,funded,Organisation,created_at
+16,Rehabilitation of Water Catchment,EUR,"20,854.00",18,published,Completed,"20,854.00",16,2008-07-15
+17,Training on Rope Pump Manufacture ,EUR,"10,469.00",4,published,Completed,"10,469.00",43,2008-07-16
+18,Marketing Ecological Sanitation,EUR,"18,000.00",3,published,Archived,"18,000.00",14,2008-07-16
+19,Water Filter Production,EUR,"18,637.00",1,published,Archived,0.00,18,2008-07-16
+20,Vocational Training Program,EUR,"14,921.00",3,published,Completed,"14,921.00",2,2008-07-16
+21,Chlorination system for gravity water supply,EUR,"13,284.00",1,published,Archived,0.00,37,2008-07-17
+22,Ecological Sanitation for Schools,EUR,"16,000.00",28,published,Completed,"16,000.00",13,2008-07-17
+23,Staff Capacity Development ,EUR,"9,223.00",8,published,Completed,"9,223.00",34,2008-07-17
+24,Ceramic Filter Production,EUR,"20,596.00",8,published,Completed,"20,596.00",22,2008-07-17
+25,School Health and Sanitation ,EUR,"13,785.00",4,published,Completed,"13,785.11",7,2008-07-17
+26,Promoting Sanitation and Hygiene ,EUR,"14,888.00",4,published,Completed,"14,888.00",25,2008-07-17
+27,School Sanitation Implementation,EUR,"16,580.00",8,published,Completed,"16,580.00",26,2008-07-17
+28,Rural School Sanitation,EUR,"10,327.00",3,published,Completed,"10,327.25",8,2008-07-17
+29,Rainwater Harvesting,EUR,"12,539.00",6,published,Completed,0.00,28,2008-07-17
+30,Training on Low-cost Manual Drilling ,EUR,"20,822.00",11,published,Completed,"20,822.00",39,2008-07-17
+31,Rehabilitation Water System ,EUR,"12,800.00",5,published,Archived,"12,800.00",93,2008-07-17
+33,Sanitation for Refugees,EUR,"19,000.00",2,published,Archived,0.00,32,2008-07-18
+34,Water Supply Protection,EUR,"4,500.00",4,published,Archived,0.00,32,2008-07-18
+35,Village Sanitation Initiative,EUR,"6,050.00",6,published,Archived,0.00,33,2008-07-18
+37,Safe Sanitation for students,EUR,"35,040.00",1,published,Archived,"11,200.00",41,2008-07-29
+38,Arsenic Filter Pilot,EUR,"21,995.00",20,published,Completed,"21,995.00",43,2008-08-10
+39,Drinking water with Solarpump,EUR,"12,865.00",3,published,Completed,"12,865.00",48,2008-08-10
+40,School Water and Sanitation,EUR,"8,500.00",1,published,Completed,"8,500.00",46,2008-08-10
+41,Sanitation in a Refugee Camp,EUR,"13,500.00",18,published,Completed,"13,500.00",55,2008-08-11
+42,School Sanitation Project,EUR,"10,700.00",11,published,Completed,"10,699.60",56,2008-11-04
+43,Health and Hygiene Education,EUR,"11,398.00",7,published,Completed,"11,397.62",57,2008-11-04
+44,Smart-technology Training Program,EUR,"14,680.00",2,published,Archived,0.00,57,2008-12-06
+45,Composting Latrines Madagascar,EUR,"17,493.00",1,published,Archived,0.00,58,2008-12-17
+46,The â€œLave mainâ€ for Schools,EUR,"1,365.00",5,published,Completed,"1,365.09",43,2008-12-18
+47,Safe Drinking Water for Slum People,EUR,"8,000.00",34,published,Completed,"8,000.00",19,2009-01-15
+49,Primary School Water and Sanitation,EUR,"6,962.00",6,published,Completed,"6,961.60",65,2009-01-27
+50,Safe Drinking Water & Empowering Women,EUR,"11,740.00",5,published,Completed,"11,740.00",169,2009-01-27
+51,Rehabilitation of 4 Wells & Pumps,EUR,"4,882.00",7,published,Completed,"4,882.00",65,2009-01-27
+52,Women Empowerment Centre,EUR,"30,465.00",4,published,Archived,0.00,65,2009-01-28
+53,Toilets and Water for Dumja,EUR,"29,644.00",6,published,Completed,"29,644.00",113,2009-02-15
+54,Water and Sanitation for Mmanze,EUR,"24,882.00",16,published,Completed,"24,881.95",164,2009-02-15
+55,Water Project Namelok,EUR,"10,550.00",3,published,Completed,"10,550.00",77,2009-02-16
+56,Borehole Rehabilitation,EUR,"17,585.00",5,published,Completed,"17,584.86",79,2009-02-16
+57,School Water and Sanitation ,EUR,"13,610.00",7,published,Completed,"13,610.00",113,2009-02-16
+59,Multi-Instit. Decentralized Drinking Water,EUR,"202,200.00",1,published,Completed,"202,200.00",184,2009-02-20
+60,Water & Sanitation for Bohol,EUR,"50,574.00",19,published,Completed,"50,574.00",89,2009-02-25
+61,Drinking Water School Ban Nalau,EUR,"4,500.00",4,published,Completed,"4,499.95",52,2009-02-26
+62,AMREF Kajiado Boreholes Project,EUR,"12,971.00",14,published,Completed,"12,971.00",94,2009-03-03
+63,Drinking Water School Ban Tja Luai,EUR,"4,500.00",3,published,Completed,"4,500.21",91,2009-03-10
+66,"WaterPyramid for Kaolack, Senegal",EUR,"95,000.00",2,published,Archived,"95,000.36",102,2009-05-25
+69,Clean Water in Rwanda ,EUR,"18,000.00",13,published,Completed,"18,000.42",101,2009-06-19
+72,TRIANGLE project,EUR,"7,580.00",4,published,Completed,"7,580.00",109,2009-07-22
+73,Elephant pumps and toilets in Northern Malawi,EUR,"5,806.00",5,published,Completed,"5,806.00",110,2009-07-30
+74,Elephant toilets in rural Liberia,EUR,"5,020.00",2,published,Completed,"5,019.58",110,2009-07-30
+75,Hydraulic Ram Pumps for Colombia - phase 1,EUR,"22,500.00",3,published,Completed,"22,499.65",227,2009-08-11
+76,Healthy Drinking Water in Ngudwini ,EUR,"24,073.00",0,published,Completed,"24,073.03",105,2009-08-12
+81,Rehabilitation of water points in Niger,EUR,"25,542.00",1,published,Archived,0.00,15,2009-09-17
+83,Water filter introduction Cameroon,EUR,"29,646.00",1,published,Archived,0.00,22,2009-09-18
+84,Clean Water for Orphans Project - China,EUR,"21,379.00",1,published,Archived,"21,379.00",123,2009-09-23
+85,Water Pumps in Zimbabwe,EUR,"5,481.00",1,published,Archived,0.00,110,2009-09-24
+86,Health Centre WASH (HC WASH) ,EUR,"23,900.00",1,published,Archived,"7,948.00",129,2009-09-25
+87,Water&sanitation in Tigania-Kenya,EUR,"11,650.00",1,published,Archived,0.00,130,2009-09-27
+88,Safe Water for 11 Community Schools,EUR,"60,000.00",1,published,Archived,"17,000.00",141,2009-09-27
+89,Rooftop Rainwater Harvesting and Storage  ,EUR,"21,651.00",1,published,Archived,"11,029.00",133,2009-09-29
+90,GWC's Changemakers: EcoTact,USD,"31,000.00",1,published,Archived,23.12,147,2009-09-30
+91,GWC's Changemakers: Manna Energy,USD,"50,000.00",1,published,Archived,249.60,135,2009-09-30
+92,GWC Water & Sanitation for Guatemalan School,USD,"12,075.00",1,published,Archived,706.08,16,2009-09-30
+93,Water for Healthy Food ,EUR,"24,688.00",1,published,Archived,0.00,137,2009-10-06
+94,Rural Mozambican Schools Practice Sanitation ,EUR,"24,374.00",4,published,Completed,"24,373.82",494,2009-10-06
+95,Drinking Water for Upland Communities,EUR,"25,000.00",1,published,Archived,0.00,112,2009-10-06
+96,Introduction of Rope Pump in Philippines,EUR,"20,000.00",1,published,Archived,0.00,112,2009-10-06
+97,Total Water Project,EUR,"30,000.00",1,published,Archived,0.00,138,2009-10-06
+98,Rope Pumps for Rural Communities,EUR,"30,000.00",2,published,Archived,0.00,57,2009-10-06
+99,Improved Latrines for Rural Communities,EUR,"20,000.00",2,published,Archived,0.00,57,2009-10-06
+100,Safe drinking water for Dzoraghbyur,EUR,"76,722.00",2,published,Archived,"8,690.00",139,2009-10-06
+101,EcoSan Project Safe Disposal & Use of Excreta,EUR,"78,593.00",6,published,Completed,"78,593.25",140,2009-10-06
+103,Indigenous Trees for Life ,EUR,"26,143.00",4,published,Archived,500.00,147,2009-10-09
+105,Sanitation&Training for Chawama Youth Project,EUR,"45,300.00",3,published,Completed,"45,300.50",148,2009-10-15
+106,Quench the thirst! Water 4 Uganda!,EUR,"45,939.00",0,published,Archived,0.00,149,2009-10-15
+107,Rainwater harvesting in Guinee Bissau,EUR,"15,182.00",2,published,Active,"15,181.87",150,2009-10-16
+108,Community Water & Sanitation Program,EUR,"4,000.00",1,published,Completed,"3,999.77",230,2009-10-16
+109,Water Supply and Sanitation System for people,EUR,"25,270.00",1,published,Archived,0.00,151,2009-10-19
+110,Professionalization of manual drilling teams,EUR,"25,000.00",1,published,Archived,0.00,39,2009-10-20
+111,Improved water supply in Tanzania,EUR,"58,863.00",3,published,Archived,0.00,57,2009-10-20
+112,Bring on the rain in Nepal,EUR,"25,000.40",3,published,Completed,"1,491.36",153,2009-11-04
+113,Water and biogas for livelihood improvement,EUR,"50,094.20",2,published,Completed,0.00,464,2009-11-04
+114,"Safe water supply for Nghadior, Senegal",EUR,"32,284.00",2,published,Archived,"4,735.10",154,2009-11-04
+115,"Safe water supply for Paanchkal, Nepal",EUR,"42,449.30",2,published,Completed,0.00,464,2009-11-04
+116,Water pumps in Malawi,EUR,"7,400.00",4,published,Completed,"7,400.47",383,2009-11-18
+117,Water for life in Zimbabwe,EUR,"25,000.00",1,published,Archived,0.00,110,2009-11-18
+118,Water for life in Zimbabwe,EUR,"12,350.00",1,published,Archived,0.00,110,2009-11-18
+119,Urine Bank for Food Security,EUR,"42,440.00",1,published,Archived,0.00,156,2009-11-20
+120,Migrant Schools Clean Water Project - China,EUR,"23,165.00",1,published,Completed,"23,164.90",237,2009-11-26
+121,AguaClara Drinking Water Treatment Plant,EUR,"44,256.39",0,published,Active,"44,256.26",158,2009-11-26
+122,"Safe water supply for Bakho, Senegal",EUR,"25,294.80",2,published,Archived,"2,050.30",35,2009-12-09
+123,"Safe water supply for ModbarÃ©, Burkina Faso",EUR,"31,450.80",2,published,Archived,"5,558.50",160,2009-12-10
+124,"Safe water supply for Bamloye, Burkina Faso",EUR,"11,184.50",2,published,Archived,"3,102.30",161,2009-12-10
+125,"Safe water supply for Bani, Burkina Faso",EUR,"11,184.50",2,published,Archived,"3,102.30",161,2009-12-10
+126,"Safe water supply for Lamdamol, Burkina Faso",EUR,"11,184.50",2,published,Archived,"3,102.30",35,2009-12-10
+127,"Safe water supply for Pagalaga, Burkina Faso",EUR,"11,184.50",1,published,Archived,"3,102.30",161,2009-12-10
+128,"Safe water supply for Fayaco, Senegal",EUR,"20,685.00",0,published,H,"3,502.52",154,2010-01-12
+129,School WATSAN Cabo Delgado,EUR,"24,500.00",3,published,Completed,"24,500.00",164,2010-01-15
+130,AMREF Kibera integrated schools health ,EUR,"13,756.00",2,published,Completed,"13,756.00",94,2010-01-19
+131,"AMREF Water and sanitation Mtwara, Tanzania",EUR,"103,251.00",3,published,Completed,"103,251.06",353,2010-01-19
+132,Creation of 2 model Ecosan Villages,EUR,"27,220.00",6,published,Archived,"27,219.75",210,2010-01-20
+133,"Micro-Sanitation in Sirajganj, Bangladesh",EUR,"3,000.00",0,published,Active,"3,000.00",152,2010-01-25
+134,School Sanitatie en Hygiene Voorlichting,EUR,"139,000.00",6,published,Completed,"139,000.00",301,2010-02-01
+135,Water for Mugeyo,EUR,"24,000.00",1,published,Active,"23,999.82",181,2010-02-02
+138,School RWH en sanitatie Mmanze,EUR,"26,056.00",19,published,Completed,"26,055.64",244,2010-02-08
+139,Water for Haiti!,EUR,"49,500.00",3,published,Archived,0.00,121,2010-02-08
+140,Project Waterinfrastructuur Niabina en Mâ€™BahÃ©,EUR,"24,445.00",0,published,H,0.00,79,2010-02-10
+141,Water pumps for rural Guatemalan communities,EUR,"16,825.00",7,published,Active,"16,824.79",43,2010-02-12
+143,Schoon water en sanitatie op scholen,EUR,"80,000.00",1,published,Completed,"80,000.21",185,2010-02-17
+144,Improving living standards in Kenya ,EUR,"360,500.00",1,published,Archived,"231,721.08",187,2010-02-17
+145,"Waterput met handpomp, blok van 3 wc's  ",EUR,"10,361.00",16,published,Completed,"10,361.00",43,2010-02-22
+146,Safe drinking water for Thai school children,EUR,"4,500.00",3,published,Completed,"4,500.00",316,2010-02-22
+147,"Water & Sanitatie, Kadurugahamaditha School ",EUR,"1,886.00",3,published,Completed,"1,886.00",43,2010-02-22
+148,Water voor Katagamuwa School ,EUR,"3,760.00",3,published,Completed,"3,760.00",188,2010-02-22
+149,Toilets for the Halmellakotowa School ,EUR,"2,900.00",6,published,Completed,"2,899.82",43,2010-02-22
+150,Toiletten voor Vithikuliya School ,EUR,"5,460.00",4,published,Completed,"5,460.00",43,2010-02-22
+151,Water en Sanitatie voor Kuli Kudavewa School,EUR,"3,630.00",3,published,Completed,"3,630.00",209,2010-02-22
+152,Toiletten voor Lagere Scholen ,EUR,"32,000.00",2,published,Active,"32,000.15",190,2010-02-25
+153,Water en Sanitation op Scholen in Nyakach,EUR,0.00,5,published,Completed,"89,000.00",193,2010-02-27
+154,Waterput in Melfa,EUR,"4,216.00",0,published,Active,"4,216.00",43,2010-03-01
+155,Uitbreiding AEPS voor de kliniek van Latou,EUR,"2,800.00",0,published,Active,"2,800.00",196,2010-03-01
+156,Water in Delta Islands,EUR,"25,200.00",1,published,Archived,"5,600.00",247,2010-03-09
+157,Wandelen voor Water ,EUR,"14,500.00",3,published,Active,"14,500.00",43,2010-03-09
+158,Rainwater harvesting for Nicolas School,EUR,"48,753.77",2,published,Completed,334.20,35,2010-03-09
+159,GWC Water & Sanitation for a Tanzanian School,USD,"18,500.00",1,published,Archived,61.93,172,2010-03-09
+160,GWC Water Kiosk in India,USD,"25,000.00",1,published,Archived,209.97,203,2010-03-09
+161,Schoon Water voor Moeders in Kenya,EUR,"177,493.00",2,published,Completed,"177,493.49",113,2010-03-11
+163,"Water for Asrada, Bheemanpalli, Gathampakala",EUR,"13,112.00",13,published,Completed,"13,112.10",60,2010-03-12
+164,Water- en Sanitatieproject in Monrovia,EUR,"437,400.00",1,published,Completed,"437,400.00",207,2010-03-15
+165,Water filters for families in Mozambique,EUR,"8,000.00",0,published,Active,"8,000.00",137,2010-03-15
+166,Water and sanitation to improve households,EUR,"20,000.00",0,published,Active,"20,000.00",214,2010-03-18
+167,"Water for Chitralgoppu, Diguvu, Jalluri Metta",EUR,"14,933.00",11,published,Completed,"14,933.00",184,2010-03-19
+168,Water for Rintada,EUR,"14,933.00",11,published,Completed,"14,933.00",184,2010-03-19
+169,Water for A.Sanivaramu,EUR,"14,933.00",12,published,Completed,"14,933.00",206,2010-03-19
+170,Water for Palada,EUR,"14,933.00",11,published,Completed,"14,933.00",206,2010-03-19
+171,"AMREF water & sanitation in Kajiado, Kenya",EUR,"88,291.99",5,published,Completed,"88,292.32",95,2010-03-19
+173,Clean Water for Rural Village in Burkina Faso,EUR,"36,937.00",1,published,Archived,"10,342.00",197,2010-03-20
+174,Borehole with handpump for village community,EUR,"7,500.00",0,published,Completed,"7,499.82",208,2010-03-23
+175,Katombora,EUR,"36,559.00",2,published,Completed,"36,559.00",216,2010-03-26
+176,FUNBOAS,EUR,"46,150.00",2,published,Archived,"46,150.00",220,2010-03-29
+177,Water for the poor in Africa,EUR,"50,000.00",1,published,Archived,0.00,223,2010-04-06
+178,Drink water supply for Sorido,EUR,"12,000.00",0,published,Completed,"12,000.00",53,2010-04-07
+179,Toilets for Katunjebesi,EUR,"32,606.00",0,published,Active,"32,605.75",71,2010-04-14
+180,Schoon water voor La Libertad,EUR,"20,000.00",1,published,Active,"20,000.00",239,2010-06-08
+181,Water & Sanitation for the poor in Mozambique,EUR,"24,514.00",1,published,Archived,0.00,242,2010-06-18
+182,Toiletten voor Kuli Dahanathgadara School ,EUR,"4,352.00",3,published,Completed,"4,352.00",188,2010-07-15
+183,Water voor School Girls College ,EUR,"2,520.00",3,published,Completed,"2,520.00",113,2010-07-15
+184,Brunapeg Water & Sanitation,EUR,"21,458.00",23,published,Completed,"21,458.00",283,2010-08-16
+185,A borehole in Kisozi,EUR,"6,816.00",13,published,Completed,"6,816.00",106,2010-08-16
+186,Health & Sanitation at Bamboo School Nepal,EUR,"49,500.00",7,published,Active,"49,500.00",251,2010-09-29
+187,The Winddrinker,EUR,"96,699.00",13,published,Active,"96,698.82",43,2010-10-06
+188,"Community led water, sanitation and hygiene",EUR,"60,048.00",0,published,Active,"60,048.00",113,2010-11-04
+192,Market information system using mobile phones,EUR,"186,920.00",2,published,Completed,"186,920.00",34,2010-11-11
+193,Community radio Pag-La-Yiri,EUR,"126,500.00",2,published,Completed,"126,500.00",269,2010-11-15
+194,Mobiles and computers for child health,EUR,"391,225.00",12,published,Completed,"391,225.00",949,2010-11-15
+195,Basic Sanitation for Loja Province,EUR,"32,000.00",0,published,H,"7,000.00",277,2010-11-19
+196,Water for poor neighborhoods: Villa Ocampo,EUR,"22,930.00",0,published,H,"6,880.00",279,2010-11-20
+197,The Circuit Rider Program in Honduras,EUR,"60,000.00",0,published,H,"35,000.00",282,2010-11-22
+199,Design of a low-cost community hand pump,EUR,"6,590.00",0,published,H,"1,346.07",15,2010-11-28
+200,Designing a windmill driven rope-pump,EUR,"12,200.00",1,published,Archived,"1,000.00",15,2010-12-02
+201,Building Entrepreneurial Capability of Women,EUR,"20,700.00",0,published,H,"3,750.00",295,2010-12-08
+202,Using SMS for HIV/AIDS education ,EUR,"10,200.00",0,published,Completed,"10,200.00",294,2010-12-08
+203,Waterproject in Namelok,EUR,"8,000.00",7,published,Completed,"8,000.82",77,2010-12-10
+204,Schoon water voor kinderen in Kirolo,EUR,"6,475.00",12,published,Active,"6,474.85",301,2010-12-10
+205,"Putten voor drinkwater, tuinbouw, veehouderij",EUR,"8,100.00",0,published,H,"6,279.00",297,2010-12-10
+206,Market and production info for farmers,EUR,"21,000.00",5,published,Completed,"21,000.00",298,2010-12-14
+208,Telemedicine in Tanzania (phase 2),EUR,"45,000.00",0,published,Active,"45,000.00",272,2010-12-14
+209,Water en sanitatie op scholen 2011,EUR,"75,570.00",1,published,Active,"75,569.83",168,2010-12-15
+210,Schoon drinkwater en sanitatie in Myanmar,EUR,"309,000.00",1,published,Completed,"308,999.82",207,2010-12-16
+213,Helping teachers use ICT for teaching,EUR,"110,820.00",6,published,Active,"110,820.00",1664,2010-12-20
+214,Computer skills for small business owners,EUR,"66,724.00",3,published,Completed,"66,724.00",34,2010-12-20
+215,Using PCs for Continuing Medical Education,EUR,"500,333.00",1,published,Completed,"500,333.00",1131,2010-12-20
+216,Webbased application /teleconference facility,EUR,"150,000.00",5,published,Active,"150,000.00",272,2010-12-20
+217,Credit management system for small farmers,EUR,"319,776.00",1,published,Completed,"319,776.00",309,2010-12-21
+218,Telemedicine in Tanzania (phase 1),EUR,"117,000.00",0,published,Completed,"117,000.00",430,2010-12-21
+219,District health management information system,EUR,"160,000.00",0,published,Active,"160,000.00",34,2010-12-21
+220,A modular implementation of ICT in health,EUR,"131,000.00",0,published,Active,"131,000.00",311,2010-12-21
+221,Management System for health facilities,EUR,"115,000.00",0,published,Active,"115,000.00",300,2010-12-21
+222,Water supply for Nyanje school in Zambia,EUR,"41,457.00",26,published,Completed,"41,457.31",43,2010-12-21
+223,Water for Samburu,EUR,"41,226.00",1,published,H,"13,742.00",106,2010-12-23
+226,Multimedia helps farmers to improve produce,EUR,"121,500.00",1,published,Active,"121,500.00",317,2010-12-23
+227,Raise awareness on hygiene and drinking water,EUR,"101,500.00",1,published,Completed,"101,500.00",21,2011-01-03
+228,Expertise center on ehealth and telemedicine,EUR,"236,639.00",2,published,Active,"236,639.00",327,2011-01-03
+229,Sene Kunafoni Bulon,EUR,"155,292.00",0,published,Active,"155,292.00",328,2011-01-03
+230,Improving visual teaching material in Zambia,EUR,"462,600.00",1,published,Completed,"462,600.00",34,2011-01-03
+231,ICT in the Zambian Classroom,EUR,"166,481.96",0,published,Active,"166,482.00",34,2011-01-03
+232,A fresh start for unskilled youths in Zambia,EUR,"138,694.00",9,published,Active,"138,694.00",34,2011-01-03
+233,Using ICT to certify and market crops abroad,EUR,"144,235.00",0,published,Active,"144,235.00",373,2011-01-04
+234,Guarantee for financing sanitation activities,EUR,"12,000.00",2,published,Archived,"12,000.00",14,2011-01-04
+235,Waterput in Bona,EUR,"9,900.00",12,published,Completed,"9,900.00",43,2011-01-04
+236,"260 Toiletten voor VDC Mangaltar, Nepal",EUR,"17,166.00",3,published,Completed,"17,166.00",71,2011-01-04
+237,Waterproject 2011,EUR,"29,000.00",9,published,Active,"29,000.00",113,2011-01-04
+238,Latrines en aansluitingen op waterleiding,EUR,"21,490.00",2,published,H,"7,713.03",325,2011-01-04
+239,Toiletten voor Scholen,EUR,"13,565.00",0,published,H,"11,541.60",189,2011-01-04
+240,Schoon water voor Kagnandofe 650 inwoners,EUR,"9,947.59",16,published,Completed,"9,948.00",168,2011-01-11
+242,FRUILEMA,EUR,"161,500.00",0,published,Completed,"161,500.00",330,2011-01-18
+243,HIV/AIDS Education Programme,EUR,"72,035.00",6,published,Active,"72,035.00",339,2011-02-01
+244,Rabo donatieproject microfinanciering,EUR,330.00,4,published,Completed,330.10,340,2011-02-08
+245,Rabo donatieproject microfinanciering,EUR,496.00,4,published,Completed,495.94,340,2011-02-20
+246,Rabo donatieproject microfinanciering,EUR,265.00,4,published,Completed,265.28,341,2011-02-20
+247,Rabo donatieproject microfinanciering,EUR,330.00,4,published,Completed,329.82,340,2011-02-20
+248,Rabo donatieproject microfinanciering,EUR,330.00,4,published,Completed,329.82,340,2011-02-20
+249,Rabo donatieproject microfinanciering,EUR,463.00,4,published,Completed,462.92,340,2011-02-20
+250,Rabo donatieproject microfinanciering,EUR,397.00,4,published,Completed,396.82,340,2011-02-20
+251,Rabo donatieproject microfinanciering,EUR,496.00,4,published,Completed,495.82,340,2011-02-20
+252,Rabo donatieproject microfinanciering,EUR,660.00,4,published,Completed,659.82,340,2011-02-20
+253,Rabo donatieproject microfinanciering,EUR,132.00,5,published,Completed,131.82,340,2011-02-20
+254,Rabo donatieproject microfinanciering,EUR,661.00,5,published,Completed,661.00,340,2011-02-20
+255,Rabo donatieproject microfinanciering,EUR,231.00,4,published,Completed,231.00,340,2011-02-20
+256,Rabo donatieproject microfinanciering,EUR,661.00,4,published,Completed,660.82,340,2011-02-20
+257,Rabo donatieproject microfinanciering,EUR,99.00,5,published,Completed,98.82,341,2011-02-20
+258,Rabo donatieproject microfinanciering,EUR,559.00,4,published,Completed,558.82,341,2011-02-20
+260,Rabo donatieproject microfinanciering,EUR,462.00,6,published,Completed,462.00,341,2011-02-20
+261,Rabo donatieproject microfinanciering,EUR,330.00,5,published,Completed,330.46,341,2011-02-20
+262,Rabo donatieproject microfinanciering,EUR,661.00,6,published,Completed,661.28,341,2011-02-20
+264,Rabo donatieproject microfinanciering,EUR,264.00,4,published,Completed,263.82,341,2011-02-20
+265,Reparatie handpompen van 3 waterputten,EUR,"6,780.00",6,published,Active,"6,779.64",289,2011-02-23
+266,Water en Sanitatie voor Kivla school ,EUR,"3,340.00",6,published,Completed,"3,340.00",188,2011-03-03
+267,"Micro Sanitation in Rajihar, Bangladesh",EUR,"2,500.00",3,published,Completed,"2,500.00",115,2011-03-08
+268,Revolving fund water and sanitation SHIPO,EUR,"147,000.00",9,published,Active,"146,999.97",43,2011-03-08
+269,Vocational training former streetchildren  ,EUR,"24,210.00",0,published,H,"15,000.00",106,2011-03-24
+270,Household Water Filtration Systems ,EUR,"11,448.00",1,published,Active,"11,448.39",228,2011-04-15
+271,Clean drinking water for bottom of pyramid ,EUR,"34,629.00",6,published,Archived,0.00,354,2011-04-28
+272,Women and Water Sanitation and Health Centre ,EUR,"15,500.00",1,published,Completed,"15,500.50",316,2011-05-18
+273,Sanitation facilities,EUR,"5,238.00",8,published,Completed,"5,237.82",43,2011-05-18
+274,A safe park for Duncan Village,EUR,"37,000.00",3,published,Active,"36,999.54",106,2011-05-19
+275,Heritage Teachers Handbook in Palestine,EUR,"24,000.00",18,published,Active,"24,023.82",362,2011-05-30
+276,Sujol brings good water,EUR,"309,800.00",105,published,Active,"309,800.00",366,2011-05-31
+277,MAMMA,EUR,"17,000.00",19,published,H,"15,587.45",294,2011-06-07
+278,Honing in on Zambian honey,EUR,"8,000.00",1,published,Active,"8,000.00",372,2011-06-07
+279,Education & training for vulnerable women,EUR,"32,950.00",1,published,Archived,"32,950.00",374,2011-06-08
+280,Education for former child soldiers,EUR,"19,250.00",1,published,Archived,241.30,384,2011-06-27
+281,Trauma counselling for survivors of war,EUR,"19,100.00",1,published,Archived,0.00,385,2011-06-30
+282,Rainwater harvesting for Vijayapura schools,EUR,"3,000.00",5,published,Completed,"3,000.13",389,2011-07-07
+283,"Sustainable Water Treatment in Asoul, Morocco",EUR,"28,140.00",1,published,Archived,"10,000.00",391,2011-07-14
+284,Archaeological Park in Nicaragua,EUR,"10,500.00",2,published,H,"2,592.07",361,2011-07-15
+285,Malawi Elephant Pump Mark II Project,EUR,"32,672.00",2,published,Active,"32,672.00",110,2011-08-08
+286,EDU-Key,EUR,"222,016.00",0,published,H,"190,000.00",395,2011-08-12
+287,Social and medical project,EUR,"23,000.00",0,published,H,"75,000.00",403,2011-08-16
+289,"Water Project in Mchinji, Malawi",EUR,"8,212.00",1,published,H,0.00,110,2011-08-18
+291,Development in Midebdo,EUR,"53,100.00",0,published,H,"24,859.64",386,2011-08-30
+292,AEC Eye Care Development Program for Vietnam,EUR,"59,350.00",0,published,H,"26,300.00",106,2011-08-30
+293,Vocational cum Skill Training Program,EUR,"75,300.00",2,published,Active,"75,300.00",168,2011-09-05
+294,Integration of ICT on agricultural commodity,EUR,"305,060.00",18,published,Active,"261,480.00",425,2011-09-07
+296,Connect4Change Education Programme - Ethiopia,EUR,"160,000.00",10,published,Active,"160,000.00",272,2011-09-16
+297,School of ban yang nam sai,EUR,"4,500.00",2,published,Completed,"4,499.64",91,2011-09-18
+298,school chum chon ban sakea,EUR,"4,500.00",1,published,Completed,"4,499.75",91,2011-09-26
+300,Elephant Pump water project,EUR,"3,506.04",3,published,Completed,"3,506.94",332,2011-10-12
+302,Tackling e-Waste in East Africa,EUR,"110,000.00",1,published,H,"5,000.00",305,2011-10-20
+303,Bits4Green - contributing to clean ICT use ,EUR,"65,000.00",1,published,H,"20,000.00",392,2011-10-20
+304,Integration of ICT in Education Project(IIEP),EUR,"68,000.00",56,published,Active,"67,999.92",272,2011-10-24
+305,Aid for Trade,USD,"6,551,961.00",19,published,Completed,"6,551,961.00",435,2011-10-26
+306,Inclusive Employment and Social Partnership,USD,"861,800.00",45,published,Active,"861,800.00",428,2011-10-26
+308,Water Provision in Northern Kenya,EUR,"268,963.00",1,published,Archived,"268,963.00",440,2011-11-14
+309,Water Provision in Rural Uganda,EUR,"248,000.00",1,published,Archived,"248,000.00",443,2011-11-14
+310,My SWEPS,EUR,"120,000.00",1,published,H,"22,968.07",472,2011-11-15
+312,ImplementaciÃ³n de software financiero,EUR,"22,266.71",3,published,Active,"22,266.71",460,2011-11-22
+313,InformaciÃ³n de precios de mercado en el sur  ,EUR,"17,733.00",25,published,Active,"17,733.00",34,2011-11-22
+314,IntegraciÃ³n SCI y SIG,EUR,"74,979.00",23,published,Active,"74,979.00",488,2011-11-22
+315,School Sanitation and Hygiene Education,EUR,"139,000.00",2,published,Completed,"139,000.00",209,2011-11-22
+316,Comunidad educativa TIC para el cambio,EUR,"116,697.00",25,published,Active,"116,697.00",272,2011-11-22
+317, Las TIC en la educaciÃ³n,EUR,"864,440.00",52,published,Active,"621,100.00",272,2011-11-22
+318,Plataforma informaciÃ³n de apoyo al SPG,EUR,"93,900.00",27,published,Active,"60,000.00",34,2011-11-22
+320,TIC para una educaciÃ³n ,EUR,"101,737.00",37,published,Active,"101,737.00",34,2011-11-23
+321,EducaciÃ³n en la interculturalidad,EUR,"122,593.00",11,published,Active,"122,593.00",488,2011-11-23
+322,EducaciÃ³n TÃ©cnica a distancia en Bolivia,EUR,"19,368.00",97,published,Active,"19,368.00",34,2011-11-24
+323,GestiÃ³n del Conocimiento para el Desarrollo,EUR,"99,141.96",27,published,Active,"99,141.96",319,2011-11-24
+324,dance4life India,EUR,"154,000.00",0,published,Active,"154,000.00",463,2011-11-25
+325,Waterput voor school in het dorp Mamaribougou,EUR,"12,546.00",9,published,Active,"12,546.00",815,2011-11-28
+326,Water and Sanitation for School Children,EUR,"37,000.00",11,published,H,"29,647.98",444,2011-11-28
+327,Red de Inteligencia de Mercados,EUR,"157,801.00",10,published,Active,"157,801.00",34,2011-11-28
+328,Uso de TIC's en sistemas de comunicaciÃ³n,EUR,"91,242.00",65,published,Active,"91,242.00",34,2011-11-28
+329,Health and Sanitation Bamboo Schools,EUR,"30,000.00",2,published,Active,"30,000.00",251,2011-12-01
+330,Waterproject 2012,EUR,"217,575.00",8,published,Active,"217,575.00",43,2011-12-02
+332,Banda Kyandazza Water System,EUR,"44,000.00",5,published,Completed,"43,999.82",510,2011-12-05
+333,"Clean water project, Malawi ",EUR,"3,507.04",1,published,Completed,"3,507.17",110,2011-12-05
+335,Making cities sustainable ,USD,"1,000,300.00",54,published,Completed,"1,000,300.00",428,2011-12-12
+336,Mother and Child care through ICT approach,EUR,"148,800.00",16,published,Active,"148,800.00",273,2011-12-13
+337,Improving access and quality of HBC and ART ,EUR,"74,000.00",8,published,Active,"74,000.00",294,2011-12-13
+338,TESO Integrated Rural Education Project ,EUR,"101,597.00",37,published,Active,"101,597.15",666,2011-12-19
+339,TIC en el desarrollo de una EIB y Productiva,EUR,"42,000.00",7,published,Active,"42,000.00",34,2011-12-20
+340,Water training centre in Malawi,EUR,"252,900.00",12,published,H,"115,615.87",498,2011-12-20
+341,Strengthen ICT capacity for Mangochi Diocese,EUR,"32,500.00",0,published,Active,"32,500.00",34,2011-12-22
+342,WATSAN & FOOD for 3 villages Mozambique,EUR,"34,936.00",4,published,Active,"34,936.28",502,2011-12-23
+343,Improving home based care in Chikwawa    ,EUR,"32,500.00",4,published,Active,"32,500.00",294,2011-12-27
+344,Warning of tuberculosis ,EUR,"38,000.00",1,published,Active,"38,000.00",503,2012-01-02
+346,Improving access to health care in Cameroon,EUR,"243,933.00",0,published,Completed,"243,933.00",517,2012-01-02
+347,Aqua Sana Corpore Sanum 2,EUR,"216,732.00",1,published,Active,"216,732.00",511,2012-01-03
+348,Electronic medical records and HMIS project,EUR,"139,036.36",0,published,Completed,"139,036.00",34,2012-01-04
+350,Sustainable Sanitation systems in communities,EUR,"62,006.78",8,published,Active,"62,006.78",275,2012-01-16
+351,Cost effective means of financing WASH ,EUR,"134,200.00",32,published,Active,"185,000.00",275,2012-01-16
+352,Renforcement des capacitÃ©s des acteurs ,EUR,"164,500.00",26,published,Active,"164,500.00",536,2012-01-16
+353,Effective teaching-learning processes by ICT,EUR,"60,035.00",26,published,Active,"60,035.00",319,2012-01-19
+354,ITELE for ICT,EUR,"39,568.00",11,published,Active,"39,568.00",319,2012-01-19
+355,Improving Learning Outcomes through ICT,EUR,"36,090.00",3,published,Active,"36,090.00",1665,2012-01-19
+356,School leadership and governance project,EUR,"15,000.00",7,published,Active,"15,000.00",34,2012-01-19
+357,Strengthening a literate society,EUR,"60,871.00",23,published,Active,"60,871.00",535,2012-01-20
+360,WASH Facilities at Kajiado Schools,EUR,"38,851.00",2,published,Active,"38,851.00",543,2012-01-24
+361,Improving Communal Health Through WASH,EUR,"66,139.00",7,published,Active,"66,139.00",546,2012-01-24
+362,Water en Sanitatie Dessa Scholen 2012-2015,EUR,"124,440.00",0,published,Active,"57,311.00",185,2012-01-24
+363,Facilitating FED value chain development,EUR,"100,500.00",12,published,Active,"100,500.00",544,2012-01-24
+364,WASH in Gorkha and Baglung,EUR,"450,000.00",10,published,Active,"450,000.00",518,2012-01-25
+365,Mzuzu Diocese C4C ICT project,EUR,"32,500.00",8,published,Completed,"32,500.00",34,2012-01-25
+366,WASH Sustainability through Women Led MFI,EUR,"231,375.00",21,published,Active,"231,375.00",13,2012-01-25
+367,"SWASH in Birendranagar, Surkhet",EUR,"208,490.00",44,published,Active,"208,490.00",13,2012-01-25
+368,Crop Price Information for Bolivian Farmers,EUR,"12,000.00",0,published,H,0.00,456,2012-01-25
+369,Yao Paukou,USD,350.00,0,published,Active,350.10,846,2012-01-26
+370,N'Dri Koffi Erneste,USD,400.00,0,published,Active,399.77,538,2012-01-26
+371,Kan Victor Yao,USD,350.00,0,published,Active,350.36,538,2012-01-26
+372,Kanga Marcellin Kouadio,USD,350.00,0,published,Active,350.16,846,2012-01-26
+373,Kouassi Louis Konan,USD,350.00,0,published,Active,350.06,538,2012-01-26
+374,Yao Emile Koffi,USD,350.00,1,published,Active,350.25,540,2012-01-26
+375,N'Goran Simon Boni ,USD,350.00,0,published,Active,349.58,846,2012-01-26
+376,Souleymane Daouda,USD,350.00,0,published,Active,350.15,538,2012-01-26
+377,Yao Paul N'Guessan ,USD,875.00,1,published,Active,882.90,539,2012-01-26
+378,N'Goran Michel Kra ,USD,400.00,0,published,Active,400.46,538,2012-01-26
+379,KouamÃ© Maurice N'Guessan ,USD,350.00,0,published,Active,349.77,540,2012-01-26
+380,Kouadio Brou,USD,350.00,0,published,Active,350.13,846,2012-01-26
+381,N'Guessan Bertin Konan,USD,350.00,0,published,Active,349.62,538,2012-01-26
+382,Yao Mathurin Kouame,USD,700.00,1,published,Active,699.77,539,2012-01-26
+384,Health Advocacy Project,EUR,"250,000.00",1,published,Active,"250,000.00",421,2012-01-26
+385,ACDEP ICTs in Healthcare Delivery ,EUR,"118,381.00",13,published,Active,"118,381.00",273,2012-01-26
+386,Scaling-up using CLTS in Kenya,EUR,"950,000.00",3,published,Active,"950,000.00",95,2012-01-27
+387,Upscaling sanitation with community credit,EUR,"109,207.00",5,published,Active,"109,207.00",275,2012-01-27
+388,"WASH Alliance project, AMREF in Ethiopia ",EUR,"1,245,000.00",3,published,Active,"1,245,000.00",275,2012-01-27
+389,Rwenzori WASH Alliance Program,EUR,"536,128.00",4,published,Active,"536,128.00",559,2012-01-27
+390,Traditional and Modern ICT for Samburu,EUR,"28,666.00",1,published,Active,"28,666.00",272,2012-01-30
+391,WatSan voorzieningen voor kinderen in Nepal,EUR,"27,937.00",6,published,Completed,"27,951.42",562,2012-01-30
+392,GLOW-Guided learning on Water and Sanitation,EUR,"40,660.00",13,published,Completed,0.00,35,2012-01-30
+393,Dawa Eresa Subsurface and Sand Dam project,EUR,"37,746.00",1,published,Active,"37,746.00",730,2012-01-30
+394,Introducing 3R in impact area of DWA,EUR,"40,660.00",3,published,Completed,0.00,464,2012-01-30
+395,"Schoon drinkwater, geen gezeik!",EUR,"600,000.00",4,published,Active,"600,023.82",207,2012-01-31
+396,Integration of ICT on Value Chain,EUR,"95,410.00",5,published,Active,"95,410.00",272,2012-01-31
+397,Eau HygiÃ¨ne et Assainissement ,EUR,"9,640.76",3,published,Active,"9,640.64",405,2012-02-01
+398,Rainwater Harvesting Capacity Center,EUR,"55,201.00",7,published,Completed,0.00,730,2012-02-01
+399,Fair economic development,EUR,"137,737.00",1,published,Active,"137,737.00",570,2012-02-01
+400,Servicios y comercializaciÃ³n con uso de TICs,EUR,"126,185.00",7,published,Active,"126,185.00",572,2012-02-02
+401,"Eau, hygiÃ¨ne et assainissement",EUR,"23,000.00",1,published,Active,"23,000.00",597,2012-02-03
+402,Integration of ICT in vocational courses,EUR,"60,904.00",7,published,Active,"60,904.00",319,2012-02-03
+403,Institutional Strengthening of SearNet,EUR,"47,485.00",1,published,Completed,0.00,464,2012-02-06
+404,Feasibility Study for Rainwater Harvesting,EUR,"22,000.00",1,published,Completed,0.00,35,2012-02-06
+405,Sistema de InformaciÃ³n y ComunicaciÃ³n  ,EUR,"61,500.00",22,published,Active,"61,500.00",578,2012-02-06
+406,Reduction of maternal mortality through ICT,EUR,"137,000.00",7,published,Active,"137,000.00",583,2012-02-07
+408,Desarrollo econÃ³mico y TICs,EUR,"104,499.99",2,published,Active,"104,500.00",405,2012-02-07
+409,Microfinanzas y TICs I,EUR,"115,008.25",6,published,Active,"116,008.00",34,2012-02-09
+410,Training Zambia's next generation of teachers,EUR,"75,000.00",0,published,Active,"75,000.00",34,2012-02-10
+411,CareerLink,EUR,"5,000.00",0,published,Active,"5,000.00",272,2012-02-15
+412,JÃ³venes promueven Ecoferias con uso de TICs,EUR,"126,500.00",2,published,Active,"126,500.00",592,2012-02-16
+413,"Eau, hygiÃ¨ne et assainissement - AED",EUR,"12,355.00",2,published,Active,"12,355.00",405,2012-02-16
+414,The Education Support Network,EUR,"20,000.00",33,published,Active,"20,000.00",594,2012-02-17
+415,Verbetering van WASH in 10 Maasai dorpen,EUR,"835,991.00",4,published,H,"577,089.15",444,2012-02-17
+416,School-to-school coaching in Zambia,EUR,"140,570.00",54,published,Active,"140,570.00",598,2012-02-17
+417,Enhacing youth employment opportunities ,EUR,"15,000.00",3,published,Active,"15,000.00",294,2012-02-18
+418,Creating job opportunities for Zambia's youth,EUR,"25,000.00",2,published,Active,"25,000.00",148,2012-02-18
+420,Technology in Distance Education in Zambia,EUR,"15,000.00",7,published,Active,"15,000.00",34,2012-02-21
+421,WASH project in Southern Ethiopia,EUR,"49,775.00",1,published,Completed,"49,775.00",601,2012-02-21
+422,Young people making viable career choices ,EUR,"10,000.00",2,published,Active,"10,000.00",34,2012-02-21
+423,Farmer Entrepreneurship,EUR,"105,000.00",1,published,Active,"105,000.00",34,2012-02-23
+425,ICT Capacity Building for HOMENET,EUR,"38,318.00",0,published,H,0.00,503,2012-02-28
+426,Inclusion for deaf people in Colombia trough ,EUR,"38,147.00",0,published,H,26.00,607,2012-02-28
+427,Scale up of Sustainable Water Access,EUR,"2,048,730.00",4,published,H,"1,349,779.00",43,2012-02-29
+428,1 slum 100 computers Project,EUR,"35,541.00",1,published,H,0.00,609,2012-03-01
+431,N'ZuÃ© Yao,USD,500.00,0,published,Active,499.70,538,2012-03-09
+432,"SKB, cibles et productrices d'informations ",EUR,"63,506.08",31,published,Active,"63,506.24",328,2012-03-12
+433,@mkoullel,EUR,"12,604.00",16,published,Active,"12,604.00",272,2012-03-14
+434,Dispositif d'information JÃ¨kawili ka dunkafa ,EUR,"100,043.00",2,published,Active,"100,043.00",34,2012-03-14
+435,PROVIA ASACOM,EUR,"21,162.22",11,published,Active,"25,195.00",369,2012-03-14
+436,Voix des Femmes ,EUR,"66,756.77",14,published,Active,"66,757.00",294,2012-03-19
+437,Building the Ethiopian WASH Alliance,EUR,"29,546.00",4,published,Active,"29,546.00",625,2012-03-26
+438,AccÃ¨s Ã  l'infor pr la Prod Agric et au marchÃ©,EUR,"143,228.14",2,published,Active,"143,228.14",34,2012-03-26
+439,Environmental Sustinability pilot in Rwambu,EUR,"71,468.37",3,published,Completed,0.00,464,2012-03-26
+440,Raising awareness on rainwater harvesting,EUR,"14,232.00",9,published,Completed,0.00,35,2012-03-26
+441,"Projet de collecte d'eau de pluie, Koulikoro",EUR,"29,667.00",0,published,Completed,0.00,35,2012-03-26
+443,Projet collecte d'eau de pluie Ã  Bandiagara,EUR,"20,317.00",0,published,Completed,0.00,630,2012-03-26
+444,CECEP Mali,EUR,"910,490.00",4,published,Completed,0.00,2286,2012-03-26
+445,Projet de collecte d' eau de pluie Ã  Sikasso,EUR,"87,192.00",4,published,Completed,0.00,464,2012-03-27
+446,Etude technique dâ€™avant-projet,EUR,"18,400.00",1,published,Completed,0.00,633,2012-03-27
+447,E-mainstreaming for DWA Mali,EUR,"33,624.00",3,published,Completed,0.00,474,2012-03-27
+448,EducaciÃ³n en comunidades rurales de Cusco,EUR,"100,850.00",4,published,Active,"100,850.00",34,2012-03-27
+449,FormaciÃ³n Docente EIB con TIC,EUR,"36,388.74",11,published,Active,"83,085.00",635,2012-03-27
+450,TIC en el proceso de enseÃ±anza-aprendizaje,EUR,"236,513.45",7,published,Active,"236,513.00",319,2012-03-27
+451,Northern Uganda WASH Alliance Project,EUR,"1,323,000.00",2,published,Active,"1,323,000.00",95,2012-03-28
+453,Training of WorldCoaches,EUR,"2,614.00",24,published,Active,"2,613.70",53,2012-03-29
+455,Bike4School Kenia and Uganda,EUR,"124,259.00",1,published,Archived,"41,420.00",106,2012-03-29
+456,Partnership in WASH services delivery   ,EUR,"27,798.00",24,published,Active,"27,798.00",275,2012-04-02
+457,6T project: Water tanks for Nakuru,EUR,"45,000.00",2,published,Active,"45,000.00",43,2012-04-03
+458,Safe drinking water for rural Thai children,EUR,"4,500.00",1,published,Completed,"4,500.07",91,2012-04-03
+459,Upscaling CLTS for Healthy Communities ,EUR,"30,457.00",5,published,Active,"37,749.00",521,2012-04-04
+460,Archaeological Capacity Building in Malawi,EUR,"18,275.00",9,published,H,"10,282.01",622,2012-04-10
+461,Youth entrepreneurship & job creation Zambia,EUR,"6,061.00",6,published,H,"2,613.70",53,2012-04-12
+462,Northern Region WASH Programme ,EUR,"604,331.82",23,published,Active,"604,332.00",275,2012-04-12
+464,Dutch WASH Alliance in Hararghe & Dire Dawa ,EUR,"93,141.00",5,published,Active,"93,141.00",405,2012-04-16
+465,Manhood Community & Schools Heritage Project,EUR,"15,000.00",4,published,H,"4,000.00",360,2012-04-17
+466,Smartboards and tablets for Zambian children,EUR,"6,000.00",12,published,H,"2,613.70",53,2012-04-19
+467,Community Water and Sanitation Project,EUR,"132,289.00",0,published,H,"65,604.57",1151,2012-04-24
+468,PHAST project,EUR,"456,000.00",3,published,Active,"136,227.00",557,2012-04-24
+469,Implementing an IWRM process in Mashuru,EUR,"56,459.00",1,published,Active,"56,459.00",8,2012-04-25
+471,Building the Ghana WASH Alliance,EUR,"52,066.32",1,published,Active,"52,066.66",275,2012-04-26
+472,ICT FOR EDUCATIONAL DEVELOPMENT (ICT-FED),EUR,"65,930.00",12,published,Active,"65,930.00",319,2012-05-02
+473,Project Water4Tomorrow,EUR,"39,000.00",2,published,H,"26,000.00",663,2012-05-09
+474,Health & Sanitation project,EUR,"497,997.00",4,published,Active,"497,997.00",480,2012-05-10
+475,Health Village: WASH Monitoring Perspective,EUR,"111,591.00",267,published,Active,"111,591.00",479,2012-05-10
+476,Ensure access to safe water and sanitation,EUR,"588,246.00",57,published,Completed,"588,246.00",476,2012-05-10
+477,Creating an enabling environment for WASH,EUR,"230,717.00",15,published,Active,"230,717.00",481,2012-05-10
+479,Building the Kenya WASH Alliance,EUR,"22,035.00",7,published,Active,"22,035.00",670,2012-05-16
+480,Protect and Respect,EUR,"262,868.00",3,published,Active,"50,000.00",273,2012-05-16
+483,Identidad y capacidades comunicativas,EUR,"207,283.79",6,published,Active,"207,283.50",168,2012-05-19
+484,Establishing production center for GNC,EUR,"104,825.00",0,published,H,"87,100.00",672,2012-05-22
+485,Mainstreaming ICT in EDucation in Nkwanta,EUR,"44,860.00",16,published,Active,"44,860.00",319,2012-05-24
+487,"Knowledge Management and Learning, Uganda WA",EUR,"90,000.00",3,published,Active,"90,000.00",638,2012-05-29
+488,Community-based WASH Project in Nepal,EUR,"60,854.00",4,published,Active,"61,000.00",405,2012-05-29
+489,Water for Life project in Ethiopia,EUR,"82,000.00",0,published,Active,"82,000.00",678,2012-05-29
+490,Integrated WASH project for Acholi Sub region,EUR,"115,000.00",20,published,Active,"115,000.00",405,2012-05-30
+494,Kajiado WASH Programm,EUR,"70,000.00",2,published,Active,"79,000.00",413,2012-06-12
+495,Sustainable progress in WASH,EUR,"584,000.00",15,published,Active,"226,893.00",20,2012-06-12
+496,Community Health Programme N-W Bangladesh,EUR,"889,794.00",0,published,Completed,"889,794.00",693,2012-06-13
+497,Communication Knowledge Management Initiative,EUR,"16,000.00",4,published,Active,"16,000.00",405,2012-06-13
+498,Beautiful Cetinje,EUR,"3,600,000.00",6,published,H,"790,009.50",696,2012-06-15
+499,Workplace based SMS quiz for health education,EUR,"8,000.00",0,published,Completed,"8,000.00",294,2012-06-18
+500,SMS to raise HIV/AIDS awareness among youth,EUR,"21,242.32",0,published,Active,"21,242.32",294,2012-06-18
+501,SMS for reproductive health in Ghana,EUR,"32,539.00",0,published,Active,"32,539.00",747,2012-06-18
+502,SMS for reproductive health in Kenya,EUR,"52,861.00",0,published,Active,"52,861.00",294,2012-06-18
+506,SMS to improve HIV treatment adherence,EUR,"62,994.86",0,published,Completed,"62,994.87",217,2012-06-18
+507,Engaging constituents with mobile polls,EUR,"32,300.00",0,published,Completed,"32,300.00",750,2012-06-18
+508,Increasing uptake of HIV treatment using SMS,EUR,"14,000.00",0,published,Completed,"14,000.00",294,2012-06-19
+509,Mobile multiple choice quiz for better health,EUR,"12,214.06",0,published,Completed,"12,214.07",294,2012-06-19
+511,SMS for reproductive health in Tanzania,EUR,"15,459.00",0,published,Active,"15,458.99",294,2012-06-19
+512,SMS to improve uptake of male circumcision,EUR,"6,966.54",0,published,Active,"6,966.53",294,2012-06-19
+513,Data gathering among blood donors through SMS,EUR,"32,525.52",0,published,Active,"32,525.50",753,2012-06-19
+514,SMS-based questionnaire for behavioral change,EUR,"7,806.57",0,published,Completed,"7,806.57",294,2012-06-19
+515,Data collection to strengthen public health,EUR,"89,000.00",0,published,Active,"89,000.00",754,2012-06-19
+516,SMS quiz for awareness on Malaria & HIV/AIDS,EUR,"7,500.00",0,published,Completed,"7,500.00",294,2012-06-19
+517,Improving TB treatment adherence using SMS,EUR,"5,414.00",0,published,Completed,"5,414.00",764,2012-06-19
+518,Workplace based messaging for HIV prevention,EUR,"32,271.13",0,published,Completed,"32,271.13",294,2012-06-19
+519,SMS for better maternal and child service ,EUR,"10,000.00",0,published,Completed,"10,000.00",274,2012-06-19
+520,Monitoring of public services through SMS,EUR,"90,000.00",0,published,Active,"90,000.00",294,2012-06-19
+521,SMS to enhance budget accountability,EUR,"110,000.00",0,published,Completed,"110,000.00",294,2012-06-19
+522,Qirui Children's Rehabilitation Center,USD,"5,000.00",2,published,Completed,"5,000.00",52,2012-06-20
+523,Shunyi Sun's Children's Village,USD,"5,000.00",1,published,Completed,"5,000.00",124,2012-06-20
+524,Clean Water for Children with Disabilities,USD,"25,000.00",1,published,Completed,"25,000.00",124,2012-06-20
+525,UN Aral Sea Programme,EUR,"3,840,449.82",110,published,Active,"3,840,449.82",717,2012-06-20
+526,Loita Maasai 4 Change,EUR,"89,162.00",10,published,Active,"89,162.00",34,2012-06-20
+528,Low-Emission Development Path,USD,"1,050,500.00",60,published,H,"950,500.00",428,2012-06-22
+529,Water Sanitation and Hygiene Project,EUR,"61,000.00",1,published,H,"36,508.82",405,2012-06-25
+530,SMS polls to collect data on public opinion,EUR,"2,272.00",0,published,Completed,"2,272.00",294,2012-06-25
+532,SMS & IVR to improve family planning services,EUR,"41,599.63",0,published,Completed,"41,599.63",294,2012-06-25
+533,Support on WASH of communities in Miyo woreda,EUR,"74,562.00",0,published,Completed,0.00,614,2012-06-25
+534,Reinforce les capacitÃ©s des acteurs communaux,EUR,"94,205.00",0,published,Active,"94,205.00",275,2012-06-25
+535,Creating awareness on water scarcity with SMS,EUR,"1,802.00",0,published,Completed,"1,802.00",294,2012-06-25
+536,Improving handwashing practices through SMS,EUR,"27,728.80",0,published,Completed,"27,729.14",294,2012-06-26
+537,SMS & IVR improving maternal and child health,EUR,"26,319.49",0,published,Completed,"26,319.61",294,2012-06-26
+538,SMS for lower mortality rates & TB prevalence,EUR,"12,034.94",0,published,Active,"12,034.93",294,2012-06-26
+539,Encouraging recycling through SMS campaigns,EUR,"2,668.00",0,published,Active,"2,668.00",294,2012-06-26
+540,SMS surveys to evaluate solar systems ,EUR,"3,726.55",0,published,Completed,"3,726.54",808,2012-06-26
+541,Addressing environmental problems through SMS,EUR,"2,675.57",0,published,Active,"2,676.00",294,2012-06-26
+542,SMS reminders to improve treatment adherence,EUR,"187,000.00",0,published,Completed,"187,000.00",779,2012-06-26
+544,Lâ€™amÃ©lioration des services WASH,EUR,"18,950.00",2,published,Active,"18,950.00",577,2012-06-27
+545,Rain Water Harvesting in Nepal ,EUR,"188,381.84",5,published,Active,"84,816.93",35,2012-06-28
+546,Using ICT to improve quality in education,EUR,"32,000.00",0,published,Active,"32,000.00",1825,2012-06-28
+547,Border Management Programme in Central Asia  ,EUR,"36,295,405.00",4,published,Active,"36,295,405.00",428,2012-07-02
+548,"Think Globally, Develop Locally ",EUR,"1,550,000.00",13,published,H,"750,000.00",724,2012-07-02
+549,Community Midwife Education,EUR,"187,179.00",1,published,Active,"187,179.00",273,2012-07-03
+550,Kandahar Institute of Health Science ,EUR,"475,266.00",0,published,Active,"475,266.00",273,2012-07-03
+551,Energy and Biomass ,EUR,"14,560,000.00",50,published,Active,"14,560,000.00",714,2012-07-03
+552,Archaeology in Telford Town Park,EUR,"18,000.00",11,published,H,"7,000.00",506,2012-07-04
+553,Interactive SMS quiz for HIV/AIDS awareness,EUR,950.00,0,published,Completed,950.00,294,2012-07-04
+554,SMS adherence program for HIV treatment,EUR,"4,896.20",0,published,Completed,"4,896.20",294,2012-07-04
+555,WASH Media Forum ,EUR,"66,869.37",5,published,Active,"165,125.00",8,2012-07-04
+558,Protection de la tÃªte de la riviÃ¨re MÃ©krou,EUR,"125,007.00",2,published,Active,"56,058.00",405,2012-07-06
+559,Promoting sustainable access to WASH services,EUR,"35,000.00",2,published,Active,"35,000.00",405,2012-07-12
+560,No hesitation for fresh water and sanitation,EUR,"23,287.00",2,published,Completed,"23,287.00",43,2012-07-12
+561,Data collection surveys by SMS & call centre,EUR,"5,620.00",0,published,Completed,"5,620.00",294,2012-07-12
+562,Using SMS to improve malaria treatment,EUR,"120,695.24",0,published,Completed,"120,695.25",294,2012-07-12
+563,SMS Alert Service for the Dutch in Uganda,EUR,"1,000.00",0,published,Active,"1,000.00",789,2012-07-13
+564,Data collection by SMS & call centre surveys,EUR,"20,626.00",0,published,Completed,"20,626.00",294,2012-07-13
+565,Improving malaria curing with our call centre,EUR,"7,722.00",0,published,Active,"7,722.00",808,2012-07-13
+566,Biodiversity conservation,EUR,"776,800.00",43,published,Active,"776,800.00",428,2012-07-16
+567,Reproductive health care for adolescents,EUR,"350,061.00",0,published,Archived,"350,061.00",273,2012-07-16
+568,Improvement of water gravity system Matowo,EUR,"20,078.00",7,published,Active,"20,078.00",1114,2012-07-17
+569,Alleviating energy poverty utilizing SMS,EUR,"1,000.00",0,published,Active,"1,000.00",294,2012-07-18
+570,Student research on health data collection,EUR,"1,500.00",0,published,Completed,"1,500.00",792,2012-07-18
+571,WaterSchools in Kibera,EUR,"12,500.00",2,published,Active,"12,500.00",43,2012-07-20
+572,Introducing 3R in impact areas of DWA,EUR,"16,500.00",1,published,Completed,0.00,35,2012-07-20
+573,HIV in Uzbekistan,USD,"23,018,844.00",14,published,Active,"23,018,844.00",428,2012-07-23
+574,Football for Water in Kisumu ,EUR,"978,077.00",50,published,Active,"978,077.00",1060,2012-07-24
+575,Football for Water in Migori,EUR,"406,579.00",56,published,Active,"406,579.00",816,2012-07-24
+576,"WaterSchools at Ebukoolo Primary School,",EUR,"12,500.00",5,published,Active,"12,500.00",381,2012-07-26
+577,Schoon water voor plattelandsbevolking Benin,EUR,"6,750.00",9,published,Completed,"6,763.82",168,2012-07-27
+578,Kake II Water Project,EUR,"85,035.00",3,published,H,"32,000.00",106,2012-07-31
+583,The world of the Baure,EUR,"20,000.00",0,published,H,"12,000.00",454,2012-08-14
+584,National advocacy project teenage pregnancy,EUR,"73,918.00",0,published,Archived,"73,918.00",1337,2012-08-16
+585,ICT for Quality Education in Malawi,EUR,"48,594.00",0,published,Active,"48,594.00",319,2012-08-17
+586,Pastoralists Education and Empowerment,EUR,"84,886.00",8,published,Active,"84,886.00",272,2012-08-17
+587,Promoting quality education through ICT,EUR,"170,848.00",4,published,Active,"170,848.00",817,2012-08-22
+588,Replacement of hand pumps on existing wells,EUR,"5,190.00",1,published,Active,"5,190.00",815,2012-08-22
+590,Rainwater Collection and Water Purification,EUR,"123,750.00",6,published,Completed,"123,750.00",825,2012-08-27
+592,Itumbu WASH project,EUR,"9,507.00",0,published,Active,"9,506.62",8,2012-08-30
+593,Gender-sensitive national policies,USD,"500,000.00",1,published,H,"85,800.00",428,2012-08-30
+594,Third Phase Drinking Water Project Ghana,EUR,"45,775.00",8,published,H,"28,408.82",113,2012-08-30
+595,6T project: Water Tanks for Nakuru 2,EUR,"156,800.00",2,published,Active,"156,960.00",43,2012-09-03
+596,Water provision in Sekamuli,EUR,"39,125.00",3,published,Active,"39,125.00",43,2012-09-03
+597,Aqua Sana Corpore Sanum 3,EUR,"34,665.00",2,published,Completed,"34,664.81",511,2012-09-03
+598,Socio-economic recovery initiatives,EUR,"442,760.00",12,published,Completed,"442,760.00",827,2012-09-04
+600,Community-led WASH and Safe Motherhood ,EUR,"108,884.00",2,published,Active,"108,884.04",43,2012-09-10
+602,Digital preservation of historic battlefields,EUR,"5,630.00",15,published,H,0.00,744,2012-09-10
+603,Safe water supply by low cost manual drilling,EUR,"41,768.00",9,published,H,"34,520.56",848,2012-09-10
+604,Kimi Sara,USD,350.00,0,published,Active,350.33,540,2012-09-11
+605,Koffi Jules Djah,USD,350.00,1,published,Active,350.09,538,2012-09-11
+606,Brou KouamÃ©,USD,350.00,1,published,Active,349.80,539,2012-09-11
+607,Amoin Kouakou,USD,350.00,1,published,Active,349.74,540,2012-09-11
+608,Kouassi RÃ©nÃ© Allou,USD,350.00,0,published,Active,350.36,538,2012-09-11
+610,Waterproject stichting Namelok,EUR,"9,500.00",2,published,Completed,"9,499.73",815,2012-09-11
+611,Buffer zone rock art documentation,EUR,"7,500.00",9,published,H,"1,500.00",360,2012-09-11
+612,Voorzieningen Rathanapala school Sri Lanka,EUR,"6,320.00",4,published,Completed,"6,319.82",113,2012-09-13
+613,Underwater Cultural Heritage in Vietnam,EUR,"12,000.00",21,published,H,"1,273.13",842,2012-09-17
+614,Tulip filters in Mozambique,EUR,"35,000.00",0,published,H,"23,345.00",102,2012-09-18
+615,Safe water in Deh Sabz,EUR,"550,000.00",3,published,Active,"550,000.00",207,2012-09-19
+616,Rock art monitoring and education groups,EUR,"10,600.00",15,published,H,"1,000.00",744,2012-09-21
+617,Sante & Developpement,EUR,"951,000.00",0,published,H,"280,000.82",949,2012-09-25
+618,Lake Victoria Water and Sanitation Initiative,EUR,"3,086,211.69",0,published,Active,"3,086,211.69",856,2012-10-02
+619,Lake Victoria Water and Sanitation Initiative,EUR,"421,194.94",0,published,Active,"421,194.94",856,2012-10-02
+620,Lake Victoria Water and Sanitation Initiative,EUR,"393,112.30",0,published,Active,"393,112.30",856,2012-10-02
+621,Lake Victoria Water and Sanitation Initiative,EUR,"1,608,390.44",1,published,Active,"1,608,390.50",860,2012-10-02
+622,Lake Victoria Water and Sanitation Initiative,EUR,"462,764.60",0,published,Active,"462,764.60",856,2012-10-02
+623,Water & Sanitation project in Homa Bay town,EUR,"266,756.04",0,published,Active,"266,756.10",856,2012-10-02
+624,Lake Victoria Water and Sanitation Initiative,EUR,"1,612,254.46",0,published,Active,"1,612,254.46",856,2012-10-02
+625,Lake Victoria Water and Sanitation Initiative,EUR,"825,303.82",4,published,Active,"825,303.82",856,2012-10-02
+626,Lake Victoria Water and Sanitation Initiative,EUR,"768,838.31",0,published,Active,"768,838.31",856,2012-10-02
+627,Lake Victoria Water and Sanitation Initiative,EUR,"641,383.72",0,published,Active,"641,383.72",856,2012-10-03
+628,Lake Victoria Water and Sanitation Initiative,EUR,"930,135.24",0,published,Active,"930,135.24",464,2012-10-03
+629,Lake Victoria Water and Sanitation Initiative,EUR,"641,383.72",0,published,Active,"641,383.72",856,2012-10-03
+630,Lake Victoria Water and Sanitation Initiative,EUR,"1,898,317.19",1,published,Active,"1,898,317.20",865,2012-10-03
+631,Lake Victoria Water and Sanitation Initiative,EUR,"1,519,870.22",0,published,Active,"1,519,870.22",856,2012-10-03
+632,Lake Victoria Water and Sanitation Initiative,EUR,"367,118.63",0,published,Active,"367,118.63",864,2012-10-03
+633,Lake Victoria Water and Sanitation Initiative,EUR,"1,112,360.48",12,published,Active,"1,112,360.48",1133,2012-10-03
+634,Lake Victoria Water and Sanitation Initiative,EUR,"303,003.17",0,published,Active,"303,003.17",864,2012-10-03
+635,Lake Victoria Water and Sanitation Initiative,EUR,"814,228.33",5,published,Active,"814,228.38",864,2012-10-03
+636,ICT4E Champions for change,EUR,"21,500.00",0,published,H,9.50,319,2012-10-04
+637,Global Compact Armenia,EUR,"415,000.00",0,published,Active,"415,000.00",428,2012-10-08
+638,Evidence based Roma inclusion policies,EUR,"1,644,508.00",3,published,Active,"1,644,508.00",428,2012-10-09
+639,Irrigated Land Reclamation in Uzbekistan,USD,"799,252.00",11,published,Active,"799,252.00",875,2012-10-09
+640,Kakamega East Water and Sanitation Phase 3,EUR,"347,840.00",1,published,H,"264,000.00",444,2012-10-12
+641,Breaking the barriers to community health,EUR,"171,300.00",0,published,Archived,"57,003.82",949,2012-10-12
+642,Women in Local Democracy,EUR,"600,000.00",5,published,Active,"600,000.00",1354,2012-10-12
+643,Malawi Rock Art Expedition,EUR,"4,000.00",10,published,H,0.00,360,2012-10-15
+644,Rwenzori Integrated School WASH Project,EUR,"451,299.00",3,published,H,"130,266.02",43,2012-10-15
+645,"Waterproject, 8 boreholes Upper East Ghana",EUR,"49,800.00",2,published,Completed,"49,800.00",43,2012-10-16
+646,Water for Life Buoye,EUR,"147,532.00",2,published,Active,"173,000.00",43,2012-10-17
+647,"Latrines for schools in Gedaref, Sudan 2013",EUR,"43,100.00",10,published,Completed,"46,723.00",444,2012-10-17
+648,Strengthening Protected areas system,EUR,"1,538,000.00",3,published,Active,"1,538,000.00",428,2012-10-17
+649,Partnership for capacity building (WOPs),EUR,"1,338,505.00",0,published,Active,"1,338,505.00",851,2012-10-19
+650,Water Operator Partnership to build capacity,EUR,"5,147,112.00",0,published,Active,"4,347,484.23",881,2012-10-19
+651,Partnership for sanitation improvement,EUR,"2,500,000.00",0,published,Active,"2,500,000.00",1013,2012-10-19
+652,Partnership for performance enhancement,EUR,"398,009.99",0,published,Active,"398,010.00",1013,2012-10-19
+653,Football for Water in Ghana,EUR,"2,681,264.00",54,published,Active,"2,681,273.50",521,2012-10-19
+654,Water supply in Yungwe-Bikore project area,EUR,"58,910.00",1,published,Completed,"58,910.00",43,2012-10-22
+655,"Water supply in Mutera project area, Mutera 2",EUR,"45,742.00",1,published,Completed,"45,742.00",885,2012-10-22
+656,Promote improved access to drinking water,EUR,"40,000.00",1,published,Active,"40,000.00",43,2012-10-22
+657,Football for Water in Manica,EUR,"969,558.00",44,published,Active,"969,558.00",678,2012-10-23
+659,Udhruh Archaeological Project,EUR,"3,280.00",6,published,H,954.41,361,2012-10-24
+660,Functionality of Rural water Systems in Kenya,EUR,"201,396.33",4,published,Active,"201,396.00",887,2012-10-24
+661,Partners Capacity Strengthening,EUR,"444,447.33",0,published,Active,"444,447.33",881,2012-10-24
+662,WASH Alliance Policy Influencing Programme,EUR,"135,000.00",0,published,Active,"135,000.00",475,2012-10-30
+663,Partners Capacity Strengthening,EUR,"444,447.33",0,published,Active,"444,447.33",888,2012-10-31
+664,Partners Capacity Strengthening,EUR,"444,447.33",0,published,Active,"444,447.33",888,2012-10-31
+665,Partnership for performance enhancement,EUR,"398,009.99",0,published,Active,"398,010.00",881,2012-11-01
+666,Partnership for performance enhancement,EUR,"398,009.99",0,published,Active,"398,010.00",1013,2012-11-01
+667,Partnership for capacity building (WOPs),EUR,"669,252.50",0,published,Active,"669,252.50",204,2012-11-01
+668,"Water for Life project Angoche, Mozambique",EUR,"173,000.00",2,published,Active,"173,000.00",679,2012-11-01
+669,Building the Mali WASH Alliance,EUR,"29,476.00",1,published,Active,"29,476.00",901,2012-11-01
+670,Local Governance Support,USD,"2,140,000.00",25,published,Active,"2,140,000.00",902,2012-11-05
+672,Indie Group and co water shop pilot business,EUR,"56,620.00",42,published,H,"32,117.82",905,2012-11-06
+673,Ecosystem Stability on Degraded Land,USD,"1,227,158.89",8,published,Active,"1,227,158.89",902,2012-11-08
+674,Wateroogst,EUR,"21,378.00",6,published,Completed,9.50,35,2012-11-09
+675,Kruger Digital Rock Art Enhancement Project,EUR,"15,000.00",9,published,H,0.00,744,2012-11-13
+676,"Unite for Body Rights, Kenya",EUR,"7,055,000.00",12,published,Active,"7,055,000.00",970,2012-11-13
+677,Tales from Udhruh,EUR,"3,320.00",11,published,H,202.74,361,2012-11-16
+678,Shape Your New Development Thinking!,USD,"50,038.00",11,published,Completed,"50,038.28",428,2012-11-16
+679,Disaster Risk Management in Kyrgyzstan,USD,"582,392.00",15,published,Active,"582,392.00",428,2012-11-19
+680,Busia Community Water Enterprises,EUR,"332,600.00",1,published,H,"69,448.50",913,2012-11-19
+681,GLEauBe-WASH,EUR,"122,500.00",2,published,Active,"122,500.00",568,2012-11-19
+682,LEauCAL-WASH,EUR,"1,715,535.00",1,published,H,"1,417,618.00",168,2012-11-19
+684,Lake. Victoria Water & Sanitation Initiative,EUR,"362,651.00",6,published,Active,"362,651.00",856,2012-11-20
+685,Business Development Support Services,EUR,"44,723.00",13,published,Active,"44,723.00",34,2012-11-20
+686,Lake Victoria Water & Sanitation Initiative,EUR,"565,088.80",0,published,Active,"565,088.80",856,2012-11-20
+687,Heritage Without Borders in Turkmenistan,EUR,"7,810.00",5,published,H,"6,257.50",915,2012-11-20
+688,Lake Victoria Water & Sanitation Initiative,EUR,"677,467.00",0,published,Active,"677,467.00",464,2012-11-20
+689,Lake Victoria Water & Sanitation Initiative,EUR,"302,855.00",0,published,Active,"302,855.00",923,2012-11-20
+690,Lake Victoria Water & Sanitation Initiative,EUR,"917,959.39",0,published,Active,"917,959.38",926,2012-11-20
+691,Lake Victoria Water & Sanitation Initiative,EUR,"407,981.33",0,published,Active,"407,981.33",922,2012-11-21
+692,Lake Victoria Water & Sanitation Initiative,EUR,"967,631.00",0,published,Active,"967,631.00",932,2012-11-21
+693,Lake Victoria Water & Sanitation Initiative,EUR,"637,527.74",0,published,Active,"675,779.41",924,2012-11-21
+694,Lake Victoria Water & Sanitation Initiative,EUR,"283,950.62",0,published,Active,"283,950.62",856,2012-11-21
+695,Lake Victoria Water & Sanitation Initiative,EUR,"689,610.40",0,published,Active,"689,610.39",464,2012-11-21
+696,Lake Victoria Water & Sanitation Initiative,EUR,"935,864.82",0,published,Active,"935,864.82",922,2012-11-21
+697,Kenya,EUR,"431,750.00",13,published,Active,"431,750.00",939,2012-11-21
+700,Enabling Access to Health Services,EUR,"101,670.00",0,published,Active,"101,670.00",273,2012-11-27
+702,Adolescents accessing SRH-care,EUR,"156,613.00",0,published,Active,"156,613.00",555,2012-11-27
+703,MWA-LAP: Mexico,USD,"7,815,000.00",14,published,Active,"7,815,000.00",969,2012-11-28
+704,Strengthening Nursing and Health in SADC,EUR,"76,741.00",0,published,Archived,"76,741.00",273,2012-11-29
+705,Egypt,EUR,"388,500.00",1,published,Active,"388,500.00",1683,2012-11-30
+706,Indonesia ,EUR,"399,250.00",8,published,Active,"399,250.00",937,2012-11-30
+707,Mali ,EUR,"468,000.00",13,published,Active,"468,000.00",948,2012-11-30
+708,Mozambique ,EUR,"233,000.00",5,published,Active,"233,000.00",464,2012-11-30
+709,Palestinian Territories,EUR,"205,000.00",9,published,Active,"205,000.00",948,2012-11-30
+710,South Africa,EUR,"410,000.00",5,published,Active,"410,000.00",641,2012-11-30
+711,Surinam,EUR,"421,500.00",3,published,Active,"421,500.00",641,2012-11-30
+716,Establish Rights2Health Services thr. Adocacy,EUR,"300,000.00",2,published,Active,"300,000.00",949,2012-12-04
+722,Finally FP-devices for girls in Nkhotakota,EUR,"172,500.00",0,published,Active,"172,500.00",949,2012-12-04
+725,Enhancing girls' education through ICT,EUR,"15,118.00",3,published,Active,"15,118.00",966,2012-12-07
+727,TESO North School and Community WASH Project,EUR,"495,893.00",5,published,H,"450,151.48",113,2012-12-11
+732,Koffi Lucien Konan,USD,350.00,0,published,Active,355.34,540,2012-12-22
+733,Ahou Pelagie Konan,USD,350.00,2,published,Active,350.28,538,2012-12-22
+734,Bohoussou Blaise Yao,USD,350.00,1,published,Active,350.00,540,2012-12-22
+735,Kouadio RaphaÃ©l Koffi,USD,350.00,1,published,Active,350.00,846,2012-12-22
+736,Amoin Konan,USD,"1,050.00",1,published,Active,"1,051.53",540,2012-12-22
+737,N'Dri Yao,USD,350.00,1,published,Active,350.00,538,2012-12-24
+738,Kouadio FÃ©lix Akpo,USD,350.00,1,published,H,261.12,540,2012-12-24
+739,Koffi Lucien Konan,USD,350.00,0,published,Active,349.77,540,2012-12-24
+740,Kouadio Jean B. Kouadio,USD,350.00,0,published,Active,350.00,539,2012-12-24
+741,Konan Kouadio,USD,"1,100.00",0,published,Active,"1,100.49",540,2012-12-24
+756,Amani FranÃ§ois N'Guessan,USD,350.00,1,published,Active,350.00,540,2013-01-08
+757,Kouadio Kouassi,USD,350.00,0,published,Active,350.00,539,2013-01-08
+758,Kouassi Jean-Piierre KouamÃ©,USD,"1,100.00",0,published,Active,"1,100.01",540,2013-01-08
+759,Kouakou Lazare Koffi,USD,350.00,0,published,Active,350.53,538,2013-01-08
+760,N'Guessan BÃ©,USD,"1,770.00",0,published,Active,"1,769.73",540,2013-01-08
+761,Koffi Kouakou,USD,350.00,0,published,Active,350.85,538,2013-01-08
+762,Yao Mathias N'Zi,USD,350.00,1,published,Active,350.13,540,2013-01-08
+763,Kouadio FÃ©lix DÃ©gbÃ©,USD,330.00,1,published,Active,330.34,540,2013-01-08
+764,Koffi Julien Klo,USD,350.00,0,published,Active,350.92,540,2013-01-08
+765,N'Dri AndrÃ© Yobouet,USD,350.00,0,published,Active,352.03,540,2013-01-08
+766,Renforcement des capacitÃ©s ,EUR,"20,473.00",3,published,Active,"20,473.00",660,2013-01-09
+767,"Access to safe water, sanitation and hygiene ",EUR,"68,119.00",3,published,Active,"68,120.00",405,2013-01-10
+768,"Coastal area Water, Sanitation and Hygiene",EUR,"81,715.00",0,published,Active,"79,748.00",275,2013-01-10
+769,Life-WASH,EUR,"72,124.00",4,published,Active,"72,124.82",1022,2013-01-14
+770,Intervention Efforts in WASH,EUR,"65,438.00",0,published,Active,"65,438.00",405,2013-01-14
+771,WASH project for Bwambo H.C. community,EUR,"96,476.00",1,published,H,"69,080.00",1053,2013-01-14
+772,Yao Amalaman Adou,USD,350.00,0,published,Active,349.96,846,2013-01-15
+774,Using barcodes to link data in Burkina Faso,EUR,"10,000.00",0,published,Active,"10,000.00",969,2013-01-16
+775,"Unite for Body Rights, Bangladesh",EUR,"5,461,000.00",1,published,Active,"5,461,000.00",912,2013-01-16
+776,Water points inventory using FLOW,EUR,"7,500.00",0,published,Active,"7,500.00",876,2013-01-16
+778,Water scheme management in Kellem Wellega,EUR,"100,000.00",2,published,Active,"100,000.00",43,2013-01-22
+779,Largest scale mHealth project in Africa,EUR,"306,685.00",0,published,Active,0.00,753,2013-01-23
+781,"Unite for Body Rights, Ethiopia",EUR,"3,614,000.00",0,published,Active,"3,614,000.00",912,2013-01-25
+782,"Unite for Body Rights, India",EUR,"2,916,000.00",0,published,Active,"2,916,000.00",912,2013-01-25
+783,Waterproject 2013,EUR,"200,000.00",5,published,H,"90,015.82",43,2013-01-30
+784,"Clean Water for Kwaloza Village, Malawi",EUR,"3,508.00",1,published,Completed,"3,508.00",110,2013-01-30
+785,Monitoring health projects with Akvo FLOW,EUR,"11,309.39",0,published,Completed,"11,309.39",272,2013-01-31
+786,MWA-LAP: Honduras,USD,"1,192,000.00",18,published,Active,"1,192,000.00",136,2013-01-31
+787,MWA-LAP: Guatemala,USD,"942,000.00",24,published,Active,"942,000.00",1048,2013-01-31
+788,MWA-LAP: Nicaragua,USD,"1,020,000.00",21,published,Active,"1,020,000.00",969,2013-01-31
+789,MWA-LAP: Colombia,USD,"399,469.00",42,published,Active,"399,469.00",1054,2013-01-31
+790,WaSH program in Rural Bangladesh,EUR,"435,070.00",26,published,H,"235,231.61",8,2013-02-04
+791,Water @ Goshenap,EUR,"9,000.00",3,published,Completed,"9,000.00",43,2013-02-04
+792,"Eau, HygiÃ¨ne et Assainissement",EUR,"8,542.00",12,published,Active,"8,542.00",569,2013-02-04
+793,"Unite for Body Rights, Malawi",EUR,"3,870,000.00",0,published,Active,"3,870,000.00",8,2013-02-06
+795,Olgulului River Project,EUR,"403,200.00",0,published,H,"35,754.80",106,2013-02-07
+796,Football for Water in Kakamega,EUR,"229,352.00",1,published,Active,"229,352.00",823,2013-02-07
+798,Football for Water in Kilifi,EUR,"203,380.00",9,published,Active,"203,380.00",1060,2013-02-07
+799,Football for Water in Mombasa,EUR,"160,986.00",0,published,Active,"160,986.00",818,2013-02-07
+800,Football for Water in Nakuru,EUR,"471,690.00",14,published,Active,"471,690.00",816,2013-02-07
+801,Football for Water in Trans-Nzoia,EUR,"364,366.00",1,published,Active,"364,366.00",830,2013-02-07
+802,"10 and 11 Abbey Square, Chester",EUR,"2,000.00",0,published,Active,"2,000.00",506,2013-02-12
+803,Oyu Tolgoi ,USD,"850,000.00",0,published,Active,"850,000.00",360,2013-02-12
+804,Mongolian Monuments,USD,"800,000.00",0,published,Active,"800,000.00",360,2013-02-12
+805,Marampa Sierra Leone,USD,"35,000.00",0,published,Completed,"35,000.00",360,2013-02-12
+806,46 Cheyne Walk,EUR,"35,000.00",0,published,Active,"35,000.00",360,2013-02-12
+807,"Land at Bardon Grange, Leicestershire",EUR,"50,000.00",0,published,Completed,"50,000.00",506,2013-02-12
+808,Havannah Mill,EUR,"10,000.00",0,published,Completed,"10,000.00",506,2013-02-12
+810,Improved Water Sanitation and Hygiene,USD,"10,000,000.00",0,published,Active,"10,000,000.00",1061,2013-02-13
+814,Malima Well Restoration,USD,"1,600.00",2,published,Completed,"1,600.00",1071,2013-02-13
+819,"Water,Food&Sanitation for School + Community",EUR,"46,494.00",3,published,H,"18,570.82",43,2013-02-13
+822,Urban WASH II in Monrovia,EUR,"500,000.00",2,published,Completed,"500,000.00",1083,2013-02-14
+823,Child Friendly School WASH Project I,USD,0.00,1,published,Completed,"600,000.00",1074,2013-02-14
+829,In the footsteps of Henry Morton Stanley,EUR,"1,156.00",0,published,Active,"1,156.10",1097,2013-02-15
+830,Scanning and Mapping the WASH Situation,EUR,"88,271.00",0,published,Active,"88,271.00",405,2013-02-15
+831,Football for Water in Tolon ,EUR,"125,051.00",1,published,Active,"125,051.00",523,2013-02-18
+833,Football for Water in Tamale,EUR,"271,720.00",11,published,Active,"271,720.00",1060,2013-02-18
+834,Football for Water in Accra,EUR,"648,023.00",35,published,Active,"648,023.00",1060,2013-02-18
+835,Football for Water in Kumbungu,EUR,"292,704.00",5,published,Active,"292,704.00",1034,2013-02-18
+836,Football for Water in Adenta,EUR,"449,456.00",0,published,Active,"449,456.00",1034,2013-02-18
+837,Football for Water in LADMA,EUR,"163,860.00",0,published,Active,"163,860.00",556,2013-02-18
+838,Football for Water in GA South District,EUR,"142,012.00",3,published,Active,"142,012.00",1034,2013-02-18
+839,Football for Water in Elmina,EUR,"32,772.00",0,published,Active,"32,772.00",1059,2013-02-18
+840,Rainwater harvesting in Guinee Bissau 2,EUR,"15,900.00",0,published,H,"11,690.82",150,2013-02-19
+841,Ninhoro TourÃ©,USD,350.00,1,published,Active,350.72,540,2013-02-20
+842,Mamadou Kourouma,USD,350.00,0,published,H,193.40,539,2013-02-20
+843,LaourÃ© Alagba,USD,350.00,0,published,H,202.56,540,2013-02-20
+844,Assouan Bertin Kouassi,USD,350.00,0,published,H,216.90,539,2013-02-20
+845,KouamÃ© Nestor N'Da,USD,350.00,0,published,H,251.66,540,2013-02-20
+846,Kouassi Sylvain Kouame,USD,350.00,1,published,Active,351.43,539,2013-02-20
+847,Adjoumani Kossonou Emmanuel Abochi,USD,350.00,0,published,H,348.44,540,2013-02-20
+848,Kouadio Koffi,USD,350.00,0,published,Active,350.69,846,2013-02-20
+849,KouamÃ© Alphonse Kouassi,USD,350.00,1,published,Active,350.00,540,2013-02-20
+850,Kouakou Kouakou,USD,350.00,1,published,Active,350.00,540,2013-02-20
+851,Teacher training and educating 200 children,EUR,"40,500.00",0,published,H,"35,000.00",1096,2013-02-22
+852,Friends of Udhruh 2013,EUR,"4,550.00",10,published,Active,"4,550.78",361,2013-02-22
+853,Environmental Monitoring in Montenegro,EUR,"770,775.00",15,published,Active,"770,775.00",428,2013-02-26
+854,Commune de Badougou Nafadji,USD,"16,000.00",0,published,H,"8,700.00",428,2013-02-26
+855,Football for Water in Sagnarigu,EUR,"219,528.00",0,published,Active,"219,528.00",556,2013-02-27
+860,Football for Water in Nampula,EUR,"879,025.00",5,published,Active,"879,025.00",1139,2013-02-28
+861,Football for Water in Central Gonja,EUR,"336,138.00",0,published,Active,"336,138.00",1034,2013-02-28
+864,Football for Water in Tete,EUR,"780,368.00",5,published,Active,"780,368.00",1693,2013-02-28
+865,Enhance youth participation through SMS,EUR,"170,000.00",0,published,Active,"170,000.00",294,2013-03-01
+867,"Unite for Body Rights, Uganda",EUR,"3,399,000.00",0,published,Active,"3,399,000.00",912,2013-03-05
+868,"Unite for Body Rights, Indonesia",EUR,"3,766,000.00",0,published,Active,"3,766,000.00",1157,2013-03-05
+869,"Unite for Body Rights, Pakistan",EUR,"3,038,000.00",82,published,Active,"3,038,000.00",1036,2013-03-05
+870,"Unite for Body Rights, Tanzania",EUR,"6,127,000.00",0,published,Active,"6,127,000.00",1043,2013-03-05
+871,Commune de Farabana,USD,"16,000.00",0,published,H,"8,700.00",1113,2013-03-06
+872,Commune de KamalÃ© Soba,USD,"16,000.00",0,published,H,"8,700.00",168,2013-03-06
+873,Commune de Bancoumana,USD,"16,000.00",0,published,H,"8,700.00",168,2013-03-06
+874,Commune de Kirina,USD,"16,000.00",0,published,H,"8,700.00",428,2013-03-06
+875,Commune de KollÃ©,USD,"16,000.00",0,published,H,"8,700.00",168,2013-03-06
+876,Construction d'une case de santÃ©,USD,"13,845.00",0,published,H,0.00,846,2013-03-07
+877,Reducing gender based violence by SMS,EUR,850.00,1,published,Active,850.00,1106,2013-03-07
+878,El Salvador 2011: Uniting stakeholders,EUR,"192,725.00",0,published,Completed,"192,725.00",273,2013-03-07
+879,Development of ICT for Outdoor Destinations,EUR,"498,957.16",1,published,Active,"498,957.16",1136,2013-03-12
+880,MWA-KALDRR-WASH program,USD,"9,831,126.00",77,published,Active,"9,831,126.00",43,2013-03-19
+881,MWA-Ethiopia Program,USD,"12,421,256.00",0,published,Active,"12,421,256.00",1048,2013-03-19
+894,Senjeh Well Restoration,USD,"1,600.00",0,published,H,70.00,1064,2013-03-26
+895,Diaspora Engagement for Economic Development,EUR,"1,193,382.00",32,published,Active,"1,250,382.00",1147,2013-03-26
+896,Gboto Well Restoration,USD,"1,600.00",0,published,H,70.00,1064,2013-03-26
+897,Behsee Town Well Restoration,USD,"1,600.00",0,published,Completed,"1,600.00",1064,2013-03-26
+898,Lebeh Well Restoration,USD,"1,600.00",0,published,Completed,"1,600.00",1064,2013-03-26
+899,James Town Well Restoration,USD,"1,600.00",0,published,Completed,"1,600.00",1064,2013-03-26
+900,Pifley Town Well Restoration,USD,"1,600.00",0,published,Completed,"1,600.00",1064,2013-03-26
+902,Tomah Town Well Restoration,USD,"1,600.00",0,published,Completed,"1,600.00",1064,2013-03-26
+907,Billy Town Well Restoration,USD,"1,600.00",0,published,H,70.00,1064,2013-03-26
+910,Amalu Well Restoration,USD,"1,600.00",0,published,Completed,"1,600.00",1064,2013-03-26
+912,Bonjeh Well Restoration,USD,"1,600.00",0,published,H,870.00,1064,2013-03-26
+913,Mellisma Well Restoration,USD,"1,600.00",0,published,Completed,"1,600.00",1064,2013-03-26
+915,Sibaye Qorke Spring Development Project ,EUR,"34,331.00",6,published,Active,"34,331.00",1163,2013-04-08
+916,MWA and TCCAF Ethiopia,USD,"1,514,216.00",0,published,Active,"1,514,216.00",1199,2013-04-10
+917,Building Energy Efficient Public Facilities,USD,"13,584,765.00",8,published,Active,"13,584,765.00",428,2013-04-16
+918,Social Innovation and Volunteerism,USD,"635,100.00",14,published,Active,"635,100.00",428,2013-04-17
+919,Education for 100 kids,EUR,"5,000.00",0,published,Active,"5,000.00",1181,2013-04-18
+920,"Kids clean water, clean sanitation",EUR,"5,000.00",0,published,Active,"5,000.00",726,2013-04-18
+921,PHASE,USD,"1,475,000.00",2,published,Active,"1,475,000.00",428,2013-04-22
+922,WaterAid Rural WASH Project,USD,"1,440,000.00",2,published,Active,"1,440,000.00",1065,2013-04-24
+923,"Safe water projects Wolisso, SWShoa, Ethiopia",EUR,"10,000.00",0,published,Active,"10,000.00",1175,2013-05-01
+924,Business Forum of Uzbekistan ,USD,"1,019,453.00",12,published,Active,"1,019,453.00",428,2013-05-02
+925,NWSHPC Training Support to NGOs,EUR,"1,500.00",0,published,Completed,"1,500.00",1661,2013-05-07
+926,Universal Periodic Review Follow-up Facility,EUR,"223,000.00",3,published,Active,"223,000.00",428,2013-05-10
+927,Scaling up water filter sales in Bali,EUR,"7,057.00",0,published,Active,"7,063.00",1179,2013-05-12
+928,Integrating ICT in Kenya ,EUR,"40,000.00",0,published,Active,"40,000.00",405,2013-05-21
+929,"Water for life project Acherensua, Ghana",EUR,"117,529.00",4,published,Active,"117,529.00",1059,2013-05-21
+931,Explosive Ordnance Destruction,EUR,"3,837,537.00",57,published,Active,"3,837,537.00",428,2013-05-29
+932,Good Governance for Social Justice ,EUR,"5,318,899.00",2,published,Active,"5,318,899.00",1354,2013-05-29
+933,Accelerating Sanitation and Water for All I,USD,"1,500,000.00",3,published,Active,"1,500,000.00",1083,2013-05-31
+934,Multipurpose Drinking Water System,EUR,"49,647.00",7,published,H,"10,056.28",405,2013-06-04
+935,Community Health and Development Project,EUR,"41,747.00",4,published,H,"35,000.00",275,2013-06-04
+936,Support to Anti-Corruption Efforts in Kosovo ,EUR,"2,160,000.00",10,published,Active,"2,160,000.00",1230,2013-06-10
+937,Provision of water in Payawa Boma,EUR,"9,850.00",3,published,Completed,"9,850.00",168,2013-06-11
+938,Water and sanitation Bandung Barat Regency,EUR,"72,699.00",0,published,Active,"72,699.00",968,2013-06-12
+940,Health Child,EUR,"166,395.00",23,published,Active,"166,395.00",274,2013-06-18
+941,ROSSA,EUR,"920,044.00",10,published,Active,"920,044.00",43,2013-06-18
+942,"Water for life Chi Tucuo Cheto, Mozambique",EUR,"210,000.00",1,published,Active,"210,000.00",678,2013-06-18
+943,School Adoption Program Ghana,EUR,"40,463.00",17,published,Active,"40,481.00",43,2013-06-24
+975,Strategic plan to strengthen capacity,EUR,"47,118.00",0,published,Completed,"47,118.00",1272,2013-06-25
+976,Building Women networks for peace promotion,EUR,"95,000.00",0,published,Active,"95,000.00",955,2013-06-25
+977,Permanent platform for peace,EUR,"441,571.00",3,published,Active,"441,571.00",1241,2013-06-25
+978,Improving women's living conditions,EUR,"73,200.00",0,published,Active,"73,200.00",273,2013-06-25
+979,Supporting improvement of rice value chain,EUR,"187,600.00",0,published,Active,"187,600.00",464,2013-06-25
+980,Development of a Market Information System,EUR,"167,655.00",0,published,Active,"167,655.00",1099,2013-06-25
+981,Promote business opportunities for women,EUR,"98,703.00",0,published,Active,"98,703.00",1278,2013-06-25
+982,Representation & visibility of Pastoral women,EUR,"84,800.00",0,published,Active,"84,800.00",1279,2013-06-25
+983,Getting girls out of prostitution,EUR,"139,139.00",1,published,Active,"139,139.00",959,2013-06-25
+984,Women's leadership for peace,EUR,"110,517.00",0,published,Active,"110,517.00",464,2013-06-25
+985,Enhance value chain for Pastoralists,EUR,0.00,0,published,Completed,0.00,273,2013-06-25
+986,Assessing the economic value of pastoralism,EUR,"95,863.00",0,published,Active,"95,863.00",1284,2013-06-25
+987,CMDRR Pilot Study Kandhamal,EUR,"12,508.00",0,published,Active,"12,508.00",1285,2013-06-25
+988,Introducing Performance Based Financing,EUR,"6,174,045.00",0,published,Active,"6,174,045.00",1653,2013-06-25
+989,Exchange knowledge on health insurance,EUR,"50,000.00",0,published,Active,"50,000.00",1287,2013-06-25
+990,Promoting Microfinance in South Sudan,EUR,"294,650.00",0,published,Active,"294,650.00",950,2013-06-25
+991,See and treat programme on cervical cancer,EUR,"214,370.00",0,published,Active,"214,370.00",814,2013-06-25
+992,Understanding food storage systems,EUR,"14,313.00",0,published,Completed,"14,313.00",1099,2013-06-25
+993,Strenthening women leadership,EUR,0.00,0,published,Completed,0.00,273,2013-06-25
+994,Support to the MaliFood Crisis 2012,EUR,"200,000.00",0,published,Active,"200,000.00",273,2013-06-25
+995,Lobby for an agricultural and trade policy,EUR,"132,500.00",0,published,Active,"132,500.00",464,2013-06-25
+996,Land and Livelihoods research,EUR,"13,500.00",0,published,Completed,"13,500.00",1099,2013-06-25
+997,CMDRR Impact Study Asia / India 2012,EUR,0.00,0,published,Completed,0.00,273,2013-06-25
+998,Promotion of Universal Safe Motherhood,EUR,"500,000.00",0,published,Active,"500,000.00",273,2013-06-25
+999,Linking and Learning PfR Ethiopia 2012,EUR,"8,340.00",0,published,Completed,"8,340.00",1659,2013-06-25
+1000,Improve living conditions in communities,EUR,"256,556.00",0,published,Active,"256,556.00",960,2013-06-25
+1001,Train communities on disaster risk reduction,EUR,"64,101.00",0,published,Completed,"64,101.00",1302,2013-06-25
+1002,Education for tri-people children,EUR,"241,318.00",1,published,Active,"241,318.00",1303,2013-06-25
+1003,Performance Based Financing training,EUR,"59,677.00",0,published,Completed,"59,677.00",273,2013-06-25
+1004,Research project,EUR,"229,105.00",0,published,Active,"229,105.00",949,2013-06-25
+1005,Syria - Refugees in Lebanon,EUR,"250,000.00",0,published,Active,"250,000.00",1306,2013-06-25
+1006,farming and risk reduction,EUR,"13,873.00",0,published,Active,"13,873.00",464,2013-06-25
+1007,Nkhoma Safe Motherhood Scale Up,EUR,"113,053.00",5,published,Active,"113,053.00",1297,2013-06-25
+1008,Care and support for streetchildren,EUR,"336,236.00",1,published,Active,"336,236.00",273,2013-06-25
+1009,integrating farming and risk reduction,EUR,"15,609.00",0,published,Active,"15,609.00",464,2013-06-25
+1010,Evaluation disaster response after drought,EUR,"40,729.00",0,published,Archived,"40,729.00",273,2013-06-25
+1011,Promoting birth registration,EUR,"153,000.00",0,published,Active,"153,000.00",949,2013-06-25
+1012,Rehabilitating smallholder coffee sector,EUR,"333,900.00",0,published,Active,"333,900.00",1099,2013-06-25
+1013,'Views from the Frontline' 2013,EUR,"20,000.00",0,published,Active,"20,000.00",273,2013-06-25
+1014,Learning on Disaster Risk Reduction,EUR,"112,000.00",0,published,Completed,"112,000.00",961,2013-06-25
+1015,Supporting farmers in disaster risk reduction,EUR,"19,830.00",1,published,Active,"19,830.00",273,2013-06-25
+1016,Re-establishing Basic Health Care Services,EUR,"238,572.00",0,published,Active,"238,572.00",1318,2013-06-25
+1017,Integrating farming and risk reduction,EUR,"20,000.00",0,published,Active,"20,000.00",961,2013-06-25
+1018,Supporting the potato value chain development,EUR,"195,009.00",0,published,Active,"195,009.00",1320,2013-06-25
+1019,Framework for dialogue,EUR,"150,000.00",0,published,Active,"150,000.00",273,2013-06-25
+1020,Cordaid - Women Inc. Award,EUR,"20,000.00",0,published,Completed,"20,000.00",962,2013-06-25
+1021,Expanding production of wild honey and cashew,EUR,"287,436.00",0,published,Active,"287,436.00",273,2013-06-25
+1022,Making 12 communities more disaster resilient,EUR,"198,098.00",1,published,Active,"198,098.00",1324,2013-06-25
+1023,to provide basic information for farmers,EUR,"14,644.00",0,published,Active,"14,644.00",1325,2013-06-25
+1024,Develop a sustainable coffee chain,EUR,"207,372.00",0,published,Active,"207,372.00",1099,2013-06-25
+1025,Health investment fund,EUR,"400,000.00",0,published,Active,"400,000.00",464,2013-06-25
+1026,Performance Based Financing in Health,EUR,"250,000.00",6,published,Active,"250,000.00",949,2013-06-25
+1027,La paritÃ© au Sud Kivu,EUR,"28,279.00",0,published,Active,"28,279.00",464,2013-06-25
+1028,Mitigating Social + Environmental Impacts of,EUR,0.00,0,published,Completed,0.00,273,2013-06-25
+1029,Dealing with extreme drought in the Sahel,EUR,"200,000.00",0,published,Completed,"200,000.00",273,2013-06-25
+1030,Creating dialogue between communities,EUR,"90,000.00",1,published,Active,"90,000.00",464,2013-06-25
+1031,Against the proliferation of small arms,EUR,"80,248.00",0,published,Active,"80,248.00",464,2013-06-25
+1032,Midwifery Education in Balkh province,EUR,"388,000.00",0,published,Active,"388,000.00",464,2013-06-25
+1033,Improving safe deliveries,EUR,"130,703.00",0,published,Active,"130,703.00",1334,2013-06-25
+1034,Professional development for midwives,EUR,"182,892.00",0,published,Active,"182,892.00",464,2013-06-25
+1035,Midwifery Education in Nangarhar,EUR,"370,817.00",0,published,Active,"370,817.00",273,2013-06-25
+1036,Teenage pregnancies,EUR,"93,577.00",0,published,Active,"93,577.00",949,2013-06-25
+1037,Reproductive health services for teenagers,EUR,"96,253.00",0,published,Active,"96,253.00",949,2013-06-25
+1038,Reproductive health care for teenagers,EUR,"52,715.00",0,published,Active,"52,715.00",1306,2013-06-25
+1039,Maternal care for rural women,EUR,"113,018.00",0,published,Active,"113,018.00",668,2013-06-25
+1040,Improvement of Health Care,EUR,"3,455,850.00",2,published,Active,"3,455,850.00",949,2013-06-25
+1041,Performance Based Financing course,EUR,"47,999.00",0,published,Active,"47,999.00",1341,2013-06-25
+1042,Stimulating school performance,EUR,"675,435.00",0,published,Active,"675,435.00",959,2013-06-25
+1043,Efficient Health Committees,EUR,"120,687.00",0,published,Active,"120,687.00",949,2013-06-25
+1044,Pharmacy in a Box,EUR,"341,568.00",0,published,Active,"341,568.00",949,2013-06-25
+1045,Working on sustainable microfinance,EUR,"20,900.00",0,published,Completed,"20,900.00",953,2013-06-25
+1046,Promote the rights of mining communities,EUR,"59,988.00",0,published,Completed,"59,988.00",273,2013-06-25
+1047,"Women farmers, a force to be reckoned with",EUR,"489,809.00",1,published,Active,"489,809.00",1101,2013-06-25
+1048,Drought affected communities Gal'ad District,EUR,"45,000.00",0,published,Active,"45,000.00",273,2013-06-25
+1049,Impact Study CMDRR Central America 2012,EUR,"9,678.00",0,published,Completed,"9,678.00",1348,2013-06-25
+1050,Protection and Education for children,EUR,"137,349.00",0,published,Active,"137,349.00",959,2013-06-25
+1051,Understanding women security issues,EUR,"265,470.00",0,published,Active,"265,470.00",273,2013-06-25
+1052,Empowerment of pastoralist women,EUR,"189,195.00",0,published,Active,"189,195.00",1351,2013-06-25
+1053,Stop violence against girls,EUR,"301,898.00",2,published,Active,"301,898.00",949,2013-06-25
+1054,Women make a stand for a safe Congo,EUR,"150,000.00",0,published,Active,"150,000.00",1353,2013-06-25
+1055,Mental&psychosocial support after earthquake,EUR,"754,219.00",0,published,Completed,"754,219.00",1311,2013-06-25
+1056,Women lead the way towards peace,EUR,"159,945.00",0,published,Active,"159,945.00",273,2013-06-25
+1057,Safe Maternity - Strong Community,EUR,"208,144.00",3,published,Completed,"208,144.00",273,2013-06-25
+1058,Protecting livelihoods against the water,EUR,"234,013.00",1,published,Active,"234,013.00",1358,2013-06-25
+1059,Participation in forum on climate finance,EUR,"11,195.00",0,published,Completed,"11,195.00",464,2013-06-25
+1060,Training partners in disaster risk reduction,EUR,"164,285.00",1,published,Active,"164,285.00",464,2013-06-25
+1061,The impact of extracting raw materials,EUR,"60,000.00",1,published,Active,"60,000.00",960,2013-06-25
+1062,Improvement of agricultural products,EUR,"553,457.00",1,published,Active,"553,457.00",273,2013-06-25
+1063,Enhancing smallholder farmers resilience to c,EUR,0.00,0,published,Completed,0.00,273,2013-06-25
+1064,Strengthening community participation,EUR,"100,517.00",0,published,Active,"100,517.00",1364,2013-06-25
+1065,Influencing European policy on security,EUR,"36,000.00",0,published,Active,"36,000.00",1365,2013-06-25
+1066,Studies on human resources & health insurance,EUR,"91,642.00",0,published,Active,"91,642.00",949,2013-06-25
+1067,Calling a halt to environmental degradation,EUR,"44,932.00",0,published,Completed,"44,932.00",1576,2013-06-25
+1068,Rehabilitation & empowerment of cooperatives,EUR,"505,678.00",0,published,Active,"505,678.00",1099,2013-06-25
+1069,National Advocacy on Healthcare Service,EUR,"119,868.00",16,published,Active,"119,868.00",273,2013-06-25
+1070,Better healthcare throughout Zimbabwe,EUR,"11,140,200.00",3,published,Active,"11,140,200.00",876,2013-06-25
+1071,Helping the poor access health insurance,EUR,"150,000.00",8,published,Active,"150,000.00",464,2013-06-25
+1072,Women's Health Program,EUR,"370,000.00",0,published,Active,"370,000.00",814,2013-06-25
+1073,Improve local security and justice systems,EUR,"4,353,253.00",0,published,Active,"4,353,253.00",1370,2013-06-25
+1074,DebtAidBuddy Programme,EUR,"25,000.00",0,published,Completed,"25,000.00",273,2013-06-25
+1075,Reduction of maternal mortality through ICT,EUR,"50,000.00",0,published,Completed,"50,000.00",273,2013-06-25
+1076,Maternal and Child Health Advocacy Project,EUR,"155,000.00",0,published,Active,"155,000.00",273,2013-06-25
+1077,Community managed local health services,EUR,"303,091.00",3,published,Active,"303,091.00",1324,2013-06-25
+1078,ICT for Accessible and Efficient Healthcare,EUR,"399,222.00",9,published,Active,"399,222.00",949,2013-06-25
+1079,280 children growing up with foster families,EUR,"438,056.00",0,published,Active,"438,056.00",959,2013-06-25
+1080,Keeping children off the streets,EUR,"110,588.00",0,published,Active,"110,588.00",1342,2013-06-25
+1081,Fight against HIV/AIDS,EUR,"46,114,136.00",14,published,Active,"46,114,136.00",737,2013-06-25
+1082,Critical citizens vital for fair extractives,EUR,"1,948,098.00",0,published,Active,"1,948,098.00",960,2013-06-25
+1083,Burn prevention program,EUR,"40,000.00",0,published,Completed,"40,000.00",464,2013-06-25
+1085,Action for global health,EUR,"136,998.00",0,published,Active,"136,998.00",1389,2013-06-25
+1086,Children underscore their own rights,EUR,"236,452.00",0,published,Active,"236,452.00",959,2013-06-25
+1087,Traditional rangeland management,EUR,"79,140.00",0,published,Active,"79,140.00",1391,2013-06-25
+1088,Protect the nomadic society against drought,EUR,"1,532,310.00",0,published,Active,"1,532,310.00",1395,2013-06-25
+1089,Campaign for more women in local government,EUR,"57,000.00",0,published,Active,"57,000.00",1397,2013-06-25
+1090,Promoting transparency in microfinance sector,EUR,"290,000.00",0,published,Active,"290,000.00",1399,2013-06-25
+1091,Cape Town 2012: Improving housing,EUR,"270,898.00",0,published,Completed,"270,898.00",1632,2013-06-25
+1092,Kisumu 2012: Developing a sanitation project,EUR,"181,356.00",2,published,Completed,"181,356.00",1402,2013-06-25
+1093,Port au Prince 2012: Housing on the agenda,EUR,"187,076.00",0,published,Completed,"187,076.00",1411,2013-06-25
+1094,Working together to create housing solutions,EUR,"1,150,359.00",2,published,Active,"1,150,359.00",464,2013-06-25
+1095,Strengthening Primary Health Care Provision,EUR,"908,950.00",0,published,Active,"908,950.00",464,2013-06-25
+1096,Observatory on mining and social conflict,EUR,"160,000.00",0,published,Active,"160,000.00",464,2013-06-25
+1097,Relief after cyclone Thane,EUR,"72,000.00",0,published,Completed,"72,000.00",961,2013-06-25
+1098,Building leadership within the church,EUR,"50,000.00",0,published,Active,"50,000.00",273,2013-06-25
+1099,Supporting new mothers,EUR,"159,906.00",0,published,Active,"159,906.00",949,2013-06-25
+1100,Primary healthcare Diocese Tombura Yambio,EUR,"387,198.00",0,published,Active,"387,198.00",1654,2013-06-25
+1101,Tri-people Children Development Program,EUR,"562,680.00",5,published,Active,"562,680.00",1417,2013-06-25
+1103,Supporting microfinance for farmers,EUR,"1,000,000.00",0,published,Active,"1,000,000.00",464,2013-06-25
+1104,Investing in microfinance for rural areas,EUR,"2,500,000.00",0,published,Active,"2,500,000.00",1006,2013-06-25
+1105,Microcredit for small farmers,EUR,"800,000.00",0,published,Active,"800,000.00",953,2013-06-25
+1106,Microcredit helps post-war recovery,EUR,"290,000.00",0,published,Active,"290,000.00",1655,2013-06-25
+1107,Promoting a better income for women,EUR,"1,000,000.00",1,published,Active,"1,000,000.00",953,2013-06-25
+1108,Loan for expansion of credit portfolio,EUR,"1,000,000.00",0,published,Active,"1,000,000.00",954,2013-06-25
+1109,"Enhance Community Resilience, Mandera County",EUR,"511,516.00",2,published,Active,"511,516.00",961,2013-06-25
+1110,"Water supply, Mekong Delta, Vietnam",EUR,"9,963,060.00",0,published,Active,"9,963,060.00",1434,2013-06-28
+1111,Anti-Corruption for Development,EUR,"1,368,000.00",16,published,Active,"1,368,000.00",1675,2013-07-03
+1112,Child Friendly School WASH Project II,USD,"450,000.00",1,published,Active,"450,000.00",168,2013-07-09
+1113,Govi Sayura (Farmer's Ocean),EUR,"1,467,604.00",0,published,Active,"601,558.00",1217,2013-07-10
+1114,Shedding Light on Endangered Mutual Heritage,EUR,"660,000.00",7,published,Active,"660,000.00",254,2013-07-12
+1115,Public Monitoring of Administrative Services,EUR,"325,407.17",96,published,Active,"329,231.00",1354,2013-07-16
+1117,The quest for the birthplace of Rembrandt,EUR,"20,000.00",0,published,H,"12,500.00",360,2013-07-25
+1118,Learning how to deal with disability,EUR,"144,407.00",0,published,Active,"144,407.00",959,2013-07-25
+1119,Engaging community in constitutional process,EUR,"346,965.00",0,published,Active,"346,965.00",464,2013-07-25
+1120,More involvement of women in community life,EUR,"201,073.00",0,published,Active,"201,073.00",1241,2013-07-25
+1121,Social protection of vulnerable children,EUR,"83,623.00",0,published,Active,"83,623.00",273,2013-07-25
+1122,Capacity building grant FSS 2013,EUR,"79,400.00",1,published,Active,"79,400.00",950,2013-07-25
+1123,Strengthening Capacity of Peace Committees,EUR,"60,390.00",0,published,Active,"60,390.00",273,2013-07-25
+1124,Strengthening disaster risks reduction,EUR,"323,922.00",0,published,Active,"323,922.00",1358,2013-07-25
+1125,Securing Healthcare in Kapoeta East,EUR,"51,285.00",0,published,Active,"51,285.00",273,2013-07-25
+1126,Awareness on Sexual Reproductive Health,EUR,"100,000.00",2,published,Active,"100,000.00",949,2013-07-25
+1127,Enhancing Peace Building and Cohesion,EUR,"73,358.00",0,published,Active,"73,358.00",961,2013-07-25
+1128,Ecological Farming,EUR,"35,020.00",0,published,Active,"35,020.00",962,2013-07-25
+1129,Caritas emergency programme Sahel 2013,EUR,"500,000.00",0,published,Active,"500,000.00",961,2013-07-25
+1130,A pilot project transforming housing in Haiti,EUR,"160,000.00",0,published,Active,"160,000.00",1643,2013-07-25
+1131,Improve basic health in Zabul province,EUR,"727,686.00",0,published,Active,"727,686.00",949,2013-07-25
+1132,Citizens' Platforms responding to disaster,EUR,"75,475.00",0,published,Active,"75,475.00",273,2013-07-25
+1133,Advocacy for enhanced resilience,EUR,"64,972.00",0,published,Active,"64,972.00",961,2013-07-25
+1134,Health care for Dalits and tribals,EUR,"111,673.00",0,published,Active,"111,673.00",1612,2013-07-25
+1135,Combating drought,EUR,"141,996.00",1,published,Active,"141,996.00",961,2013-07-25
+1136,Improving basic services in Uruzgan,EUR,"1,489,093.00",0,published,Active,"1,489,093.00",273,2013-07-25
+1137,Improve access to information on mining,EUR,"40,642.00",0,published,Completed,"40,642.00",960,2013-07-25
+1138,Pakistan Floods 2011 Sindh,EUR,"354,392.00",0,published,Completed,"354,392.00",1358,2013-07-25
+1139,Supporting local organizations,EUR,"379,102.00",0,published,Completed,"379,102.00",1653,2013-07-25
+1140,Mill Hill missionaries projects,EUR,"67,500.00",0,published,Completed,"67,500.00",962,2013-07-25
+1141,Cape Town 2011: Starting a youth project,EUR,"244,027.00",0,published,Completed,"244,027.00",1633,2013-07-25
+1142,Kisumu 2011: Mapping needs of residents,EUR,"155,350.00",0,published,Completed,"155,350.00",880,2013-07-25
+1143,Prevention and fight against AIDS,EUR,"75,890.00",0,published,Completed,"75,890.00",962,2013-07-25
+1144,Community health service in Gulbarga,EUR,"22,226.00",0,published,Completed,"22,226.00",962,2013-07-25
+1145,Financial support for individuals,EUR,"29,867.00",0,published,Completed,"29,867.00",1636,2013-07-25
+1146,Pigs for Pencils,EUR,"12,500.00",1,published,Completed,"12,500.00",1547,2013-07-25
+1147,Nairobi 2011: Base-line research,EUR,"7,949.00",0,published,Completed,"7,949.00",946,2013-07-25
+1148,Port au Prince 2011: Post-earthquake exchange,EUR,"13,192.00",0,published,Completed,"13,192.00",1460,2013-07-25
+1149,Dissemination of Petroleum Act,EUR,"50,800.00",0,published,Active,"50,800.00",273,2013-07-25
+1150,Community Awareness on recent oil laws,EUR,"61,970.00",0,published,Active,"61,970.00",1598,2013-07-25
+1151,Strategic Plan Zambia Land Alliance,EUR,"130,000.00",0,published,Active,"130,000.00",961,2013-07-25
+1152,Health worker skills upgrading,EUR,"850,000.00",0,published,Active,"850,000.00",949,2013-07-25
+1153,Ensuring Water and Sanitation Facilities,EUR,"1,167,233.00",2,published,Active,"1,167,233.00",1306,2013-07-25
+1154,Loans for 1500 women in 2013,EUR,"50,000.00",0,published,Completed,"50,000.00",464,2013-07-25
+1155,"Partners for Resilience Linking, Learning and",EUR,0.00,0,published,Active,0.00,1576,2013-07-25
+1156,Uruzgan Livestock Development Program 2013,EUR,"320,256.00",0,published,Active,"320,256.00",1099,2013-07-25
+1157,From conflict to market; knowledgedevelopment,EUR,"109,945.00",0,published,Active,"109,945.00",1099,2013-07-25
+1158,Contingency Fund for CMDRR Partners Ethiopia,EUR,"50,000.00",0,published,Active,"50,000.00",1659,2013-07-25
+1159,Ella (singing well) rehabilitation,EUR,"21,439.00",5,published,Active,"21,439.00",1816,2013-07-25
+1160,Reducing the risk of natural hazards,EUR,"117,500.00",0,published,Active,"117,500.00",273,2013-07-25
+1161,Building a Disaster Resilient,EUR,"55,000.00",3,published,Active,"55,000.00",464,2013-07-25
+1162,Community development in remote villages,EUR,"51,669.00",0,published,Active,"51,669.00",1285,2013-07-25
+1163,Mining and human rights in La Guajira,EUR,"50,000.00",0,published,Active,"50,000.00",1500,2013-07-25
+1164,Capacity development for Region des Palmes,EUR,"15,000.00",0,published,Active,"15,000.00",961,2013-07-25
+1165,Community Response for OVC's in North Uganda,EUR,"178,658.00",0,published,Active,"178,658.00",273,2013-07-25
+1166,Research on Inclusive Economic Development,EUR,"106,578.00",0,published,Active,"106,578.00",1617,2013-07-25
+1167,Peace and Children Initiative Facilitation,EUR,"89,000.00",0,published,Active,"89,000.00",961,2013-07-25
+1168,Empowering women human rights defenders,EUR,"117,968.00",0,published,Active,"117,968.00",955,2013-07-25
+1169,Womenâ€™s participation in community life,EUR,"63,669.00",0,published,Active,"63,669.00",1241,2013-07-25
+1170,Strengthening communities,EUR,"317,304.00",0,published,Active,"317,304.00",1241,2013-07-25
+1171,Strengthening a new oil and gas NGO coalition,EUR,"93,511.00",0,published,Active,"93,511.00",464,2013-07-25
+1172,Strengthen the capacity of mediators,EUR,"26,713.00",0,published,Active,"26,713.00",1241,2013-07-25
+1173,Research on corporate abuses of human rights,EUR,"87,911.00",0,published,Active,"87,911.00",464,2013-07-25
+1174,Expanding PublishWhatYouPay in Latin America,EUR,"20,000.00",0,published,Active,"20,000.00",464,2013-07-25
+1175,The Rongdhonu floating hospital,EUR,"262,000.00",0,published,Active,"262,000.00",949,2013-07-25
+1176,Reinforcing health coordination,EUR,"37,964.00",0,published,Active,"37,964.00",1412,2013-07-25
+1177,Gas alert system for affected communities,EUR,"98,142.00",0,published,Active,"98,142.00",960,2013-07-25
+1178,Supporting the Dutch Gender Platform,EUR,"493,000.00",0,published,Active,"493,000.00",955,2013-07-25
+1179,Film as advocacy and sensibilisation tool,EUR,"249,834.00",0,published,Active,"249,834.00",960,2013-07-25
+1180,Integrated maternal health program,EUR,"84,975.00",0,published,Active,"84,975.00",1616,2013-07-25
+1181,Program for equal justice for all,EUR,"30,000.00",0,published,Active,"30,000.00",1241,2013-07-25
+1182,Construction of Cyclone Shelters,EUR,"902,860.00",1,published,Active,"902,860.00",961,2013-07-25
+1183,Performance based financing of health care,EUR,"-800,000.00",0,published,Active,"-800,000.00",273,2013-07-25
+1184,Support for a network of women peacebuilders,EUR,"2,571,288.00",0,published,Active,"2,571,288.00",955,2013-07-25
+1185,Mining and its impact on water resources,EUR,"137,537.00",0,published,Active,"137,537.00",464,2013-07-25
+1186,Women leadership in peace and security,EUR,"150,740.00",1,published,Active,"150,740.00",955,2013-07-25
+1187,Haiti Emergency Aid After Hurricane SANDY,EUR,"300,000.00",0,published,Active,"300,000.00",961,2013-07-25
+1188,Defending Women Human Rights Defenders,EUR,"156,812.00",0,published,Active,"156,812.00",1468,2013-07-25
+1189,CMDRR Project in Mboro and Ngisa (WDG),EUR,"35,021.00",3,published,Active,"35,021.00",961,2013-07-25
+1190,Pakistan Flood Emergency Response Sindh,EUR,"191,537.00",3,published,Active,"191,537.00",1503,2013-07-25
+1191,Education and care for children,EUR,"279,181.00",1,published,Active,"279,181.00",1527,2013-07-25
+1192,Promoting farmer entrepreneurship,EUR,"200,000.00",0,published,Active,"200,000.00",1099,2013-07-25
+1193,Making SRH Services Work for next generation,EUR,"29,644,152.00",1,published,Active,"29,644,152.00",464,2013-07-25
+1194,Study in Cameroon on equity in health care,EUR,"124,136.00",0,published,Active,"124,136.00",949,2013-07-25
+1195,Developing survey tools for data collection,EUR,"94,620.00",0,published,Active,"94,620.00",949,2013-07-25
+1196,El Salvador 2013: Pitching for Citypark,EUR,"196,686.00",4,published,Active,"196,686.00",1552,2013-07-25
+1197,Cape Town 2013: Hard and Soft infrastructure,EUR,"239,416.00",1,published,Active,"239,416.00",1633,2013-07-25
+1198,Kisumu 2013: Housing on the agenda,EUR,"141,506.00",1,published,Completed,"141,506.00",464,2013-07-25
+1199,Nairobi 2013: Innovations in Sanitation,EUR,"104,386.00",0,published,Completed,"104,386.00",43,2013-07-25
+1200,Addis Ababa 2013: Creating an integrated plan,EUR,"58,199.00",0,published,Completed,"58,199.00",1506,2013-07-25
+1201,Guatemala 2013: Exploring partnerships,EUR,"47,915.00",1,published,Active,"47,915.00",464,2013-07-25
+1202,Port au Prince 2013: Affordable Housing,EUR,"221,753.00",0,published,Completed,"221,753.00",946,2013-07-25
+1203,Support to starting entrepreneurs,EUR,"198,588.00",0,published,Active,"198,588.00",273,2013-07-25
+1204,Better care by sharing health care expertise,EUR,"276,500.00",0,published,Active,"276,500.00",1297,2013-07-25
+1205,Consultancy services for projects of PI's,EUR,"50,000.00",0,published,Active,"50,000.00",273,2013-07-25
+1206,Community-Managed Disaster Risk Reduction,EUR,"247,576.00",1,published,Active,"247,576.00",1472,2013-07-25
+1207,Multi-stakeholder meetings,EUR,"27,420.00",0,published,Active,"27,420.00",1341,2013-07-25
+1208,Improved performance of the honey sector,EUR,"66,659.00",0,published,Active,"66,659.00",961,2013-07-25
+1209,Capacity building local organizations,EUR,"306,217.00",0,published,Active,"306,217.00",273,2013-07-25
+1210,Sharing PBF knowledge multi-country,EUR,"198,626.00",0,published,Active,"198,626.00",1340,2013-07-25
+1211,From exit strategy to entry strategy,EUR,"99,500.00",0,published,Active,"99,500.00",273,2013-07-25
+1212,Peace Building Activities,EUR,"76,997.00",0,published,Active,"76,997.00",1581,2013-07-25
+1213,Health support on the basis of performance,EUR,"688,420.00",0,published,Active,"688,420.00",949,2013-07-25
+1214,Improvement of Soil Fertility,EUR,"194,907.00",0,published,Active,"194,907.00",273,2013-07-25
+1215,Women leadership worldwide,EUR,"1,629,412.00",0,published,Active,"1,629,412.00",955,2013-07-25
+1216,Researching and redirecting mining revenues,EUR,"263,287.00",0,published,Active,"263,287.00",464,2013-07-25
+1217,Improving access to quality water,EUR,"814,756.00",0,published,Active,"814,756.00",1306,2013-07-25
+1218,Development opportunities for female farmers,EUR,"68,946.00",0,published,Completed,"68,946.00",1099,2013-07-25
+1219,Strengthening mental health,EUR,"272,223.00",0,published,Completed,"272,223.00",961,2013-07-25
+1220,Consolidating positive achievements,EUR,"63,135.00",0,published,Active,"63,135.00",1241,2013-07-25
+1221,Improving relationships within families,EUR,"601,271.00",0,published,Active,"601,271.00",1241,2013-07-25
+1222,Towards Flood-resistant Communities in Bihar,EUR,"368,025.00",2,published,Active,"368,025.00",273,2013-07-25
+1223,Clean water for Bertoua,EUR,"180,404.00",0,published,Active,"180,404.00",962,2013-07-25
+1224,Street and working children program,EUR,"301,156.00",0,published,Active,"301,156.00",1342,2013-07-25
+1225,Facing the challenges posed by landgrabbing,EUR,"66,600.00",0,published,Active,"66,600.00",464,2013-07-25
+1226,Strengthening justice and peace groups,EUR,"133,930.00",0,published,Active,"133,930.00",464,2013-07-25
+1227,Strengthening health care in South Kivu,EUR,"241,289.00",0,published,Completed,"241,289.00",1340,2013-07-25
+1228,Care and Education for Indigenous children,EUR,"333,381.00",0,published,Active,"333,381.00",1342,2013-07-25
+1229,Strengthening health workers,EUR,"180,000.00",0,published,Active,"180,000.00",1306,2013-07-25
+1230,Traditional Mechanism for Peacebuilding,EUR,"90,500.00",0,published,Active,"90,500.00",1513,2013-07-25
+1231,Support to vulnerable children,EUR,"651,941.00",0,published,Active,"651,941.00",1342,2013-07-25
+1232,Health project CDD-Maroua,EUR,"442,246.00",0,published,Active,"442,246.00",949,2013-07-25
+1233,Strengthening the PublishWhatYouPay-campaign,EUR,"271,068.00",0,published,Completed,"271,068.00",1092,2013-07-25
+1234,Support to families affected by hazards,EUR,"20,000.00",0,published,Completed,"20,000.00",961,2013-07-25
+1235,Disaster Risk Reduction Larique,EUR,"20,000.00",0,published,Completed,"20,000.00",961,2013-07-25
+1236,Promoting the national mining debate,EUR,"49,900.00",0,published,Completed,"49,900.00",960,2013-07-25
+1237,Participation of affected communities,EUR,"138,000.00",0,published,Active,"138,000.00",960,2013-07-25
+1238,Developing a model for community empowerment,EUR,"116,081.00",0,published,Active,"116,081.00",464,2013-07-25
+1239,Health system strengthening through PBF,EUR,"291,418.00",0,published,Active,"291,418.00",1483,2013-07-25
+1240,Resilience building for Women in Borana,EUR,"187,788.00",0,published,Active,"187,788.00",614,2013-07-25
+1241,Strengthening the national debate on mining,EUR,"50,833.00",0,published,Active,"50,833.00",960,2013-07-25
+1242,Reducing food insecurity for rural households,EUR,"217,000.00",0,published,Active,"217,000.00",1603,2013-07-25
+1243,Haiti Survie project 2012,EUR,"19,987.00",0,published,Completed,"19,987.00",961,2013-07-25
+1244,Promoting human rights in Haiti,EUR,"685,266.00",0,published,Active,"685,266.00",1241,2013-07-25
+1245,Microfinance & Climate Smart Agriculture,EUR,"698,184.00",1,published,Active,"698,184.00",953,2013-07-25
+1246,Participation of women in governance,EUR,"209,430.00",1,published,Active,"209,430.00",955,2013-07-25
+1247,Reducing the risk for disasters,EUR,"18,473.00",0,published,Completed,"18,473.00",464,2013-07-25
+1248,CMDRR Project Grand Goave CPH,EUR,"29,150.00",0,published,Completed,"29,150.00",961,2013-07-25
+1249,Conflict resolution with young entrepreneurs,EUR,"135,698.00",0,published,Active,"135,698.00",1099,2013-07-25
+1250,Monitoring water quality in mining areas,EUR,"50,000.00",0,published,Active,"50,000.00",960,2013-07-25
+1251,Empower Farmer Associations and their members,EUR,"260,209.00",2,published,Active,"260,209.00",464,2013-07-25
+1252,Monitoring the impact of multinationals,EUR,"263,992.00",0,published,Active,"263,992.00",1099,2013-07-25
+1253,Samburu Integrated Development Programme,EUR,"99,965.00",0,published,Active,"99,965.00",961,2013-07-25
+1254,"Empower, train and link women NGOs",EUR,"106,000.00",0,published,Active,"106,000.00",955,2013-07-25
+1255,Promoting Children's Rights and Education,EUR,"230,878.00",0,published,Active,"230,878.00",959,2013-07-25
+1256,Construction and repair of health facilities,EUR,"130,535.00",1,published,Active,"130,535.00",273,2013-07-25
+1257,Ongoing trainings for midwives,EUR,"141,984.00",1,published,Active,"141,984.00",1297,2013-07-25
+1258,Promote women's rights in microfinance,EUR,"52,434.00",0,published,Completed,"52,434.00",1610,2013-07-25
+1259,Accompanying a community resettlement,EUR,"5,000.00",0,published,Completed,"5,000.00",960,2013-07-25
+1260,Strengthening local organization IADH,EUR,"204,144.00",0,published,Active,"204,144.00",949,2013-07-25
+1261,Rehabilitation for Flood Affected Families,EUR,"60,000.00",0,published,Completed,"60,000.00",961,2013-07-25
+1262,Counter the negative impact of oil bunkering,EUR,"79,615.00",0,published,Active,"79,615.00",960,2013-07-25
+1263,Opportunities for dairy and apiary farmers,EUR,"433,092.00",1,published,Active,"433,092.00",1470,2013-07-25
+1264,Promoting sanitation & hygiene practice,EUR,"97,854.00",0,published,Completed,"97,854.00",962,2013-07-25
+1265,Indigenous communities threatened by mining,EUR,"51,860.00",0,published,Active,"51,860.00",1523,2013-07-25
+1266,Farmers resilience to climate change,EUR,"110,500.00",2,published,Active,"110,500.00",273,2013-07-25
+1267,Restoring Shelters after Thane Cyclone,EUR,"112,957.00",1,published,Active,"112,957.00",961,2013-07-25
+1268,ACDEP: ICT in Healthcare Delivery,EUR,"323,581.00",3,published,Active,"323,581.00",1572,2013-07-25
+1269,Access to land for small scale farmers,EUR,"55,250.00",0,published,Active,"55,250.00",1099,2013-07-25
+1270,Building Resilience in Acholi Region,EUR,"150,378.00",0,published,Active,"150,378.00",683,2013-07-25
+1271,Improving the livelihoods of households,EUR,"79,945.00",0,published,Active,"79,945.00",961,2013-07-25
+1272,Rural development through cooperatives,EUR,"466,123.00",0,published,Active,"466,123.00",1099,2013-07-25
+1273,Evidence Based Policy Recommendation,EUR,"348,035.00",4,published,Active,"348,035.00",961,2013-07-25
+1274,Enhence effective responses to disasters,EUR,"127,500.00",0,published,Active,"127,500.00",273,2013-07-25
+1275,"Access to Care, Support & Protection for OVCs",EUR,"157,500.00",0,published,Active,"157,500.00",273,2013-07-25
+1276,Strengthening women leadership,EUR,"95,000.00",0,published,Active,"95,000.00",273,2013-07-25
+1277,Access to Education at Sandwip Island,EUR,"329,522.00",0,published,Active,"329,522.00",273,2013-07-25
+1278,People at the centre of drylands governance,EUR,"246,558.00",0,published,Active,"246,558.00",961,2013-07-25
+1279,Alliance concerning HIV/AIDS,EUR,"3,871,971.00",0,published,Active,"3,871,971.00",949,2013-07-25
+1280,Capacity building for risk reduction,EUR,"1,270,005.00",1,published,Active,"1,270,005.00",1306,2013-07-25
+1281,Disaster Risk Reduction Capacity Enhancement,EUR,"699,370.00",0,published,Active,"699,370.00",1358,2013-07-25
+1282,Program Justice for Sale,EUR,"1,262,700.00",1,published,Active,"1,262,700.00",273,2013-07-25
+1283,Climate proof communities,EUR,"439,895.00",2,published,Active,"439,895.00",961,2013-07-25
+1284,Human rights in relation to mining operations,EUR,"66,500.00",0,published,Active,"66,500.00",960,2013-07-25
+1285,Financial education for farmers,EUR,"104,000.00",0,published,Active,"104,000.00",1099,2013-07-25
+1286,Strengthening Disaster Risk Reduction,EUR,"362,495.00",3,published,Active,"362,495.00",1473,2013-07-25
+1287,Research on Communities of Change in Haiti,EUR,"45,000.00",0,published,Completed,"45,000.00",1241,2013-07-25
+1288,Resilient Communities,EUR,"463,140.00",2,published,Active,"463,140.00",273,2013-07-25
+1289,Support for communities to care for orphans,EUR,"327,187.00",1,published,Active,"327,187.00",273,2013-07-25
+1290,Improved access to education and health.,EUR,"381,795.00",0,published,Active,"381,795.00",273,2013-07-25
+1291,Basic health care in Urozgan,EUR,"4,400,005.00",0,published,Active,"4,400,005.00",1354,2013-07-25
+1292,Climate Proof Disaster Risk Reduction,EUR,"431,481.00",0,published,Active,"431,481.00",961,2013-07-25
+1293,Improving the quality of education,EUR,"530,061.00",0,published,Active,"530,061.00",1465,2013-07-25
+1294,Support local production and processing.,EUR,"1,017,445.00",0,published,Active,"1,017,445.00",1099,2013-07-25
+1295,Optimize Community Clinics,EUR,"198,269.00",0,published,Completed,"198,269.00",949,2013-07-25
+1296,Development of the rice value chain,EUR,"400,000.00",1,published,Active,"400,000.00",273,2013-07-25
+1297,Solutions for affected women and girls,EUR,"1,220,000.00",0,published,Completed,"1,220,000.00",1525,2013-07-25
+1298,Nutrition for children,EUR,"404,616.00",0,published,Active,"404,616.00",1334,2013-07-25
+1299,Kandahar Institute of Health Sciences,EUR,"1,406,917.00",0,published,Active,"1,406,917.00",1297,2013-07-25
+1300,Food security for farmers in Mombin Crochu,EUR,"1,085,633.00",0,published,Active,"1,085,633.00",1099,2013-07-25
+1301,Funding based on performance: HIV/AIDS,EUR,"604,621.00",1,published,Active,"604,621.00",949,2013-07-25
+1302,Better health care in 5 health zones,EUR,"4,685,303.00",0,published,Active,"4,685,303.00",949,2013-07-25
+1303,"Mining, monocultures and indigenous rights",EUR,"88,163.00",1,published,Active,"88,163.00",1482,2013-07-25
+1304,SMS to raise HIV/AIDS awareness among youth,EUR,"99,848.00",0,published,Active,"99,848.00",1382,2013-07-25
+1305,Providing farmers with access to credit,EUR,"807,816.00",2,published,Active,"807,816.00",1099,2013-07-25
+1306,Foster Care for Children in Slums,EUR,"63,202.00",1,published,Active,"63,202.00",273,2013-07-25
+1307,Improving the milk sector in Haiti,EUR,"248,517.00",0,published,Active,"248,517.00",464,2013-07-25
+1308,Access to healthcare in Nana MambÃ©rÃ©,EUR,"1,380,456.00",0,published,Active,"1,380,456.00",1297,2013-07-25
+1309,Emergency Aid Drought for Vulnerable People,EUR,"500,000.00",0,published,Completed,"500,000.00",614,2013-07-25
+1310,Training community health workers,EUR,"315,796.00",0,published,Active,"315,796.00",949,2013-07-25
+1311,Building a maternity clinic,EUR,"42,248.00",1,published,Active,"42,248.00",1297,2013-07-25
+1312,Agro ecological project in La Montagne,EUR,"260,597.00",0,published,Active,"260,597.00",1570,2013-07-25
+1313,Enhancing local institutions,EUR,"4,768,752.00",0,published,Completed,"4,768,752.00",949,2013-07-25
+1314,Training local community mobilizers,EUR,"300,658.00",0,published,Active,"300,658.00",464,2013-07-25
+1315,Empowerment of female farmers in rural areas,EUR,"389,684.00",0,published,Active,"389,684.00",1485,2013-07-25
+1316,Capacity Building for Disaster Risk Response,EUR,"236,640.00",0,published,Completed,"236,640.00",464,2013-07-25
+1317,Bina Swadaya Disaster Risk Reduction,EUR,"226,347.00",4,published,Active,"226,347.00",1358,2013-07-25
+1318,Partners for Resilience Karina 2011,EUR,"327,318.00",2,published,Active,"327,318.00",1516,2013-07-25
+1319,Support to Children with Disability,EUR,"262,479.00",0,published,Active,"262,479.00",959,2013-07-25
+1320,Reducing vulnerability through microinsurance,EUR,"1,219,928.00",0,published,Active,"1,219,928.00",953,2013-07-25
+1321,Inclusion of disabled children,EUR,"449,458.00",0,published,Active,"449,458.00",959,2013-07-25
+1322,Back Home House,EUR,"128,000.00",0,published,Completed,"128,000.00",962,2013-07-25
+1323,Improvement of basic health care,EUR,"5,899,754.00",3,published,Completed,"5,899,754.00",1354,2013-07-25
+1324,Disaster Risk Reduction & Management,EUR,"363,853.00",1,published,Active,"363,853.00",961,2013-07-25
+1325,Reconstruction through economic development,EUR,"495,132.00",1,published,Active,"495,132.00",273,2013-07-25
+1326,Loan to increase access to credit,EUR,"112,900.00",0,published,Active,"112,900.00",464,2013-07-25
+1327,Providing loans for micro entrepreneurs,EUR,"815,000.00",0,published,Active,"815,000.00",464,2013-07-25
+1328,Investing in Bolivia's rural economy,EUR,"798,472.00",0,published,Active,"798,472.00",953,2013-07-25
+1329,Supporting Microfinance in East Africa,EUR,"14,120,518.00",0,published,Active,"14,120,518.00",273,2013-07-25
+1330,WASH services & capacity building Liberia,EUR,"1,000,000.00",3,published,Completed,"1,000,000.00",1178,2013-08-01
+1331,Manual percussion drilling in Malawi,EUR,"35,550.00",1,published,Completed,"35,550.00",43,2013-08-09
+1332,"Water, Sanitation, Hgyiene and Health ",EUR,"30,000.00",2,published,Active,"30,000.00",405,2013-08-12
+1333,Sustainable Water Sources,EUR,"20,000.00",2,published,Active,"20,000.00",1666,2013-08-14
+1334,Scaling up sanitation as a business in Kitgum,EUR,"40,000.00",3,published,Active,"40,000.00",405,2013-08-14
+1335,Umoja Primary School,EUR,"26,000.00",0,published,H,29.24,816,2013-08-14
+1336,Friends of Udhruh 2014,EUR,"4,550.00",4,published,H,0.00,361,2013-08-26
+1337,Help een school in Kenia!,EUR,"27,500.00",1,published,H,0.00,113,2013-08-26
+1338,Social Media for Innovative Local Empowerment,USD,"200,000.00",15,published,Active,"200,000.00",1674,2013-08-27
+1339,Legal Aid for Justice [LAJ],USD,"115,000.00",2,published,Active,"115,000.00",428,2013-08-27
+1340,DVD Papas Nativas,EUR,"10,853.28",8,published,Active,"10,853.27",34,2013-08-29
+1341,Efficient Water Use,EUR,"11,622,114.00",0,published,Active,"11,622,114.00",1679,2013-08-29
+1342,Addressing basic needs,EUR,"132,233.00",0,published,Active,"132,233.00",1306,2013-09-02
+1343,Improving youth policy,EUR,"649,644.00",3,published,Active,"649,644.00",946,2013-09-02
+1344,El Salvador 2012: Creating a housing toolbox,EUR,"168,756.00",0,published,Completed,"168,756.00",946,2013-09-02
+1345,Nairobi 2012: Need for improved sanitation,EUR,"75,732.00",0,published,Completed,"75,732.00",1403,2013-09-02
+1346,Addis Ababa 2012: Involving stakeholders,EUR,"44,837.00",0,published,Completed,"44,837.00",273,2013-09-02
+1347,Guatemala 2012: Mapping neighborhoods,EUR,"26,817.00",0,published,Completed,"26,817.00",1531,2013-09-02
+1348,"Toiletten voor Kabre Palenchowk, Nepal",EUR,"15,500.00",0,published,H,"4,943.00",2150,2013-09-13
+1349,Safe water for Wajir,EUR,"15,700.00",0,published,H,"11,467.00",2151,2013-09-16
+1351,PPP for increased access to sustainable water,EUR,"4,352,972.00",4,published,Active,"4,352,972.00",1429,2013-09-23
+1352,Increasing access to justice in South Kivu,EUR,"64,973.00",0,published,Active,"64,973.00",273,2013-09-24
+1354,Sanitation projects in Jakarta,EUR,"40,000.00",4,published,Active,"40,000.00",464,2013-09-26
+1355,Innovative Sanitation in Nakuru,EUR,"40,000.00",4,published,Active,"40,000.00",881,2013-09-26
+1356,Indonesian water challenge,EUR,"40,000.00",10,published,Active,"40,000.00",1690,2013-09-26
+1357,Rural Water Services Delivery in Kisumu,EUR,"40,000.00",17,published,Active,"40,000.00",1686,2013-09-26
+1358,"Non-Revenue Water reduction, East Africa, YEP",EUR,"40,000.00",14,published,Active,"40,000.00",1686,2013-09-26
+1359,Ethiopia Climate Innovation Centre (CIC),EUR,"40,000.00",4,published,Active,"40,000.00",464,2013-09-26
+1361,YEP - Partnerships in the Ghanian WASH sector,EUR,"40,000.00",5,published,Active,"40,000.00",1059,2013-09-26
+1363,Rain Water Harvesting ,EUR,"12,000.00",6,published,Active,"12,000.00",1684,2013-09-26
+1365,Facilities Ibbagamuwa school Sri Lanka,EUR,"6,762.00",1,published,Active,"6,761.75",1151,2013-10-09
+1366,Rural Boreholes and Rehabilitation 1,USD,"3,451.80",0,published,Completed,"3,451.80",168,2013-10-14
+1367,Panta District Rural Water Project 1,USD,"3,451.80",0,published,Completed,"3,451.80",1071,2013-10-14
+1368,Panta District Rural Water Project 2,USD,"3,450.95",0,published,Completed,"3,450.95",1061,2013-10-14
+1369,Rural Boreholes and Rehabilitation 2,USD,"3,455.80",0,published,Completed,"3,455.80",1061,2013-10-14
+1370,Rural Boreholes and Rehabilitation 3,USD,"3,451.80",0,published,Completed,"3,451.80",1061,2013-10-14
+1371,Toiletten voor school in Mamaribougou,EUR,"4,854.00",6,published,H,"3,804.03",2150,2013-10-15
+1372,Rural Boreholes and Rehabilitation 4,USD,"3,450.95",0,published,Completed,"3,450.95",1061,2013-10-15
+1373,Rural Boreholes and Rehabilitation 5,USD,"3,450.95",0,published,Active,"3,450.95",1694,2013-10-15
+1374,Integrated Community Water and Hygiene (ICWH),USD,"390,244.00",0,published,Active,"390,244.00",1061,2013-10-15
+1375,Integrated Community Water & Hygiene (ICWH) 2,USD,"390,244.00",0,published,Active,"390,244.00",1071,2013-10-15
+1376,Integrated Community Water & Hygiene (ICWH) 3,USD,"390,244.00",0,published,Active,"390,244.00",168,2013-10-15
+1377,Ruai Waterproject,EUR,"25,000.00",5,published,Active,"25,000.00",43,2013-10-17
+1378,NWSHPC Training Support to NGOs,USD,"9,353.00",0,published,Completed,"9,353.00",1061,2013-10-23
+1379,Rural Boreholes and Rehabilitation 6,USD,"3,451.80",0,published,Active,"3,451.80",1061,2013-10-23
+1380,Rural Boreholes and Rehabilitation 7,USD,"3,450.95",0,published,Completed,"3,450.95",1061,2013-10-23
+1381,Health & WASH in BHP Billiton Work Area 1,USD,"1,966.08",0,published,Completed,"1,966.08",1076,2013-10-23
+1382,Health & WASH in BHP Billiton Work Area 2,USD,"1,966.08",0,published,Completed,"1,966.08",1061,2013-10-23
+1383,Nundu water gravity scheme and WASH training,EUR,"205,000.00",2,published,Active,"205,000.00",43,2013-10-24
+1384,Wateroogst 2: Upscaling Rainwater harvesting,EUR,"36,738.00",2,published,H,0.00,43,2013-10-24
+1385,Health & WASH in BHP Billiton Work Area 3,USD,"1,966.08",0,published,Completed,"1,966.08",1076,2013-10-30
+1386,Health & WASH in BHP Billiton Work Area 4,USD,"5,176.77",0,published,Completed,"5,176.77",1061,2013-10-30
+1387,Health & WASH in BHP Billiton Work Area 5,USD,"5,176.77",0,published,Completed,"5,176.77",1076,2013-10-30
+1388,Health & WASH in BHP Billiton Work Area 6,USD,"5,176.77",0,published,Completed,"5,176.77",1061,2013-10-30
+1389,Health & WASH in BHP Billiton Work Area 7,USD,"5,176.77",0,published,Completed,"5,176.77",1076,2013-10-30
+1390,Health & WASH in BHP Billiton Work Area 8,USD,"5,176.77",0,published,Completed,"5,176.77",1061,2013-10-30
+1391,Health & WASH in BHP Billiton Work Area 9,USD,"5,176.77",0,published,Completed,"5,176.77",1076,2013-10-30
+1392,Health & WASH in BHP Billiton Work Area 10,USD,"5,176.77",0,published,Completed,"5,176.77",1061,2013-10-30
+1393,Health & WASH in BHP Billiton Work Area 11,USD,"1,966.08",0,published,Completed,"1,966.08",1076,2013-10-30
+1394,6T project: Water Tanks for Nakuru in Kenya,EUR,"100,000.00",0,published,Active,"100,000.00",43,2013-11-05
+1395,Community-led WASH and Safe Motherhood ,EUR,"95,582.00",3,published,Active,"95,583.00",1151,2013-11-05
+1396,Same Hospital Rehabilitate Sanitation,EUR,"3,800.00",1,published,Active,"3,800.00",43,2013-11-05
+1397,Health & WASH in BHP Billiton Work Area 12,USD,"5,176.77",0,published,Completed,"5,176.77",1076,2013-11-05
+1398,Health & WASH in BHP Billiton Work Area 13,EUR,"5,176.77",0,published,Completed,"5,176.77",1061,2013-11-05
+1399,Health & WASH in BHP Billiton Work Area 14,USD,"5,176.77",0,published,Completed,"5,176.77",1071,2013-11-05
+1400,Health & WASH in BHP Billiton Work Area 15,USD,"1,966.08",0,published,Completed,"1,966.08",1061,2013-11-05
+1401,Health & WASH in BHP Billiton Work Area 16,USD,"1,966.08",0,published,Completed,"1,966.08",1071,2013-11-05
+1402,Health & WASH in BHP Billiton Work Area 17,USD,"1,966.08",0,published,Completed,"1,966.08",1061,2013-11-05
+1403,Health & WASH in BHP Billiton Work Area 18,USD,"5,176.77",0,published,Completed,"5,176.77",1071,2013-11-05
+1404,Health & WASH in BHP Billiton Work Area 19,USD,"5,176.77",0,published,Completed,"5,176.77",1061,2013-11-05
+1405,Health & WASH in BHP Billiton Work Area 20,USD,"5,176.77",0,published,Completed,"5,176.77",1071,2013-11-05
+1406,Health & WASH in BHP Billiton Work Area 21,USD,"5,176.77",0,published,Completed,"5,176.77",1071,2013-11-08
+1407,Health & WASH in BHP Billiton Work Area 22,USD,"1,966.08",0,published,Completed,"1,966.08",1071,2013-11-08
+1408,Health & WASH in BHP Billiton Work Area 23,USD,"1,966.08",0,published,Completed,"1,966.08",1061,2013-11-08
+1409,Health & WASH in BHP Billiton Work Area 24,USD,"5,176.77",0,published,Completed,"5,176.77",1071,2013-11-08
+1410,Health & WASH in BHP Billiton Work Area 25,USD,"1,966.08",0,published,Completed,"1,966.08",1061,2013-11-08
+1411,Health & WASH in BHP Billiton Work Area 26,USD,"1,966.08",0,published,Completed,"1,966.08",1071,2013-11-08
+1412,Health & WASH in BHP Billiton Work Area 27,USD,"1,966.08",0,published,Completed,"1,966.08",1061,2013-11-08
+1413,Health & WASH in BHP Billiton Work Area 28,USD,"1,966.08",0,published,Completed,"1,966.08",1071,2013-11-08
+1414,Health & WASH in BHP Billiton Work Area 29,USD,"5,176.77",0,published,Completed,"5,176.77",1061,2013-11-08
+1415,Health & WASH in BHP Billiton Work Area 30,USD,"1,966.08",0,published,Completed,"1,966.08",1071,2013-11-08
+1416,Health & WASH in BHP Billiton Work Area 31,USD,"1,966.08",0,published,Completed,"1,966.08",1061,2013-11-08
+1426,Strengthening the organization ADIS,EUR,"141,853.00",0,published,Active,"141,853.00",273,2013-11-08
+1427,Protect and Respect,EUR,"170,000.00",0,published,Active,"170,000.00",949,2013-11-08
+1428,SMS to improve reproductive health care,EUR,"141,227.00",0,published,Active,"141,227.00",1297,2013-11-08
+1429,Rapid Results Health Programme Fashoda,EUR,"552,157.00",0,published,Active,"552,157.00",949,2013-11-08
+1430,Promotion of Women's Health Rights,EUR,"45,800.00",0,published,Active,"45,800.00",949,2013-11-08
+1431,Pilot PBF project,EUR,"275,000.00",0,published,Active,"275,000.00",1297,2013-11-08
+1432,Human Resources in Health Coalition,EUR,"79,625.00",0,published,Active,"79,625.00",273,2013-11-08
+1433,Respect for girls and women,EUR,"92,880.00",0,published,Active,"92,880.00",1352,2013-11-08
+1434,Performance based financing in Bas Congo,EUR,"420,725.00",0,published,Active,"420,725.00",949,2013-11-08
+1435,Rapid Results Health Program Panyikang,EUR,"412,701.00",0,published,Active,"412,701.00",949,2013-11-08
+1436,Business Plan Results Based Financing Trainin,EUR,0.00,0,published,Active,0.00,1566,2013-11-08
+1437,Health Policy & Financing Course,EUR,"26,000.00",0,published,Completed,"26,000.00",273,2013-11-08
+1438,PILOT HIV and AIDS Project,EUR,"154,337.00",1,published,Active,"154,337.00",1527,2013-11-08
+1439,Improved maternal health using ICT,EUR,"68,000.00",6,published,Active,"68,000.00",949,2013-11-08
+1440,Access to Healthcare in Nana-Mambere,EUR,"277,021.00",0,published,Active,"277,021.00",1297,2013-11-08
+1441,"Institutional support to the \Agence d'Achat\""""",EUR,"90,000.00",0,published,Active,"90,000.00",273,2013-11-08
+1442,Improving pregnancy outcomes,EUR,"125,000.00",0,published,Active,"125,000.00",949,2013-11-08
+1443,Improving SRH for Rural Adolesents,EUR,"103,238.00",1,published,Active,"103,238.00",1810,2013-11-08
+1444,Reproductive Health Services for pastoralists,EUR,"129,276.00",0,published,Active,"129,276.00",1728,2013-11-08
+1445,Closing gap in maternal and neonatal health,EUR,"132,685.00",0,published,Active,"132,685.00",949,2013-11-08
+1446,Improving maternal and reproductive health,EUR,"111,112.00",0,published,Active,"111,112.00",949,2013-11-08
+1447,PBF MIS and database,EUR,"36,100.00",0,published,Active,"36,100.00",949,2013-11-08
+1448,Integration of disabled people in the society,EUR,"246,254.00",0,published,Active,"246,254.00",1342,2013-11-08
+1449,Child Protection & Alternative Care,EUR,"126,223.00",0,published,Active,"126,223.00",959,2013-11-08
+1450,Education support to Moro and IP children,EUR,"287,231.00",0,published,Active,"287,231.00",1773,2013-11-08
+1451,Combatting Child trafficking,EUR,"130,916.00",0,published,Active,"130,916.00",464,2013-11-08
+1452,Support payment of subsidies in Batouri,EUR,"305,289.00",0,published,Active,"305,289.00",1465,2013-11-08
+1453,Reintegration of street children,EUR,"252,015.00",0,published,Active,"252,015.00",959,2013-11-08
+1454,Children Education and Community Care,EUR,"212,963.00",0,published,Active,"212,963.00",1705,2013-11-08
+1455,More Children in school,EUR,"35,033.00",0,published,Active,"35,033.00",959,2013-11-08
+1456,Sexuality education in schools,EUR,"119,108.00",0,published,Active,"119,108.00",464,2013-11-08
+1457,Inclusive education in tea plantations,EUR,"120,581.00",1,published,Active,"120,581.00",959,2013-11-08
+1458,Education of children with disabilities,EUR,"78,102.00",0,published,Active,"78,102.00",1646,2013-11-08
+1459,Linking & Learning convergence partners,EUR,"46,364.00",0,published,Active,"46,364.00",273,2013-11-08
+1460,To offer protection for children by education,EUR,"247,166.00",0,published,Active,"247,166.00",1527,2013-11-08
+1461,The Road Map to quality education,EUR,"188,431.00",0,published,Active,"188,431.00",273,2013-11-08
+1462,Capturing mangrove values in land protection,EUR,"25,000.00",1,published,Active,"25,000.00",273,2013-11-08
+1463,Community Managed Drought Risk Reduction,EUR,"540,071.00",1,published,Active,"540,071.00",961,2013-11-08
+1464,Community Managed Disaster Risk Reduction,EUR,"200,000.00",0,published,Active,"200,000.00",1308,2013-11-08
+1465,Linking and Learning 2012,EUR,"12,765.00",0,published,Active,"12,765.00",961,2013-11-08
+1466,Malawi Emergency and Early Recovery,EUR,"93,000.00",0,published,Active,"93,000.00",1306,2013-11-08
+1467,Karonga CMDRR & Climate Change Adaptation,EUR,"78,274.00",0,published,Active,"78,274.00",961,2013-11-08
+1468,Building Community Resilience and Response,EUR,"80,000.00",0,published,Active,"80,000.00",1757,2013-11-08
+1469,Disaster Response after Typhoon Bopha,EUR,"50,000.00",0,published,Active,"50,000.00",1709,2013-11-08
+1470,Disaster Response Typhoon Bopha,EUR,"275,000.00",0,published,Active,"275,000.00",961,2013-11-08
+1471,Emergency Response after Typhoon Pablo,EUR,"50,000.00",0,published,Active,"50,000.00",961,2013-11-08
+1472,Strong livelihoods,EUR,"163,160.00",0,published,Active,"163,160.00",2022,2013-11-08
+1473,Afar drought response,EUR,"142,777.00",2,published,Active,"142,777.00",1728,2013-11-08
+1474,Conflict Resolution and Peace Building,EUR,"80,683.00",0,published,Active,"80,683.00",464,2013-11-08
+1475,"Neighbourhood upgrading in Carrefour, Haiti",EUR,"8,590,500.00",0,published,Active,"8,590,500.00",1802,2013-11-08
+1476,"small producers, agriculture and CMDRR",EUR,"108,405.00",0,published,Active,"108,405.00",961,2013-11-08
+1477,"medical services for displaced in Homs, Syria",EUR,0.00,0,published,Active,0.00,961,2013-11-08
+1478,Disaster Risk Reduction on Sandwip Island,EUR,"66,150.00",0,published,Active,"66,150.00",1702,2013-11-08
+1479,Emergency Aid in Central African Republic,EUR,"50,000.00",0,published,Active,"50,000.00",961,2013-11-08
+1480,Developing Livestock Markets,EUR,"121,524.00",0,published,Active,"121,524.00",1713,2013-11-08
+1481,Consultancy India on donor mapping,EUR,"18,465.00",0,published,Active,"18,465.00",464,2013-11-08
+1482,Emergency Relief Flood Affected Families,EUR,"130,000.00",1,published,Active,"130,000.00",1461,2013-11-08
+1483,Emergency Reconstruction Support,EUR,"269,776.00",0,published,Active,"269,776.00",961,2013-11-08
+1484,Organisation Institutional Development,EUR,"6,150.00",0,published,Active,"6,150.00",464,2013-11-08
+1485,"Emergency aid in Artibonite, Haiti",EUR,"130,000.00",0,published,Active,"130,000.00",1358,2013-11-08
+1486,Emergency aid and early recovery,EUR,"419,089.00",0,published,Active,"419,089.00",1453,2013-11-08
+1487,Disaster relief project Uttarakhand,EUR,"53,800.00",1,published,Active,"53,800.00",961,2013-11-08
+1488,NFI Kits for Displaced People in North Kivu,EUR,"311,500.00",5,published,Active,"311,500.00",961,2013-11-08
+1489,Emergency Aid Central African Republic 2013,EUR,"210,000.00",0,published,Active,"210,000.00",273,2013-11-08
+1490,EA 08/2013 Earthquake Balochistan,EUR,"50,000.00",0,published,Active,"50,000.00",961,2013-11-08
+1491,Tirah Valley Emergency Response,EUR,"122,248.00",3,published,Active,"122,248.00",961,2013-11-08
+1492,Sustainable Dykes for Bangladesh,EUR,"164,395.00",5,published,Active,"164,395.00",961,2013-11-08
+1493,Training and Monitoring UNSCR 1325,EUR,"62,310.00",0,published,Active,"62,310.00",955,2013-11-08
+1494,Bayan: Connecting Afghans for Women's Rights,EUR,"70,000.00",0,published,Active,"70,000.00",273,2013-11-08
+1495,training and accompaniment women leaders,EUR,"525,000.00",0,published,Active,"525,000.00",464,2013-11-08
+1496,Women in Governance for security and peace,EUR,"203,924.00",0,published,Active,"203,924.00",273,2013-11-08
+1497,Strengthening womenâ€™s participation,EUR,"40,000.00",0,published,Active,"40,000.00",955,2013-11-08
+1498,Reflection and debate on expanding mining,EUR,"68,840.00",0,published,Active,"68,840.00",960,2013-11-08
+1499,Reinforcing communities threatened by mining,EUR,"50,000.00",0,published,Completed,"50,000.00",273,2013-11-08
+1500,Mining as an oportunity,EUR,"51,471.00",0,published,Active,"51,471.00",960,2013-11-08
+1501,Community Oil Spill Monitoring,EUR,"58,500.00",0,published,Active,"58,500.00",2034,2013-11-08
+1502,Next Generation of Governance Reporting,EUR,"48,000.00",0,published,Active,"48,000.00",464,2013-11-08
+1503,Social Accountability of Public Resources,EUR,"150,000.00",0,published,Active,"150,000.00",1751,2013-11-08
+1504,Environmental Monitoring and Gas Alert System,EUR,"68,000.00",0,published,Active,"68,000.00",1593,2013-11-08
+1505,Niger Delta Community monitors oil companies,EUR,"70,000.00",0,published,Active,"70,000.00",960,2013-11-08
+1506,Support to South Sudan Civil Society Alliance,EUR,"171,979.00",0,published,Active,"171,979.00",1241,2013-11-08
+1507,Raising awareness on Human Rights issues,EUR,"169,433.00",0,published,Active,"169,433.00",273,2013-11-08
+1508,Capacity strengthening,EUR,"131,070.00",0,published,Active,"131,070.00",1274,2013-11-08
+1509,Integration of women in the security sector,EUR,"121,132.00",0,published,Active,"121,132.00",1241,2013-11-08
+1510,South Sudan Community Policing Research,EUR,0.00,0,published,Active,0.00,273,2013-11-08
+1511,Market Study 'Mobile Money Transfers',EUR,"20,000.00",0,published,Completed,"20,000.00",273,2013-11-08
+1512,Job and housing opportunities for women,EUR,"227,000.00",0,published,Completed,"227,000.00",1534,2013-11-08
+1513,Employment and education for youth at risk,EUR,"315,500.00",0,published,Completed,"315,500.00",1654,2013-11-08
+1514,Working together on water and sanitation,EUR,"95,000.00",0,published,Completed,"95,000.00",273,2013-11-08
+1515,A local hub for Cordaid's activities,EUR,"457,035.00",0,published,Active,"457,035.00",273,2013-11-08
+1516,Urban Agriculture for youth,EUR,"511,502.00",0,published,Completed,"511,502.00",273,2013-11-08
+1517,Providing urban youth with opportunities,EUR,"62,750.00",0,published,Completed,"62,750.00",1723,2013-11-08
+1518,Upgrading slums by tackling multiple issues,EUR,"1,205,695.00",0,published,Completed,"1,205,695.00",946,2013-11-08
+1519,Livable houses for the urban poor,EUR,"1,815,467.00",0,published,Completed,"1,815,467.00",946,2013-11-08
+1520,Lobbying for inclusive housing policy,EUR,"1,066,739.00",0,published,Completed,"1,066,739.00",464,2013-11-08
+1521,Turning pollution into profit,EUR,"106,000.00",0,published,Completed,"106,000.00",1722,2013-11-08
+1522,Improved housing by working together,EUR,"3,255,897.00",0,published,Completed,"3,255,897.00",946,2013-11-08
+1523,Working together for a cleaner city,EUR,"587,689.00",0,published,Completed,"587,689.00",946,2013-11-08
+1524,An integrated approach for water and waste,EUR,"1,156,343.00",0,published,Completed,"1,156,343.00",946,2013-11-08
+1525,Networking to battle urban poverty,EUR,0.00,0,published,Completed,0.00,273,2013-11-08
+1526,Water supply for Youth City,EUR,"8,500.00",0,published,Completed,"8,500.00",1761,2013-11-08
+1527,St. Noa's Family,EUR,"114,000.00",0,published,Completed,"114,000.00",962,2013-11-08
+1528,Furnishing of womenâ€™s shelters,EUR,"25,000.00",0,published,Completed,"25,000.00",962,2013-11-08
+1529,Water 4 Tomorrow,EUR,"16,000.00",0,published,Completed,"16,000.00",273,2013-11-08
+1530,Establishing small libraries,EUR,"45,000.00",0,published,Completed,"45,000.00",962,2013-11-08
+1531,Care for children living with HIV/Aids,EUR,"14,000.00",0,published,Completed,"14,000.00",273,2013-11-08
+1532,Mushrooms production,EUR,"50,000.00",0,published,Completed,"50,000.00",464,2013-11-08
+1533,Lighten their Future,EUR,"19,500.00",0,published,Completed,"19,500.00",962,2013-11-08
+1534,Reconstruction of Codrington College,EUR,"30,000.00",1,published,Active,"30,000.00",962,2013-11-08
+1535,Care for children with mental disabilities,EUR,"82,000.00",0,published,Active,"82,000.00",962,2013-11-08
+1536,Empowerment behind bars III,EUR,"20,000.00",0,published,Completed,"20,000.00",962,2013-11-08
+1537,Financial independence for women,EUR,"31,750.00",0,published,Completed,"31,750.00",1777,2013-11-08
+1538,Strengthening Women's Leadership,EUR,"281,568.00",4,published,Completed,"281,568.00",962,2013-11-08
+1539,Rainwater Collection and Water Purification,EUR,"30,000.00",0,published,Completed,"30,000.00",962,2013-11-08
+1540,Workshops for youth in prison,EUR,"58,139.00",1,published,Completed,"58,139.00",962,2013-11-08
+1541,Improving maternal and child health,EUR,"26,675.00",0,published,Completed,"26,675.00",1785,2013-11-08
+1542,Media library for anatomy program,EUR,"25,000.00",0,published,Active,"25,000.00",1780,2013-11-08
+1543,Kofale Health Clinic,EUR,"80,625.00",0,published,Active,"80,625.00",962,2013-11-08
+1544,Building a future,EUR,"209,850.00",0,published,Completed,"209,850.00",273,2013-11-08
+1545,Health care for undocumented migrants,EUR,"131,248.00",0,published,Completed,"131,248.00",1653,2013-11-08
+1546,Rehabilitation unit in Sumve Hospital,EUR,"43,000.00",0,published,Active,"43,000.00",962,2013-11-08
+1547,Day care in Bangalore,EUR,"27,700.00",0,published,Completed,"27,700.00",962,2013-11-08
+1548,Peer support and education for youth,EUR,"32,450.00",0,published,Active,"32,450.00",962,2013-11-08
+1549,Community HIV/AIDS prevention and care,EUR,"103,092.00",0,published,Completed,"103,092.00",962,2013-11-08
+1550,Zenji treasures,EUR,"16,000.00",0,published,Completed,"16,000.00",962,2013-11-08
+1551,Pigs for Pencils,EUR,"36,994.00",0,published,Active,"36,994.00",962,2013-11-08
+1552,Sharing riches,EUR,"16,844.00",0,published,Active,"16,844.00",962,2013-11-08
+1553,"Water, sanitation and hygiene education",EUR,"93,604.00",0,published,Active,"93,604.00",1595,2013-11-08
+1554,Lobby and information undocumented migrants,EUR,"25,000.00",0,published,Completed,"25,000.00",1732,2013-11-08
+1555,Fresh drinking water project,EUR,"48,200.00",0,published,Active,"48,200.00",273,2013-11-08
+1556,Clean water as an important start,EUR,"117,395.00",0,published,Active,"117,395.00",115,2013-11-08
+1557,Contribution to lobby & advocacy networks,EUR,"50,000.00",0,published,Active,"50,000.00",464,2013-11-08
+1558,Construction of an eye clinic,EUR,"65,000.00",0,published,Active,"65,000.00",273,2013-11-08
+1559,Release children from cleft lip or palate,EUR,"30,000.00",0,published,Active,"30,000.00",1738,2013-11-08
+1560,Clean Cooking Stoves for rural households,EUR,"34,636.00",0,published,Active,"34,636.00",464,2013-11-08
+1561,Day for Private Initiatives 2013,EUR,"113,395.00",0,published,Completed,"113,395.00",962,2013-11-08
+1562,Knowledge program emerging powers in Africa,EUR,"65,000.00",0,published,Active,"65,000.00",464,2013-11-08
+1563,Microfinance for rural areas in Ethiopia,EUR,"530,000.00",0,published,Active,"530,000.00",273,2013-11-08
+1564,Credit for rural areas,EUR,"600,000.00",0,published,Active,"600,000.00",953,2013-11-08
+1565,Loan to Opportunity Kenya Limited 2013,EUR,"865,000.00",0,published,Active,"865,000.00",953,2013-11-08
+1566,Promote entrepreneurship with microfinance,EUR,"1,152,684.00",0,published,Active,"1,152,684.00",953,2013-11-08
+1567,Knowledge management and partner support,EUR,"85,577.00",0,published,Active,"85,577.00",1717,2013-11-08
+1568,Securing livelihoods in post-conflict area,EUR,"558,050.00",1,published,Active,"558,050.00",273,2013-11-08
+1569,Spices Producer support Investment Fund,EUR,"250,000.00",0,published,Active,"250,000.00",273,2013-11-08
+1570,Lobby capacities of farmer organizations,EUR,"100,000.00",0,published,Active,"100,000.00",1099,2013-11-08
+1571,Small farmer's access to financial services,EUR,"338,000.00",0,published,Active,"338,000.00",1099,2013-11-08
+1572,Evidence based advocacy on land issues,EUR,"239,900.00",1,published,Active,"239,900.00",1099,2013-11-08
+1573,Enhancing Economic Performance of Farmers,EUR,"312,187.00",0,published,Active,"312,187.00",1099,2013-11-08
+1574,Small scale dairy industries,EUR,"1,550,000.00",0,published,Active,"1,550,000.00",1099,2013-11-08
+1575,Plantain and potato value chain development,EUR,"123,000.00",0,published,Active,"123,000.00",1812,2013-11-08
+1576,Akvo RSR Update App,EUR,"50,000.00",38,published,Completed,"50,000.00",272,2013-11-12
+1577,"Water, sanitation and hygiene in Ethiopia",EUR,"83,416.00",1,published,H,"69,744.40",1151,2013-11-13
+1578,WASH Consortium - Akvo FLOW,EUR,"38,000.00",0,published,Active,"38,000.00",440,2013-11-18
+1579,DRR program in Central America,EUR,"1,172,170.00",11,published,Active,"1,172,170.00",273,2013-12-03
+1580,CRS Emergency response Typhoon Haiyan,EUR,"200,000.00",0,published,Active,"200,000.00",1358,2013-12-11
+1581,School Adoption Program Ghana fase II 2014,EUR,"114,976.00",0,published,Active,"114,976.00",43,2013-12-18
+1582,"Water for life - Nakuru, Kenya",EUR,"117,000.00",1,published,Active,"117,000.00",43,2013-12-18
+1583,"Water for Life in Dhaka, Bangladesh",EUR,"338,678.00",1,published,Active,"338,678.00",8,2013-12-18
+1584,Prepaid Handpumps Kenya,EUR,"161,050.00",9,published,Active,"161,050.00",881,2013-12-18
+1585,Santeen,EUR,"8,650.00",0,published,H,"2,198.82",2150,2013-12-18
+1587,Watervoorziening voor school in Kameroen,EUR,"4,000.00",5,published,Active,"4,000.00",1151,2013-12-23
+1588,Fite Bako water project,EUR,"11,702.00",1,published,Active,"11,701.82",1151,2014-01-06
+1589,"Clean Water, Conserve Water in Moradabad",EUR,"65,200.00",0,published,H,"18,780.00",2150,2014-01-15
+1591,Productive Reuse of Waste for Food Production,EUR,"17,750.00",2,published,Active,"17,750.00",35,2014-01-17
+1592,Toilets and Improved Cooking Stoves,EUR,"23,407.00",1,published,Active,"23,407.00",43,2014-01-17
+1593,Young Football Volunteers,USD,"442,144.00",4,published,Active,"442,144.00",739,2014-01-22
+1594,Performance Improvement Water Company Bonaire,EUR,"286,000.00",1,published,Active,"428,000.00",678,2014-01-22
+1595,Improved capacity drinking water FIPAG Norte,EUR,"1,243,320.00",4,published,Active,"1,073,320.00",1354,2014-01-22
+1596,Reducing Non Revenue Water in Morogoro,EUR,"59,730.00",0,published,Active,"59,730.00",678,2014-01-22
+1597,"Source to Tap and Back, Ethiopia",EUR,"7,100,000.00",1,published,Active,"7,100,000.00",678,2014-01-22
+1598,"Water Operator Partnership, Dhaka, Bangladesh",EUR,"6,800,000.00",13,published,Active,"6,800,000.00",1837,2014-01-22
+1599,Realizing Sustainable Water Services,EUR,"5,590,963.00",1,published,Active,"5,479,144.00",1234,2014-01-22
+1600,Climate change and drinking water supply ,EUR,"10,000,000.00",0,published,Active,"9,350,000.00",1430,2014-01-22
+1601,Institutional strengthening of FIPAG,EUR,"7,300,000.00",8,published,Active,"7,300,000.00",911,2014-01-27
+1602,The Copperbelt Water Operator Partnership,EUR,"1,319,200.00",4,published,Active,"1,361,416.00",678,2014-01-27
+1603,Peri-urban Water Supply and Sanitation,EUR,"3,850,000.00",1,published,Active,"3,850,000.00",678,2014-01-27
+1604,The Centre of Expertise,EUR,"1,000,000.00",11,published,Active,"1,000,000.00",1629,2014-01-27
+1605,"Water Quality Monitoring/Surveillance, Ghana",EUR,"1,141,700.00",11,published,Active,"1,141,700.00",2311,2014-01-27
+1606,WASH project in Southern Ethiopia,EUR,"32,000.00",1,published,Active,"32,000.00",43,2014-01-27
+1607,Enhancing water service providers performance,EUR,"1,194,030.00",0,published,Active,"1,217,910.00",1691,2014-01-27
+1608,"Urban Dredging Demonstration Project, Dhaka ",EUR,"7,500,000.00",14,published,Active,"7,500,000.00",1837,2014-01-28
+1609,Better Water Services in Naivasha,EUR,"5,100,000.00",2,published,Active,"4,309,500.00",1841,2014-01-28
+1610,Capacity Building in Kisumu and Nakuru,EUR,"1,341,488.00",1,published,Active,"1,336,961.00",1089,2014-01-28
+1611,Enhancing water services in Mombasa,EUR,"7,400,000.00",0,published,Active,"5,712,800.00",882,2014-01-28
+1612,Nakuru County Sanitation Project,EUR,"4,200,000.00",5,published,Active,"1,260,000.00",881,2014-01-28
+1613,Enhancing Water Asset Management,EUR,"1,540,000.00",13,published,Active,"1,543,325.00",2161,2014-01-28
+1614," Capacity Building in Oromia, Ethiopia",EUR,"1,216,384.00",0,published,Active,"1,216,385.00",1354,2014-01-28
+1615,Sustainable Access to improved WASH Services ,EUR,"1,131,902.00",0,published,Active,"1,131,902.00",1824,2014-01-28
+1616,Cooperation between SONEB and Brabant Water,EUR,"40,000.00",5,published,Active,"40,000.00",1684,2014-01-28
+1617,Data gathering and Mapping in West Africa,EUR,"40,000.00",5,published,Active,"40,000.00",464,2014-01-28
+1618,EnterWASH: Enterprising in WASH sector,EUR,"40,000.00",8,published,Active,"40,000.00",464,2014-01-28
+1619,Consultancy in water supply and sanitation,EUR,"40,000.00",4,published,Active,"40,000.00",464,2014-01-28
+1620,Rural drinking water supply in Uganda,EUR,"40,000.00",2,published,Active,"40,000.00",464,2014-01-28
+1621,YEP Water Northern Uganda,EUR,"40,000.00",3,published,Active,"40,000.00",464,2014-01-28
+1622,"YEP | Drinking water | Dhaka, Bangladesh",EUR,"40,000.00",3,published,Active,"40,000.00",1686,2014-01-28
+1623,Joint Zambezi River Basin E-flow Programme,EUR,"40,000.00",1,published,Active,"40,000.00",1975,2014-01-28
+1624,"Rehabilitation of Canal del Dique, Colombia",EUR,"40,000.00",1,published,Active,"40,000.00",1684,2014-01-28
+1625,Land Use Planning in the Central Rift Valley,EUR,"40,000.00",8,published,Active,"40,000.00",1684,2014-01-28
+1626,Monitoring and Evaluation in Bangladesh,EUR,"40,000.00",3,published,Active,"40,000.00",464,2014-01-28
+1627,Yep Water in Northern Uganda,EUR,"12,000.00",2,published,Active,"12,000.00",464,2014-01-28
+1628,"WASH Project in Amuria, Uganda",EUR,"12,000.00",4,published,Active,"12,000.00",464,2014-01-28
+1629,Improvement of water supply network,EUR,"12,000.00",6,published,Active,"12,000.00",464,2014-01-28
+1630,One hundred wetlands in Northern Uganda,EUR,"12,000.00",4,published,Active,"12,000.00",464,2014-01-28
+1631,Supporting West Africa hub in IT and GIS,EUR,"12,000.00",1,published,Active,"12,000.00",464,2014-01-28
+1632,Modeste Spero Tokpon,EUR,"12,000.00",1,published,Active,"12,000.00",190,2014-01-28
+1633,EnterWASH,EUR,"12,000.00",1,published,Active,"12,000.00",464,2014-01-28
+1634,Project MULGRO ,EUR,"12,000.00",4,published,Active,"12,000.00",464,2014-01-28
+1635,Better health through mobiles & computers,EUR,"180,000.00",0,published,Completed,"180,000.00",273,2014-01-28
+1636,Channeling India's Entrepreneural Energy,EUR,"1,659,818.00",0,published,Active,"1,659,818.00",464,2014-01-28
+1637,Networking to battle urban poverty,EUR,"13,123,000.00",0,published,Completed,"13,123,000.00",464,2014-01-28
+1638,Ondoy-Pepeng Rehabilitation Fund,EUR,"1,650,000.00",0,published,Active,"1,650,000.00",273,2014-01-28
+1639,Microfinance in Uttar Pradesh and Bihar,EUR,"500,000.00",0,published,Active,"500,000.00",1422,2014-01-28
+1640,General health and Health Insurance 2010-2013,EUR,"455,000.00",0,published,Active,"455,000.00",1856,2014-01-28
+1641,Telemedicine in Tanzania,EUR,"55,000.00",0,published,Completed,"55,000.00",273,2014-01-28
+1642,Investing in a worldwide Rural Fund,EUR,"2,500,326.00",0,published,Active,"2,500,326.00",273,2014-01-28
+1643,Integrated ICT activities in health system,EUR,"402,351.00",1,published,Active,"402,351.00",42,2014-01-28
+1644,Medical care for undocumented migrants,EUR,"25,000.00",0,published,Completed,"25,000.00",273,2014-01-28
+1645,Microfinance in Madhya Pradesh,EUR,"450,000.00",0,published,Active,"450,000.00",273,2014-01-28
+1646,Providing access to capital for agri-SMEs,EUR,"10,100,000.00",0,published,Active,"10,100,000.00",273,2014-01-28
+1647,Integration of ICT in PBF program,EUR,"146,056.00",10,published,Completed,"146,056.00",272,2014-01-28
+1648,Safe Motherhood campaign,EUR,"62,803.00",0,published,Completed,"62,803.00",1906,2014-01-28
+1649,Advocacy for Rights to Health Services,EUR,"268,513.00",0,published,Active,"268,513.00",949,2014-01-28
+1650,National depot for essential medicines,EUR,"250,885.00",0,published,Active,"250,885.00",949,2014-01-28
+1651,Improving data management in Home Based Care,EUR,"13,533.00",0,published,Active,"13,533.00",1297,2014-01-28
+1652,Stimulate agri production by microfinance,EUR,"760,290.00",0,published,Active,"760,290.00",273,2014-01-28
+1653,Implementing Integrated e-Health applications,EUR,"232,553.00",0,published,Active,"232,553.00",949,2014-01-28
+1654,Restoring local ecosystems,EUR,"477,741.00",5,published,Active,"477,741.00",273,2014-01-28
+1655,Theatre activities for Palestinian youth,EUR,"947,799.00",0,published,Active,"947,799.00",464,2014-01-28
+1656,Supporting agricultural enterprises,EUR,"100,000.00",0,published,Active,"100,000.00",273,2014-01-28
+1657,Women empowerment in relation to peace,EUR,"40,000.00",1,published,Active,"40,000.00",273,2014-01-28
+1658,Alternative News Portal for Social Change,EUR,"206,859.00",0,published,Active,"206,859.00",955,2014-01-28
+1659,Reducing vulnerability to climate change,EUR,"89,593.00",0,published,Active,"89,593.00",1653,2014-01-28
+1660,Disaster Preparedness in South Sudan,EUR,"221,500.00",1,published,Active,"221,500.00",961,2014-01-28
+1661,Capacity building for local organization,EUR,"239,621.00",0,published,Active,"239,621.00",1530,2014-01-28
+1662,Local Conditional Cash Transfer project,EUR,"155,420.00",0,published,Active,"155,420.00",949,2014-01-28
+1663,Result based education and care for children,EUR,"530,240.00",0,published,Active,"530,240.00",1527,2014-01-28
+1664,Youth empowerment through sports and arts,EUR,"809,137.00",1,published,Active,"809,137.00",1354,2014-01-28
+1665,Equity fund health insurance,EUR,"50,000.00",0,published,Active,"50,000.00",1385,2014-01-28
+1666,Safe drinking water for Sofyanin village,EUR,"50,000.00",0,published,Completed,"50,000.00",962,2014-01-28
+1667,Accompaniment in CCT program,EUR,0.00,0,published,Active,0.00,273,2014-01-28
+1668,Additional loan for expansion to Mekong Delta,EUR,"500,000.00",0,published,Active,"500,000.00",273,2014-01-28
+1669,Empowering Minority Communities in Haifa,EUR,"168,977.00",0,published,Active,"168,977.00",1857,2014-01-28
+1670,Relieving pastoralist women of poverty,EUR,"140,118.00",0,published,Active,"140,118.00",464,2014-01-28
+1671,Innovations for mother and child health,EUR,"525,252.00",1,published,Active,"525,252.00",34,2014-01-28
+1672,Agricultural finance product development,EUR,"989,774.00",0,published,Active,"989,774.00",1354,2014-01-28
+1673,Strengthening community leadership,EUR,"46,117.00",0,published,Active,"46,117.00",1653,2014-01-28
+1674,"Maternal, Infant and Reproductive Health",EUR,"75,000.00",1,published,Active,"75,000.00",1881,2014-01-28
+1675,Reproductive health services for girls,EUR,"361,000.00",0,published,Active,"361,000.00",1297,2014-01-28
+1676,Sustainable Microfinance in Vietnam,EUR,"30,000.00",0,published,Active,"30,000.00",953,2014-01-28
+1677,Preparing Teeru community for drought,EUR,"98,103.00",1,published,Active,"98,103.00",1358,2014-01-28
+1678,Impunity related to violence against women,EUR,"53,922.00",0,published,Active,"53,922.00",1915,2014-01-28
+1679,Strengthened health care and rights,EUR,"352,720.00",0,published,Active,"352,720.00",949,2014-01-28
+1680,Non Food Items Kits for Displaced Families,EUR,"565,500.00",0,published,Active,"565,500.00",1384,2014-01-28
+1681,Resilience building in Arero,EUR,"311,207.00",0,published,Active,"311,207.00",614,2014-01-28
+1682,Trauma relief for women and girls in Gaza,EUR,"50,307.00",0,published,Active,"50,307.00",1306,2014-01-28
+1683,Support for children from poor families,EUR,"22,500.00",0,published,Completed,"22,500.00",273,2014-01-28
+1684,Business Plan Results Based Financing Trainin,EUR,"80,685.00",0,published,Active,"80,685.00",1800,2014-01-28
+1685,Use of computers in improving health services,EUR,"162,613.00",1,published,Active,"162,613.00",42,2014-01-28
+1686,Building a Culture of Peace,EUR,"157,903.00",0,published,Active,"157,903.00",273,2014-01-28
+1687,Equity investments in Eastern African MFIs,EUR,"3,370,786.00",0,published,Active,"3,370,786.00",273,2014-01-28
+1688,Adapting pastoralism to climate change,EUR,"863,546.00",0,published,Active,"863,546.00",961,2014-01-28
+1689,Enabling Access to health through ICT,EUR,"126,989.00",1,published,Active,"126,989.00",273,2014-01-28
+1690,Support Healthcare of chronic diseases,EUR,"47,563.00",0,published,Active,"47,563.00",273,2014-01-28
+1691,The relic of my heritage,EUR,"6,500.00",0,published,Completed,"6,500.00",1890,2014-01-28
+1692,Manganjo water development project,EUR,"128,600.00",0,published,Active,"128,600.00",1909,2014-01-28
+1693,Corporate Lobby activities 2013,EUR,"144,864.00",0,published,Active,"144,864.00",273,2014-01-28
+1694,Strengthening Healthcare for the Underserved,EUR,"150,000.00",1,published,Active,"150,000.00",949,2014-01-28
+1695,Feasibility study microfinance fund,EUR,"78,960.00",0,published,Active,"78,960.00",273,2014-01-28
+1696,ICT for safe motherhood and chronically ill,EUR,"51,047.00",0,published,Active,"51,047.00",1852,2014-01-28
+1697,Sustainable forestry and agrifinance,EUR,"20,000.00",0,published,Active,"20,000.00",953,2014-01-28
+1698,Sustainable forestry and agrifinance,EUR,"75,393.00",0,published,Active,"75,393.00",273,2014-01-28
+1699,Access to finance for Ethiopian farmers,EUR,"838,336.00",0,published,Active,"838,336.00",273,2014-01-28
+1700,Women leaders engaging men for their security,EUR,"30,970.00",0,published,Active,"30,970.00",1930,2014-01-28
+1701,Evaluation of TitanE program in Moluccas,EUR,"15,000.00",0,published,Active,"15,000.00",1901,2014-01-28
+1702,result based extension services,EUR,"134,892.00",0,published,Active,"134,892.00",1946,2014-01-28
+1703,Improving women's health in two woreda's,EUR,"187,408.00",0,published,Active,"187,408.00",1947,2014-01-28
+1704,Bike 4 Care,EUR,"42,341.00",0,published,Active,"42,341.00",1949,2014-01-28
+1705,care project 2013-2014,EUR,"45,000.00",0,published,Active,"45,000.00",464,2014-01-28
+1706,Basic healthcare Urozgan,EUR,"1,075,255.00",0,published,Active,"1,075,255.00",1354,2014-01-28
+1707,Hospital healthcare in Urozgan,EUR,"529,816.00",0,published,Active,"529,816.00",273,2014-01-28
+1708,CMDRR in Luangwa Valley,EUR,"79,709.00",0,published,Active,"79,709.00",273,2014-01-28
+1709,Increased community resilience to disasters,EUR,"293,730.00",0,published,Active,"293,730.00",464,2014-01-28
+1710,Community interventions in Gitega and Mwaro,EUR,"323,981.00",0,published,Active,"323,981.00",273,2014-01-28
+1711,Performance based health care provision,EUR,"1,615,027.00",0,published,Active,"1,615,027.00",1592,2014-01-28
+1712,capacity building and training program,EUR,"84,000.00",0,published,Active,"84,000.00",273,2014-01-28
+1713,Continuation Zimbabwean WB RBF Health program,EUR,"20,000,000.00",0,published,Active,"20,000,000.00",876,2014-01-28
+1714,Increasing access to quality health services,EUR,"578,664.00",6,published,Active,"578,664.00",273,2014-01-28
+1715,Rural Savings and Legal Frameworks,EUR,"61,600.00",0,published,Active,"61,600.00",1917,2014-01-28
+1716,Mobile Bakery for Syrian People,EUR,"63,000.00",0,published,Active,"63,000.00",962,2014-01-28
+1717,The impact of coal mining in CesÃ¡r Colombia,EUR,"60,500.00",0,published,Active,"60,500.00",273,2014-01-28
+1718,Protecting Nature,EUR,"45,000.00",0,published,Active,"45,000.00",273,2014-01-28
+1719,Education for out of school children,EUR,"330,117.00",0,published,Active,"330,117.00",464,2014-01-28
+1720,Reducing the worst forms of child labor,EUR,"48,145.00",0,published,Active,"48,145.00",273,2014-01-28
+1721,Food Security Project Wenchi 2013-2014,EUR,"30,000.00",0,published,Active,"30,000.00",273,2014-01-28
+1722,Improving the Well Being of Pastoralist Women,EUR,"32,194.00",0,published,Active,"32,194.00",949,2014-01-28
+1723,Mitigate negative efects of mining,EUR,"74,600.00",0,published,Active,"74,600.00",1361,2014-01-28
+1724,Political Advocacy in Extractive Industries,EUR,"75,700.00",0,published,Active,"75,700.00",1361,2014-01-28
+1725,Women's Health Programme in Borana,EUR,"110,000.00",0,published,Active,"110,000.00",949,2014-01-28
+1726,Mother and Child Health Improvement Program,EUR,"120,000.00",0,published,Active,"120,000.00",2072,2014-01-28
+1727,Distribution of malaria bednets,EUR,"217,085.00",0,published,Active,"217,085.00",1880,2014-01-28
+1728,Access to finance in emerging economies,EUR,"6,285,000.00",0,published,Active,"6,285,000.00",1653,2014-01-28
+1729,Building disaster resilience in Congo (DRC),EUR,0.00,0,published,Active,0.00,464,2014-01-28
+1730,Social cohesion for disaster risk reduction,EUR,"315,494.00",0,published,Active,"315,494.00",1933,2014-01-28
+1731,Development of innovative Shelter,EUR,0.00,0,published,Active,0.00,273,2014-01-28
+1732,Disaster risk reduction in Juba Diocese,EUR,"51,916.00",1,published,Active,"51,916.00",464,2014-01-28
+1733,Maternal Health in Oromia Region,EUR,"149,955.00",0,published,Active,"149,955.00",1416,2014-01-28
+1734,"CMDRR en Guisayote y Rio Blanco, Honduras",EUR,"232,700.00",6,published,Active,"232,700.00",464,2014-01-28
+1735,Water management and Disaster Risk Reduction,EUR,"593,889.00",5,published,Active,"593,889.00",1971,2014-01-28
+1736,Enhancing Resilience by Recovering Livelihood,EUR,"248,000.00",4,published,Active,"248,000.00",1306,2014-01-28
+1737,Education of youth in Sacoj,EUR,"44,200.00",0,published,Active,"44,200.00",1952,2014-01-28
+1738,CMDRR Phase 2 in Larique (BND),EUR,"208,322.00",1,published,Active,"208,322.00",1452,2014-01-28
+1739,Femmes au Fone: the voice of local women,EUR,"935,984.00",0,published,Active,"935,984.00",273,2014-01-28
+1740,More transparency in the extractivesâ€™ sector,EUR,"100,000.00",0,published,Active,"100,000.00",1931,2014-01-28
+1741,Restoring grasslands,EUR,200.00,0,published,Active,200.00,1058,2014-01-28
+1742,Back Home House activities,EUR,"60,400.00",0,published,Active,"60,400.00",273,2014-01-28
+1743,Evaluation missie BDom's / Caritas Dr Congo,EUR,"45,000.00",0,published,Active,"45,000.00",273,2014-01-28
+1744,Community Security & Small Arms Program,EUR,0.00,0,published,Active,0.00,273,2014-01-28
+1745,Peace Unveiled Screening Event and Debate,EUR,"50,000.00",0,published,Active,"50,000.00",273,2014-01-28
+1746,Raise the voices of Indigenous People,EUR,"102,910.00",0,published,Active,"102,910.00",2028,2014-01-28
+1747,Cooperative Social Entrepreneurship,EUR,"199,500.00",0,published,Active,"199,500.00",273,2014-01-28
+1748,Giving partners an online platform,EUR,"119,587.00",0,published,Active,"119,587.00",273,2014-01-28
+1749,Reconstruction of schools after cloud burst,EUR,"120,000.00",0,published,Active,"120,000.00",1315,2014-01-28
+1750,Expansion of Microfinance Program,EUR,"705,000.00",0,published,Active,"705,000.00",273,2014-01-28
+1751,South Sudan Community Policing Research,EUR,0.00,0,published,Active,0.00,273,2014-01-28
+1752,Improve living conditions mothers and kids,EUR,"46,165.00",0,published,Active,"46,165.00",273,2014-01-28
+1753,Increasing household food security,EUR,"147,000.00",0,published,Active,"147,000.00",1476,2014-01-28
+1754,Strengthening the Lobby Capacities of Farmers,EUR,"138,000.00",0,published,Active,"138,000.00",273,2014-01-28
+1755,lobby and advocacy action plan 2013,EUR,"241,800.00",0,published,Active,"241,800.00",1099,2014-01-28
+1756,Strengthening medicines supply in CAR,EUR,"146,231.00",0,published,Active,"146,231.00",1354,2014-01-28
+1757,Water Shops for India,EUR,"250,000.00",1,published,Active,"250,000.00",961,2014-01-28
+1758,Strengthening Communities in the Niger Delta,EUR,"70,000.00",0,published,Active,"70,000.00",1495,2014-01-28
+1759,Strengthening dialogue on environment,EUR,"51,300.00",0,published,Active,"51,300.00",960,2014-01-28
+1760,Empowerment of women's groups,EUR,0.00,0,published,Active,0.00,273,2014-01-28
+1761,Projet de Renforcement du Leadership Feminin,EUR,"100,000.00",0,published,Active,"100,000.00",273,2014-01-28
+1762,Research in transparency & accountability,EUR,"57,000.00",1,published,Active,"57,000.00",464,2014-01-28
+1763,Economic empowerment in Upper Nile State,EUR,"80,000.00",0,published,Active,"80,000.00",1957,2014-01-28
+1764,Womenâ€™s competitiveness in rural markets,EUR,"198,000.00",0,published,Active,"198,000.00",464,2014-01-28
+1765,Meet the Deaf,EUR,"41,085.00",0,published,Active,"41,085.00",273,2014-01-28
+1766,Farmer Empowerment in Kunduz,EUR,"179,000.00",0,published,Active,"179,000.00",1967,2014-01-28
+1767,Integrated agriculture development in Kunduz,EUR,"247,000.00",0,published,Active,"247,000.00",464,2014-01-28
+1768,Food security and peace building programme,EUR,"47,400.00",0,published,Active,"47,400.00",464,2014-01-28
+1769,Improve Farmers and Fishermen Production,EUR,"36,000.00",0,published,Active,"36,000.00",273,2014-01-28
+1770,Improved food security for (wo)men in Makal,EUR,"26,900.00",0,published,Active,"26,900.00",1957,2014-01-28
+1771,Support agricultural producers in Grand GoÃ¢ve,EUR,"216,000.00",1,published,Active,"216,000.00",1362,2014-01-28
+1772,Handbook Educating Local Communities,EUR,"65,500.00",0,published,Active,"65,500.00",464,2014-01-28
+1773,Support to under age mothers,EUR,"48,000.00",0,published,Active,"48,000.00",962,2014-01-28
+1774,Pharmacist technical assistant,EUR,"44,842.00",0,published,Active,"44,842.00",464,2014-01-28
+1775,International women projects 2013-2014,EUR,"49,920.00",0,published,Active,"49,920.00",273,2014-01-28
+1776,Promoting Risk Assessment,EUR,"64,470.00",1,published,Active,"64,470.00",960,2014-01-28
+1777,Analyzing 40 years of mining activities,EUR,"46,000.00",0,published,Active,"46,000.00",464,2014-01-28
+1778,Pilot project building capacities of MFIs,EUR,"75,000.00",0,published,Active,"75,000.00",1959,2014-01-28
+1779,Technical Assistance for OXUS MFI,EUR,"156,374.00",0,published,Active,"156,374.00",950,2014-01-28
+1780,Training of local entrepreneurs in South Kivu,EUR,"63,000.00",0,published,Active,"63,000.00",1960,2014-01-28
+1781,Dialogue about extractive industries,EUR,"60,000.00",0,published,Active,"60,000.00",273,2014-01-28
+1783,Protection of Women Leaders,EUR,"93,200.00",0,published,Active,"93,200.00",1862,2014-01-28
+1784,Bihar Floods 2013,EUR,"300,000.00",0,published,Active,"300,000.00",1453,2014-01-28
+1785,Increased empowerment for Palestinian women,EUR,"75,000.00",0,published,Active,"75,000.00",464,2014-01-28
+1786,Accompaniment Extractives Program in S. Sudan,EUR,"55,570.00",0,published,Active,"55,570.00",960,2014-01-28
+1787,Emergency Aid to displaced in Damascus,EUR,"315,518.00",0,published,Active,"315,518.00",961,2014-01-28
+1788,Strengthening emerging MFIs in East Africa,EUR,"20,000.00",0,published,Active,"20,000.00",953,2014-01-28
+1789,Securing land and resources rights,EUR,"130,000.00",0,published,Active,"130,000.00",1765,2014-01-28
+1790,Helping girls survivors of sexual violence,EUR,"90,269.00",0,published,Active,"90,269.00",273,2014-01-28
+1791,Alliance of Women Free of Violence,EUR,"199,000.00",0,published,Active,"199,000.00",955,2014-01-28
+1792,Capacity Building of women organisations,EUR,"206,214.00",0,published,Active,"206,214.00",273,2014-01-28
+1794,Advocacy for better results in health,EUR,"150,000.00",3,published,Active,"150,000.00",273,2014-01-28
+1795,Strengthening Women's Leadership for Peace,EUR,"232,945.00",0,published,Active,"232,945.00",464,2014-01-28
+1796,Women Constructing Peace in Colombia,EUR,"267,879.00",0,published,Active,"267,879.00",1652,2014-01-28
+1797,"Collecting evidence, sharing knowledge",EUR,"300,000.00",0,published,Active,"300,000.00",273,2014-01-28
+1798,Improving maternal and neonatal health,EUR,"163,932.00",0,published,Active,"163,932.00",693,2014-01-28
+1799,Basic needs and climate change advocacy,EUR,"61,000.00",0,published,Active,"61,000.00",273,2014-01-28
+1800,Clean water for Bertoua phase 7,EUR,"200,191.00",0,published,Active,"200,191.00",273,2014-01-28
+1801,Strengthening the civil society networks,EUR,"371,010.00",0,published,Active,"371,010.00",464,2014-01-28
+1802,Counseling and Social Services Center,EUR,"122,130.00",0,published,Active,"122,130.00",1954,2014-01-28
+1803,Loan to Microfinance Instutions,EUR,"587,928.00",0,published,Active,"587,928.00",1563,2014-01-28
+1804,Women building learning communities,EUR,"36,000.00",0,published,Active,"36,000.00",1731,2014-01-28
+1805,Presenting evidence and results,EUR,"100,000.00",0,published,Active,"100,000.00",949,2014-01-28
+1806,Local Economic development in Mindanao,EUR,"339,250.00",0,published,Active,"339,250.00",950,2014-01-28
+1807,Women in charge of their stories,EUR,"100,000.00",4,published,Active,"100,000.00",1859,2014-01-28
+1808,Supporting Caritas Central African Republic,EUR,"24,774.00",0,published,Active,"24,774.00",273,2014-01-28
+1809,Short Term Loan Finance South Sudan 2013,EUR,"204,072.00",0,published,Active,"204,072.00",1278,2014-01-28
+1810,Epilepsie Programme Kenya,EUR,"50,000.00",0,published,Active,"50,000.00",962,2014-01-28
+1811,Advocacy on resilience to climate change,EUR,"31,608.00",0,published,Active,"31,608.00",273,2014-01-28
+1812,Strengthening enterprises in East Africa,EUR,"60,000.00",0,published,Active,"60,000.00",1870,2014-01-28
+1813,"Emergency Aid Orissa,Cyclone Phailin affected",EUR,"74,618.00",0,published,Active,"74,618.00",273,2014-01-28
+1814,"Cordaid, AAP and the inspection join hands",EUR,"150,367.00",0,published,Active,"150,367.00",1341,2014-01-28
+1815,Women trafficking: prevent and sensibilize,EUR,"40,000.00",0,published,Active,"40,000.00",1876,2014-01-28
+1816,Livelihood support Phailin Affected Victims,EUR,"50,000.00",0,published,Active,"50,000.00",1285,2014-01-28
+1817,Creating opportunities for water catchment,EUR,"56,630.00",0,published,Active,"56,630.00",1878,2014-01-28
+1818,Strengthening Women's Political Leadership,EUR,"299,298.00",7,published,Active,"299,298.00",273,2014-01-28
+1819,Women in search of equal human rights,EUR,"31,500.00",0,published,Active,"31,500.00",1905,2014-01-28
+1820,Strengthening Women Political Capacity,EUR,"40,000.00",0,published,Active,"40,000.00",1875,2014-01-28
+1821,Strengthening Women's Leadership,EUR,"30,000.00",0,published,Active,"30,000.00",464,2014-01-28
+1822,Combating Illiteracy for Women Empowerment,EUR,"88,850.00",0,published,Active,"88,850.00",1923,2014-01-28
+1823,Emergency Response after Cyclone Phailin,EUR,"650,092.00",0,published,Active,"650,092.00",1453,2014-01-28
+1824,Natural resources and mining,EUR,"47,500.00",0,published,Active,"47,500.00",2020,2014-01-28
+1825,Coffee cooperative in Mubuga,EUR,"31,927.00",0,published,Active,"31,927.00",464,2014-01-28
+1826,Preventing femicides and violence,EUR,"35,000.00",0,published,Active,"35,000.00",464,2014-01-28
+1827,Development of the honey sector,EUR,"65,782.00",0,published,Active,"65,782.00",1853,2014-01-28
+1828,Informing people about natural resources,EUR,"84,000.00",0,published,Active,"84,000.00",1364,2014-01-28
+1829,Improving community health,EUR,"350,000.00",0,published,Active,"350,000.00",273,2014-01-28
+1830,Results based financing ExtrÃªme Nord,EUR,"904,007.00",0,published,Active,"904,007.00",464,2014-01-28
+1831,Twiga Ventures,EUR,"135,000.00",0,published,Active,"135,000.00",949,2014-01-28
+1832,Increasing effective participation of women,EUR,"100,000.00",0,published,Active,"100,000.00",1797,2014-01-28
+1833,Day care centres in Bangalore,EUR,"26,000.00",0,published,Active,"26,000.00",273,2014-01-28
+1834,Rhetoric to reality â€“ implementing UNSCR1325,EUR,"11,600.00",0,published,Active,"11,600.00",955,2014-01-28
+1835,Increasing community disaster resilience,EUR,"67,104.00",0,published,Active,"67,104.00",1758,2014-01-28
+1836,Service offering by BlueSquare,EUR,"90,484.00",0,published,Active,"90,484.00",1814,2014-01-28
+1837,Development of agricultural value chains,EUR,"210,500.00",0,published,Active,"210,500.00",1910,2014-01-28
+1838,Improving storage facilities for madams Sara,EUR,"183,500.00",0,published,Active,"183,500.00",273,2014-01-28
+1839,Haiyan affected families receive relief kits,EUR,"300,000.00",0,published,Active,"300,000.00",1945,2014-01-28
+1840,Portable water for Botogwina,EUR,"21,085.00",0,published,Completed,"21,085.00",1926,2014-01-28
+1841,Haiyan emergency assistance in 9 dioceses,EUR,"1,000,000.00",1,published,Active,"1,000,000.00",1850,2014-01-28
+1842,Women's citizenship and Life without violence,EUR,"38,435.00",0,published,Active,"38,435.00",464,2014-01-28
+1843,Daikundi livestock development program,EUR,"343,000.00",1,published,Active,"343,000.00",464,2014-01-28
+1844,Promoting Social Enterprise,EUR,"540,000.00",0,published,Active,"540,000.00",273,2014-01-28
+1845,Nabari Community Empowerment Project,EUR,"30,000.00",0,published,Active,"30,000.00",837,2014-01-28
+1846,Social Performance of MFIs,EUR,"75,000.00",0,published,Active,"75,000.00",273,2014-01-28
+1847,Our Territory,EUR,"70,000.00",0,published,Active,"70,000.00",960,2014-01-28
+1848,Youth Entrepreneurship,EUR,"61,200.00",0,published,Active,"61,200.00",950,2014-01-28
+1849,India - Contingency Planning,EUR,"20,000.00",0,published,Active,"20,000.00",273,2014-01-28
+1850,Impact study & cooperation CUB-Cordaid,EUR,"37,000.00",0,published,Active,"37,000.00",1324,2014-01-28
+1851,Self-determination through philanthropy,EUR,"53,800.00",0,published,Active,"53,800.00",2044,2014-01-28
+1852,Women leadership and elections conflicts,EUR,"81,500.00",0,published,Active,"81,500.00",1973,2014-01-28
+1853,Coal mining and human rights in La Guajira,EUR,"50,000.00",0,published,Active,"50,000.00",960,2014-01-28
+1854,Strengthening of Burundi NGO Working Group,EUR,"68,000.00",0,published,Active,"68,000.00",273,2014-01-28
+1855,Favela Painting Investigation in Haiti,EUR,"20,000.00",0,published,Active,"20,000.00",961,2014-01-28
+1856,Day care centre refugee children,EUR,"29,000.00",0,published,Active,"29,000.00",464,2014-01-28
+1857,Credit services and education for rural women,EUR,"544,745.00",0,published,Active,"544,745.00",273,2014-01-28
+1858,Women in Gaza monitor their daily security,EUR,"82,000.00",1,published,Active,"82,000.00",1869,2014-01-28
+1859,Haiyan affected families receive food aid,EUR,"85,000.00",0,published,Active,"85,000.00",1863,2014-01-28
+1860,Comprehensive Risk Assessment Livelihood,EUR,"13,050.00",0,published,Active,"13,050.00",464,2014-01-28
+1861,"Cholera prevention in Artibonite, Haiti",EUR,"220,915.00",0,published,Active,"220,915.00",1601,2014-01-28
+1862,Response Syrian Refugees in Istanbul,EUR,"157,585.00",0,published,Active,"157,585.00",2016,2014-01-28
+1863,Emergency Aid Programme in Syria,EUR,"518,600.00",0,published,Active,"518,600.00",1948,2014-01-28
+1864,Coordination Uttarakhand & Odisha,EUR,"20,000.00",0,published,Active,"20,000.00",1918,2014-01-28
+1866,Mobile Data Gathering in East Africa,EUR,"40,000.00",6,published,Active,"40,000.00",1684,2014-02-04
+1867,Kouassi Oka,USD,350.00,0,published,H,24.10,846,2014-02-06
+1868,"Water & sanitation in small towns, Mozambique",EUR,"7,635,218.00",9,published,Active,"7,635,218.00",222,2014-02-07
+1869,Kouadio Jachin Koua,USD,350.00,0,published,H,160.74,539,2014-02-07
+1870,Kouadio Kouame,USD,350.00,0,published,H,0.00,540,2014-02-07
+1871,Kouakou Lazare Kouame,USD,350.00,0,published,H,33.86,540,2014-02-07
+1872,Saraka Kouassi,USD,350.00,0,published,Active,350.76,540,2014-02-07
+1873,Special Ability ,USD,"13,440.00",2,published,Active,"13,440.00",428,2014-02-12
+1874,Rain Water Harvesting Project,EUR,"49,973.00",3,published,Active,"49,973.00",275,2014-02-18
+1875,"Water for Life Chimoio, Mozambique",EUR,"93,500.00",1,published,Active,"93,500.00",679,2014-02-18
+1876,Drinkwater voor schoolkinderen in Kwale Kenia,EUR,"51,300.00",0,published,H,0.00,1151,2014-02-20
+1877,Sarakasi Performing Arts ,EUR,"263,880.00",5,published,Active,"263,880.00",1977,2014-02-25
+1878,Water and Sanitation Bandung Barat Regency,EUR,"65,012.00",0,published,H,0.00,43,2014-02-25
+1879,Mobile Technology for Clean Water in Uganda,EUR,"65,000.00",0,published,Active,"65,000.00",969,2014-02-27
+1880,Kuona Visual Arts ,EUR,"271,210.00",16,published,Active,"271,210.00",360,2014-03-04
+1881,H2O Health Plus (H2O+),EUR,"670,000.00",12,published,H,"470,000.00",43,2014-03-05
+1882,"Search for a Dutch VOC-wreck, lost in 1626",EUR,"20,700.00",3,published,H,"9,331.98",1698,2014-03-05
+1883,PAWA254 Arts and Culture Centre,EUR,"132,847.00",16,published,Active,"132,847.00",1977,2014-03-09
+1884,TamTam Alert,EUR,"50,000.00",0,published,Active,"50,000.00",273,2014-03-11
+1885,NHRIs Plus,USD,"53,000.00",1,published,Active,"53,000.00",428,2014-03-11
+1886,Artists in Residence in Moengo,EUR,"90,000.00",0,published,Active,"90,000.00",1992,2014-03-14
+1887,Villa Zapakara Children's Museum,EUR,"477,346.00",0,published,Active,"477,346.00",1996,2014-03-14
+1888,AccÃ¨s Ã  l'eau pour la rÃ©gion de Koulikoro,EUR,"130,000.00",92,published,Active,"130,000.00",1995,2014-03-17
+1889,AccÃ¨s Ã  l'eau pour la rÃ©gion de Mopti,EUR,"65,000.00",25,published,Active,"65,000.00",1994,2014-03-17
+1890,AccÃ¨s Ã  l'eau pour la rÃ©gion de Sikasso,EUR,"105,000.00",50,published,Active,"105,000.00",1994,2014-03-17
+1891,Pundo Community water project,EUR,"6,623.00",5,published,Active,"6,623.00",43,2014-03-20
+1895,Tell Balata Visitor Centre Upgrade,EUR,"55,780.00",0,published,Active,"55,780.00",360,2014-04-01
+1897,Bringing tangible and sustainable changes ,EUR,"94,870.00",9,published,Active,"94,869.89",8,2014-04-08
+1900,Archdiocese of Blantyre Health Commission,EUR,"181,000.00",0,published,Active,"181,000.00",273,2014-04-23
+1901,Sustainable microfinance in Sierra Leone,EUR,"200,000.00",0,published,Active,"200,000.00",273,2014-04-28
+1902,Linking Civil and Political Societies,EUR,"415,198.00",1,published,Active,"415,198.00",960,2014-04-28
+1903,Mining concessions and conflicts,EUR,"55,000.00",0,published,Active,"55,000.00",960,2014-04-28
+1904,Improved healthcare in North Cameroon,EUR,"167,753.00",0,published,Active,"167,753.00",949,2014-04-28
+1905,Community and family based care for OVCs,EUR,"99,809.00",0,published,Active,"99,809.00",273,2014-04-28
+1906,Prevention of high incidence of suicides,EUR,"68,480.00",0,published,Active,"68,480.00",962,2014-04-28
+1907,EA 18/2013 Earthquake in Balochistan,EUR,"50,000.00",0,published,Active,"50,000.00",961,2014-04-28
+1908,Respect Education,EUR,"103,625.00",1,published,Active,"103,625.00",959,2014-04-28
+1909,Community HIV/AIDS Prevention III,EUR,"113,580.00",0,published,Active,"113,580.00",1584,2014-04-28
+1910,Microfinancing 3000 women,EUR,"150,000.00",0,published,Active,"150,000.00",464,2014-04-28
+1911,Ecosystem based Adaptation,EUR,"65,570.00",0,published,Active,"65,570.00",961,2014-04-28
+1912,Strengthening urban partnerships in Haiti,EUR,"15,000.00",1,published,Active,"15,000.00",1408,2014-04-28
+1913,Urban Matters City Addis Ababa 2014,EUR,"25,000.00",1,published,Active,"25,000.00",946,2014-04-28
+1914,Knowledge development CSR,EUR,"102,038.00",0,published,Active,"102,038.00",962,2014-04-28
+1915,CMDRR Partner Support - India & Bangladesh,EUR,"102,234.00",0,published,Active,"102,234.00",961,2014-04-28
+1916,The role of women in peace negotiations,EUR,"20,000.00",0,published,Active,"20,000.00",955,2014-04-28
+1917,Womenâ€™s access to justice,EUR,"69,130.00",0,published,Active,"69,130.00",955,2014-04-28
+1918,Livelihood restoration in Uttarakhand,EUR,"87,543.00",0,published,Active,"87,543.00",961,2014-04-28
+1919,Initial Response Operation to Earthquake Aceh,EUR,"45,000.00",0,published,Active,"45,000.00",961,2014-04-28
+1920,Disaster management capacity building,EUR,"67,000.00",0,published,Active,"67,000.00",961,2014-04-28
+1921,Education for Girls in Shabunda District,EUR,"824,421.00",0,published,Active,"824,421.00",1340,2014-04-28
+1922,Counselling Centre in NR Pura and Koppa,EUR,"38,050.00",0,published,Active,"38,050.00",962,2014-04-28
+1923,The unknown hazards of mining,EUR,"45,000.00",0,published,Active,"45,000.00",960,2014-04-28
+1924,Linking and Learning PFR Kenya - 2013 - 2014,EUR,"190,000.00",3,published,Active,"190,000.00",2029,2014-04-28
+1925,Trans border Early Warning Systems,EUR,"20,000.00",0,published,Active,"20,000.00",961,2014-04-28
+1926,Emergency Response after Conflict,EUR,"45,000.00",0,published,Active,"45,000.00",961,2014-04-28
+1927,Emergency Relief after Mt. Sinabung eruption,EUR,"10,000.00",1,published,Active,"10,000.00",961,2014-04-28
+1928,Health Care Program 2012/2013,EUR,"255,055.00",0,published,Active,"255,055.00",1897,2014-04-28
+1929,2013-2015 action plan,EUR,"97,310.00",0,published,Active,"97,310.00",2023,2014-04-28
+1930,Development of Organic spices and Beekeeping,EUR,"153,375.00",0,published,Active,"153,375.00",273,2014-04-28
+1931,Improving the microfinance sector in Uganda,EUR,"250,000.00",0,published,Active,"250,000.00",464,2014-04-28
+1932,Supporting local organizations in DRR&DR,EUR,0.00,0,published,Active,0.00,273,2014-04-28
+1933,Vocational Training Maidan Wardak Province,EUR,"50,000.00",0,published,Active,"50,000.00",464,2014-04-28
+1934,Amplifying the Voice of Civil Society,EUR,"437,002.00",0,published,Active,"437,002.00",2097,2014-04-28
+1935,Tackling Land & Border Conflicts,EUR,"93,260.00",0,published,Active,"93,260.00",1241,2014-04-28
+1936,Recovery after Haiyan,EUR,0.00,0,published,Active,0.00,273,2014-04-28
+1937,Strengthening womenâ€™s voices in the Negev,EUR,"85,000.00",0,published,Active,"85,000.00",2081,2014-04-28
+1938,Better healthcare ELCT through e-health,EUR,"112,586.00",0,published,Active,"112,586.00",949,2014-04-28
+1939,Follow up CMDRR in Flood-prone Villages,EUR,"478,286.00",0,published,Active,"478,286.00",973,2014-04-28
+1940,Human Rights and Community Mental Health,EUR,"40,000.00",0,published,Active,"40,000.00",955,2014-04-28
+1941,Mental support for South Sudanese refugees,EUR,"242,040.00",0,published,Active,"242,040.00",1358,2014-04-28
+1942,Expansion of a primary school in Ghana,EUR,"62,000.00",0,published,Active,"62,000.00",464,2014-04-28
+1943,Emergency aid for displaced families in Syria,EUR,"3,784,475.00",0,published,Active,"3,784,475.00",961,2014-04-28
+1944,Improving the Education System in Hawassa,EUR,"98,433.00",0,published,Active,"98,433.00",959,2014-04-28
+1945,Innovation in Sexual Reproductive Health,EUR,"80,000.00",0,published,Active,"80,000.00",1297,2014-04-28
+1946,Development Livestock Marketing,EUR,"105,375.00",0,published,Active,"105,375.00",464,2014-04-28
+1947,Reducing religious and ethnic tensions,EUR,"56,000.00",0,published,Active,"56,000.00",2063,2014-04-28
+1949,Disaster Response and Preparedness,EUR,"99,930.00",0,published,Active,"99,930.00",961,2014-04-28
+1950,CMDRR and Livelihood Security,EUR,"58,510.00",0,published,Active,"58,510.00",273,2014-04-28
+1951,Resocialization project boys in Mikuyu Prison,EUR,"50,000.00",0,published,Active,"50,000.00",962,2014-04-28
+1952,Rufi staff capacity building program,EUR,"68,600.00",0,published,Active,"68,600.00",950,2014-04-28
+1953,CIDSE Fee 2013,EUR,"294,656.00",0,published,Active,"294,656.00",962,2014-04-28
+1954,Funding Strategy CELEP,EUR,"40,000.00",0,published,Active,"40,000.00",961,2014-04-28
+1955,Emergency aid for Syrian Refugees in Lebanon,EUR,"475,000.00",0,published,Active,"475,000.00",961,2014-04-28
+1956,A local hub for action,EUR,"657,669.00",0,published,Active,"657,669.00",946,2014-04-28
+1957,Towards a resilient Marsabit,EUR,"85,000.00",0,published,Active,"85,000.00",2049,2014-04-28
+1958,An educational youth center for local youth,EUR,"196,334.00",0,published,Completed,"196,334.00",1654,2014-04-28
+1959,CMDRR in four disaster prone states,EUR,"141,362.00",0,published,Active,"141,362.00",1306,2014-04-28
+1960,Co-operation Cordaid and Mitra Foundation,EUR,"43,568.00",0,published,Active,"43,568.00",962,2014-04-28
+1961,Education as a tool for women empowerment,EUR,"62,000.00",0,published,Active,"62,000.00",464,2014-04-28
+1962,Economic Empowerment of women in Negelle zone,EUR,0.00,0,published,Active,0.00,273,2014-04-28
+1963,Building capacity of local organizations,EUR,"480,000.00",0,published,Active,"480,000.00",464,2014-04-28
+1964,Support to PBF Technical Unit,EUR,"210,000.00",0,published,Active,"210,000.00",949,2014-04-28
+1965,Kisumu 2014: supporting local initiatives,EUR,"82,500.00",0,published,Active,"82,500.00",1400,2014-04-28
+1966,"WUF7, Medellin, Colombia 2014",EUR,"20,000.00",0,published,Active,"20,000.00",946,2014-04-28
+1967,Promote CMDRR to Disaster Authorities,EUR,"35,000.00",1,published,Active,"35,000.00",961,2014-04-28
+1968,Livelihoods Recovery Washi 2011,EUR,"72,119.00",0,published,Active,"72,119.00",961,2014-04-28
+1969,Emergency Response in South Sudan,EUR,"245,290.00",0,published,Active,"245,290.00",1318,2014-04-28
+1970,Polity and society programme,EUR,"83,160.00",0,published,Active,"83,160.00",2033,2014-04-28
+1971,Water supply for Karro and Konchi,EUR,"44,137.00",0,published,Active,"44,137.00",464,2014-04-28
+1972,Developing talents of young people,EUR,"26,352.00",0,published,Active,"26,352.00",1770,2014-04-28
+1973,Economic empowerment for poor char dwellers,EUR,"329,556.00",0,published,Active,"329,556.00",273,2014-04-28
+1974,Towards the implementation of Resolution 1325,EUR,"57,650.00",0,published,Active,"57,650.00",955,2014-04-28
+1975,Strengthening vulnerable children and women,EUR,"110,390.00",0,published,Active,"110,390.00",962,2014-04-28
+1976,FairPen Newsletter Project,EUR,"26,000.00",0,published,Active,"26,000.00",962,2014-04-28
+1977,Preparation Grant: continuation of program,EUR,"750,000.00",0,published,Active,"750,000.00",949,2014-04-28
+1978,"â€˜Embrace, educate, enableâ€™",EUR,"150,000.00",0,published,Active,"150,000.00",962,2014-04-28
+1979,Education available for all,EUR,"201,200.00",0,published,Active,"201,200.00",962,2014-04-28
+1980,Programme development through learning,EUR,"57,000.00",0,published,Active,"57,000.00",961,2014-04-28
+1981,Community Risk Analysis in DR Congo,EUR,"31,712.00",0,published,Active,"31,712.00",961,2014-04-28
+1982,"Food, seeds and planting material support",EUR,"150,000.00",0,published,Active,"150,000.00",961,2014-04-28
+1983,Rehabilitation of victims of typhoon Labuyo,EUR,"16,770.00",0,published,Active,"16,770.00",2017,2014-04-28
+1984,Irrigation to improve agriculture,EUR,"58,907.00",1,published,Active,"58,907.00",961,2014-04-28
+1985,Campaign for Gun Free Kitchen Tables,EUR,"20,000.00",0,published,Active,"20,000.00",955,2014-04-28
+1986,Conditional cash transfers,EUR,"343,725.00",0,published,Active,"343,725.00",949,2014-04-28
+1987,Preserve clean water in mining areas,EUR,"52,000.00",0,published,Active,"52,000.00",1484,2014-04-28
+1988,SEISUD and ZEFP Ecological Farming,EUR,"99,141.00",0,published,Active,"99,141.00",464,2014-04-28
+1989,RUFI conflict mitigation programme,EUR,"22,650.00",0,published,Active,"22,650.00",1005,2014-04-28
+1990,Strengthening Health Systems in in Borana,EUR,"38,800.00",0,published,Active,"38,800.00",949,2014-04-28
+1991,Family and child development,EUR,"36,626.00",0,published,Active,"36,626.00",962,2014-04-28
+1992,Enhanced Resilience to Multiple Disasters,EUR,"72,111.00",1,published,Active,"72,111.00",961,2014-04-28
+1993,Scaling up trans-border Flood Warning Systems,EUR,"227,901.00",0,published,Active,"227,901.00",961,2014-04-28
+1994,Disaster Risk Reduction in northern Karamoja,EUR,"261,830.00",1,published,Active,"261,830.00",1878,2014-04-28
+1995,Improving production of 600 small farmers,EUR,"130,000.00",0,published,Active,"130,000.00",1099,2014-04-28
+1996,Small Business will get access to finance,EUR,"200,000.00",0,published,Active,"200,000.00",1343,2014-04-28
+1997,Investing in East African businesses,EUR,"10,000,000.00",0,published,Active,"10,000,000.00",273,2014-04-28
+1998,Investing in a wholesale microfinance fund,EUR,"10,700,000.00",0,published,Active,"10,700,000.00",953,2014-04-28
+1999,Kari & TIC,EUR,"46,279.00",0,published,Active,"46,279.00",892,2014-05-02
+2001,Resilient communities in Coron,EUR,"1,304,800.00",8,published,Active,"1,304,800.00",1358,2014-05-15
+2002,Resilient communities in Guiuan,EUR,"2,002,000.00",12,published,Active,"2,002,000.00",273,2014-05-15
+2003,Food Security Vanuatu,USD,"300,000.00",7,published,Active,"300,000.00",2102,2014-05-20
+2004,Bilateral Project ,USD,"2,000,000.00",13,published,Active,"2,000,000.00",2108,2014-05-20
+2010,VCPP - WASH (Water and Sanitation Hygiene),USD,"200,000.00",13,published,Completed,"200,000.00",2107,2014-05-26
+2011,SDF-WASH (Water & Sanitation Hygiene),USD,"1,400,000.00",21,published,Active,"1,400,000.00",2109,2014-05-26
+2012,Gender Needs Assessment,USD,"15,000.00",4,published,Completed,"15,000.00",2107,2014-05-26
+2013,Supporting Afghanistan's museum sector,EUR,"753,900.00",0,published,Active,"753,900.00",2135,2014-05-27
+2014,Cape Coast Water Supply Project,EUR,"20,000,000.00",1,published,Active,"20,000,000.00",2134,2014-05-28
+2015,La Wireless Cluster of Schools,EUR,"26,000.00",0,published,H,0.00,689,2014-05-28
+2016,Vegetables for All ,EUR,"3,151,000.00",0,published,Active,"3,151,000.00",180,2014-06-04
+2019,Water for Bilibiza,EUR,"49,258.00",0,published,H,0.00,170,2014-06-04
+2021,Assessing the image of Archaeology,EUR,"206,000.00",0,published,Active,"206,000.00",2130,2014-06-11
+2022,The European Day of Archaeology,EUR,"275,000.00",0,published,Active,"275,000.00",361,2014-06-11
+2023,The Nearch app for mobile devices,EUR,"109,000.00",0,published,Active,"109,000.00",2105,2014-06-11
+2024,Your Archaeology - portraying your past,EUR,"516,750.00",0,published,Active,"516,750.00",2142,2014-06-11
+2025,Archaeology in a multicultural society,EUR,"103,000.00",0,published,Active,"103,000.00",2105,2014-06-11
+2026,Artists in residence: Paris and Maastricht,EUR,"210,000.00",0,published,Active,"210,000.00",2105,2014-06-11
+2027,An international conference in Paris,EUR,"57,000.00",0,published,Active,"57,000.00",2105,2014-06-11
+2028,An international workshop in Maastricht,EUR,"57,000.00",0,published,Active,"57,000.00",2105,2014-06-11
+2029,An archaeological e-learning platform,EUR,"276,000.00",0,published,Active,"276,000.00",2105,2014-06-12
+2030,How to digitally share archaeological data?,EUR,"228,000.00",0,published,Active,"228,000.00",2105,2014-06-12
+2031,Archaeology and the crisis: a European survey,EUR,"205,000.00",0,published,Active,"205,000.00",2127,2014-06-12
+2032,An international colloquium in Santiago,EUR,"175,000.00",0,published,Active,"175,000.00",2105,2014-06-12
+2033,A field workshop for community involvement,EUR,"103,000.00",0,published,Active,"103,000.00",361,2014-06-12
+2034,Community involvement UNESCO heritage sites,EUR,"263,000.00",0,published,Active,"263,000.00",2131,2014-06-12
+2035,An international colloquium in Berlin,EUR,"174,750.00",0,published,Active,"174,750.00",2105,2014-06-12
+2036,NEARCH supports mobility grants,EUR,"99,000.00",0,published,Active,"99,000.00",360,2014-06-12
+2039,Scaling WASH in Kenya,EUR,"40,000.00",4,published,Active,"40,000.00",1684,2014-06-17
+2040,Climate Smart Land and Water Management ,EUR,"40,000.00",2,published,Active,"40,000.00",1684,2014-06-17
+2041,Water consultant in Zambia,EUR,"40,000.00",3,published,Active,"40,000.00",1684,2014-06-17
+2042,YEP Water: Drinking Water Reservoirs Ghana,EUR,"40,000.00",2,published,Active,"40,000.00",1684,2014-06-17
+2043,Reinforcing a Rainwater Network in SE-Africa,EUR,"40,000.00",1,published,Active,"40,000.00",1684,2014-06-17
+2044,"Non Revenue Water reduction, Kenya, YEP Water",EUR,"40,000.00",1,published,Active,"40,000.00",678,2014-06-17
+2045,VEI support to increase water availability,EUR,"40,000.00",1,published,Active,"40,000.00",464,2014-06-17
+2046,YEP Water for Ho Chi Minh City & Mekong Delta,EUR,"40,000.00",1,published,Active,"40,000.00",678,2014-06-17
+2047,WE Consult Mozambique,EUR,"40,000.00",1,published,Active,"40,000.00",464,2014-06-17
+2048,On Farm Water Savings in Agri Supply Chains,EUR,"40,000.00",0,published,Active,"40,000.00",2139,2014-06-17
+2049,Low-Cost WASH techniques for Malawi,EUR,"40,000.00",2,published,Active,"40,000.00",464,2014-06-17
+2050,Hydrogeology Water consultancy in Zambia,EUR,"12,000.00",2,published,Active,"12,000.00",464,2014-06-17
+2051,FUTURAGUA,EUR,"12,000.00",3,published,Active,"12,000.00",464,2014-06-17
+2052,Integrated Water Action Programme (IWRAP),EUR,"12,000.00",5,published,Active,"12,000.00",464,2014-06-17
+2053,Max Value for WASH,EUR,"12,000.00",1,published,Active,"12,000.00",115,2014-06-17
+2054,Water Management in Nepal,EUR,"12,000.00",2,published,Active,"12,000.00",530,2014-06-17
+2055,Establishment of a sludge management system,EUR,"12,000.00",1,published,Active,"12,000.00",15,2014-06-17
+2056,ExpÃ©rimentation de l'approche 3R,EUR,"12,000.00",1,published,Active,"12,000.00",35,2014-06-17
+2057,YEP - Maintenance of water treatment plans,EUR,"12,000.00",1,published,Active,"12,000.00",678,2014-06-17
+2058,YEP - Pro-poor programme coordinator,EUR,"12,000.00",1,published,Active,"12,000.00",678,2014-06-17
+2059,Bacelar Muneme ,EUR,"12,000.00",0,published,Active,"12,000.00",2138,2014-06-17
+2060,Seriba Konare,EUR,"12,000.00",0,published,Active,"12,000.00",464,2014-06-17
+2061,The Joint Zambezi River Basin E-Flows Project,EUR,"12,000.00",2,published,Active,"12,000.00",464,2014-06-17
+2062,Fortified Dairy,EUR,"1,540,000.00",1,published,Active,"1,540,000.00",2231,2014-06-17
+2063,Active Citizens Through Culture and Sport,EUR,"373,480.00",0,published,Active,"373,480.00",168,2014-06-19
+2064,Micronutrient Powders,EUR,"1,500,000.00",2,published,Active,"1,500,000.00",804,2014-06-19
+2066,Mobile data collection & mapping in SE-Asia,EUR,"40,000.00",1,published,Active,"40,000.00",42,2014-06-24
+2067,UNDP Eastern Europe & Central Asia,EUR,"7,020.00",0,published,Active,"7,020.00",428,2014-06-24
+2068,Aqua for All ,EUR,"75,000.00",0,published,Active,"75,000.00",43,2014-06-24
+2069,Connect4Change Programme 2011-2015,EUR,"2,000,000.00",0,published,Active,"2,000,000.00",34,2014-06-24
+2070,FXB India Suraksha,EUR,"8,100.00",0,published,Active,"8,100.00",42,2014-06-24
+2071,ICCO Indonesia,EUR,"16,000.00",0,published,Completed,"16,000.00",42,2014-06-24
+2072,Ecorys,EUR,"13,378.00",0,published,Completed,"13,378.00",2251,2014-06-24
+2073,Liberia - Ministry of Public Works,EUR,"57,000.00",0,published,Completed,"72,140.00",42,2014-06-24
+2074,Football for Water 2012-2016,EUR,"458,393.00",0,published,Active,"458,393.00",678,2014-06-24
+2075,SRHR Alliance 2012-2013,EUR,"15,689.00",0,published,Active,"15,689.00",42,2014-06-24
+2076,UN-Habitat phase 1,USD,"35,824.00",0,published,Completed,"35,824.00",42,2014-06-24
+2077,RAIN ,EUR,"34,296.00",1,published,Active,"34,296.00",42,2014-06-24
+2078,Cordaid,EUR,"120,947.00",1,published,Active,"120,947.00",42,2014-06-24
+2079,"Millennium Water Alliance, Kenya",EUR,"48,100.00",3,published,Active,"61,284.00",42,2014-06-24
+2080,"Millennium Water Alliance, South America ",EUR,"50,723.00",0,published,Active,"50,723.00",42,2014-06-24
+2081,Akvo PPP Phase 3 2014-2017,EUR,"2,820,000.00",0,published,Active,"2,820,000.00",464,2014-06-24
+2082,PPP SMARTerWASH,EUR,"1,310,200.00",4,published,Active,"1,310,200.00",464,2014-06-24
+2083,Rain4Food,EUR,"95,138.00",1,published,Active,"95,138.00",35,2014-06-24
+2084,SNV Kenya,EUR,"11,591.00",0,published,Completed,"11,591.00",42,2014-06-24
+2085,The Dutch WASH Alliance ,EUR,"1,580,000.00",0,published,Active,"1,580,000.00",8,2014-06-24
+2086,Liberia WASH Consortium 2013-2014,EUR,"19,076.00",0,published,Completed,"19,076.00",42,2014-06-24
+2087,Simavi Tanzania,EUR,"18,850.00",0,published,Active,"18,850.00",8,2014-06-24
+2089,The Dutch WASH Alliance - FLOW,EUR,"120,000.00",0,published,Active,"120,000.00",35,2014-06-24
+2091,YEP Water programme bureau,EUR,"40,000.00",1,published,Active,"40,000.00",1684,2014-06-25
+2092,Nehalennia in Ganuenta,EUR,"7,500.00",0,published,H,98.82,1698,2014-06-25
+2093,Welthungerhilfe - Uganda and Zimbabwe,EUR,"25,142.00",0,published,Active,"25,142.00",42,2014-06-30
+2095,WSP Tanzania,EUR,"37,500.00",0,published,Active,"37,500.00",1032,2014-06-30
+2096,WWF-Indonesia,EUR,"13,000.00",0,published,Active,"16,500.00",2166,2014-06-30
+2097,WASTE FINISH,EUR,"17,042.00",0,published,Active,"17,042.00",13,2014-06-30
+2098,UNICEF Guinee-Conakry ,EUR,"56,300.00",1,published,Active,"56,300.00",42,2014-06-30
+2099,Unicef Mali - WCARO,EUR,"145,150.00",0,published,Active,"145,150.00",42,2014-06-30
+2100,UNICEF Pacific,EUR,"51,433.00",1,published,Active,"51,433.00",42,2014-06-30
+2101,Unicef Ethiopia,EUR,"75,408.00",2,published,Active,"75,408.00",2223,2014-06-30
+2102,SNV Burkina Faso,EUR,"27,330.00",0,published,Active,"27,330.00",42,2014-06-30
+2103,SNV Zambia,EUR,"40,513.20",0,published,Active,"40,513.20",42,2014-06-30
+2104,SNV SSH4A,EUR,"165,393.00",1,published,Active,"165,393.00",42,2014-06-30
+2106,SuSanA ,EUR,"10,000.00",0,published,Active,"10,000.00",785,2014-06-30
+2107,WUMP+3R,EUR,"22,087.00",0,published,Active,"22,087.00",2157,2014-06-30
+2109,Cardno Emerging Markets,EUR,"117,754.00",0,published,Active,"117,754.00",2212,2014-06-30
+2110,Cida Grand Challenge - TTC,EUR,"26,584.00",0,published,Active,"26,584.00",1993,2014-06-30
+2111,GNWP - Ghana (Berenschot & Simavi),EUR,"76,303.00",0,published,Active,"76,303.00",42,2014-06-30
+2113,ICCO - global strategic partnership,EUR,"75,000.00",0,published,Active,"75,000.00",42,2014-06-30
+2114,Dutch Embassy Kenya,EUR,"24,596.00",1,published,Active,"24,596.00",882,2014-06-30
+2115,Mars Farmers First,EUR,"50,000.00",0,published,Active,"50,000.00",539,2014-06-30
+2116,"National Programme of Water, Benin",EUR,"44,800.00",0,published,Active,"44,800.00",2325,2014-06-30
+2117,Cordaid Tam Tam alert,EUR,"18,617.74",0,published,Completed,"18,617.74",294,2014-06-30
+2118, Vitens Evides International (VEI) ,EUR,"9,576.00",0,published,Active,"9,576.00",42,2014-06-30
+2119,YEP Water ,EUR,"19,886.00",0,published,Active,"19,886.00",42,2014-06-30
+2120,UNESCO - Openaid,EUR,"30,376.00",0,published,Active,"30,376.00",42,2014-06-30
+2121,SEIU Nepal,EUR,"2,034.00",0,published,Active,"2,034.00",2219,2014-06-30
+2124,Water- and sanitation project in West Nyakach,EUR,"6,200.00",0,published,H,0.00,2150,2014-07-03
+2126,Upscaling WUMP+3R in Nepal and Pakistan,EUR,"248,397.00",1,published,Active,"248,397.00",42,2014-07-21
+2127,SystÃ¨me d'information et de communication,EUR,"99,668.00",0,published,Active,"99,668.00",272,2014-07-23
+2128,Romeinse haven in de Maas bij Cuijk,EUR,"1,500.00",0,published,H,0.00,1698,2014-07-23
+2129,Creating Employment Opportunities,EUR,"10,721.00",0,published,Completed,"10,721.00",464,2014-07-24
+2131,Vastenaktie - Dutch Lenten Campaign,EUR,"2,400,000.00",0,published,Active,"2,400,000.00",273,2014-07-24
+2132,Production of seeds for potatoes and rice,EUR,"135,000.00",0,published,Active,"135,000.00",273,2014-07-24
+2133,Study for Plan Agribusiness Services,EUR,"28,500.00",0,published,Completed,"28,500.00",2188,2014-07-24
+2134,Monitoring fragility in Democratic Congo,EUR,"60,000.00",0,published,Active,"60,000.00",950,2014-07-24
+2135,Knowledge Centre Religion and Development,EUR,"75,000.00",0,published,Active,"75,000.00",962,2014-07-24
+2136,Prevention of youth violence and advocay,EUR,"82,217.00",0,published,Active,"82,217.00",273,2014-07-24
+2137,Eye Camp programme for the visually impaired,EUR,"36,440.00",0,published,Active,"36,440.00",962,2014-07-24
+2138,Monitoring water quality in Santa Rosa,EUR,"60,000.00",0,published,Active,"60,000.00",960,2014-07-24
+2139,Cordaid Ethiopia Programme Support Team,EUR,"433,375.00",0,published,Active,"433,375.00",464,2014-07-24
+2140,,EUR,"74,000.00",0,published,Active,"74,000.00",464,2014-07-24
+2141,Contribute to the wellbeing of children,EUR,"67,760.00",0,published,Active,"67,760.00",1358,2014-07-24
+2142,Healthcare for poor children,EUR,"100,000.00",1,published,Active,"100,000.00",962,2014-07-24
+2143,Strengthening agricultural livelihoods,EUR,"237,784.00",0,published,Active,"237,784.00",273,2014-07-24
+2144,Pilot Rwanda Health Investment Fund,EUR,"77,605.00",0,published,Active,"77,605.00",1366,2014-07-24
+2145,Building Community Resilience,EUR,"977,203.00",0,published,Active,"977,203.00",961,2014-07-24
+2146,A guide book for communities,EUR,"87,000.00",0,published,Active,"87,000.00",960,2014-07-24
+2147,Mining and Land Observatory,EUR,"94,183.00",0,published,Active,"94,183.00",1413,2014-07-24
+2148,Building partners' disaster preparedness,EUR,"245,303.00",0,published,Active,"245,303.00",273,2014-07-24
+2149,Promotion on business conflict mediation,EUR,"144,023.00",0,published,Active,"144,023.00",2210,2014-07-24
+2150,Urban Matters City Cape Town 2014,EUR,"45,000.00",0,published,Active,"45,000.00",1632,2014-07-24
+2151,Capacity strengthening partner organizations,EUR,"730,000.00",0,published,Active,"730,000.00",464,2014-07-24
+2152,Strengthening Health Committees,EUR,"1,043,255.00",0,published,Active,"1,043,255.00",1853,2014-07-24
+2153,Ethiopian Female Cancer Initiative,EUR,"20,000.00",0,published,Active,"20,000.00",273,2014-07-24
+2154,Reduction Impacts Climate-based Hazards,EUR,0.00,0,published,Active,0.00,2172,2014-07-24
+2155,Rural and agricultural loans in southern Peru,EUR,"730,000.00",0,published,Active,"730,000.00",953,2014-07-24
+2156,Working Capital generic Medicines,EUR,"750,000.00",0,published,Active,"750,000.00",1586,2014-07-24
+2157,Emergency Response after Afghan landslide,EUR,"19,500.00",1,published,Active,"19,500.00",273,2014-07-24
+2158,New land and affordable houses,EUR,"104,721.00",0,published,Active,"104,721.00",961,2014-07-24
+2159,Support to restore natural environment,EUR,"49,500.00",0,published,Active,"49,500.00",961,2014-07-24
+2160,Emergency Aid after Floods in Serbia,EUR,"25,000.00",1,published,Active,"25,000.00",273,2014-07-24
+2161,Expansion Respect Education in Mindanao,EUR,"145,679.00",0,published,Active,"145,679.00",1342,2014-07-24
+2162,Migration And Development network (MADE),EUR,"186,380.00",0,published,Active,"186,380.00",273,2014-07-24
+2163,Musoni Kenya Loan 2014,EUR,"800,000.00",0,published,Active,"800,000.00",464,2014-07-24
+2164,Role of Women in the Peace Negotiations,EUR,"26,930.00",0,published,Active,"26,930.00",1909,2014-07-24
+2165,Disaster resilient communities in Dire Dawa,EUR,"207,871.00",0,published,Active,"207,871.00",1358,2014-07-24
+2166,Repairing Water Piping Installations,EUR,"43,085.00",0,published,Active,"43,085.00",961,2014-07-24
+2167,Child protection to improve access to schools,EUR,"178,674.00",1,published,Active,"178,674.00",273,2014-07-24
+2168,Integration ex-child soldiers,EUR,"80,000.00",0,published,Active,"80,000.00",962,2014-07-24
+2169,Urban Matters City El Salvador 2014,EUR,"107,500.00",0,published,Active,"107,500.00",464,2014-07-24
+2170,Diversified sustainable food project,EUR,"402,606.00",3,published,Active,"402,606.00",273,2014-07-24
+2171,"Transparency in oil, gas & mining",EUR,"221,410.00",0,published,Active,"221,410.00",960,2014-07-24
+2172,"Communication, Peace and Security for Women",EUR,"43,775.00",0,published,Active,"43,775.00",955,2014-07-24
+2173,Hygiene services after vulcano eruption,EUR,"47,637.00",1,published,Active,"47,637.00",2032,2014-07-24
+2174,Support Program MFI sector development,EUR,"199,377.00",0,published,Active,"199,377.00",950,2014-07-24
+2175,Emergency aid for families fled to Kinshasa,EUR,"50,000.00",0,published,Active,"50,000.00",1384,2014-07-24
+2176,Water program 2013,EUR,"28,510.00",0,published,Active,"28,510.00",273,2014-07-24
+2177,Legal Empowerment of the Poor,EUR,"112,000.00",3,published,Active,"112,000.00",2194,2014-07-24
+2178,Village Pineapples Cooperative Project,EUR,"103,000.00",0,published,Active,"103,000.00",950,2014-07-24
+2179,RUFI Loan 2014,EUR,"300,000.00",0,published,Active,"300,000.00",1005,2014-07-24
+2180,Health Investment Fund,EUR,"45,587.00",0,published,Active,"45,587.00",273,2014-07-24
+2181,Ibala Organic farming course 2014,EUR,"65,436.00",0,published,Active,"65,436.00",2176,2014-07-24
+2182,Using Mobile Phone for flood warning,EUR,"74,151.00",0,published,Active,"74,151.00",273,2014-07-24
+2183,Building Capacity: Maternal & Newborn Health,EUR,"261,113.00",0,published,Active,"261,113.00",464,2014-07-24
+2184,Carradeux Community Vitalization Program,EUR,"765,479.00",0,published,Active,"765,479.00",2193,2014-07-24
+2185,Institutional support for two partners,EUR,"136,080.00",0,published,Active,"136,080.00",273,2014-07-24
+2186,Subordinated Loan to support IDEPRO,EUR,"1,089,459.00",0,published,Active,"1,089,459.00",273,2014-07-24
+2187,Children's Entrepreneurial Training Village,EUR,"26,000.00",0,published,Active,"26,000.00",273,2014-07-24
+2188,CELEP Focal Point position - core funds,EUR,"40,000.00",0,published,Active,"40,000.00",273,2014-07-24
+2189,Safe water for Tashi Jong,EUR,"25,200.00",0,published,Active,"25,200.00",962,2014-07-24
+2190,Supporting business growth through BDS,EUR,"149,525.00",0,published,Active,"149,525.00",273,2014-07-24
+2191,Reducing the impact of floods,EUR,"580,552.00",1,published,Active,"580,552.00",273,2014-07-24
+2192,Disaster Risk Reduction in flood prone areas,EUR,"145,870.00",0,published,Active,"145,870.00",464,2014-07-24
+2193,Supply Chain Manager for emergency response,EUR,"34,000.00",0,published,Active,"34,000.00",1358,2014-07-24
+2194,Barometer Implementation in Colombia,EUR,0.00,0,published,Active,0.00,1467,2014-07-24
+2195,Translation CMDRR Manual 2014,EUR,"61,143.00",0,published,Active,"61,143.00",961,2014-07-24
+2196,Gun Free Kitchen 2014-2015,EUR,"99,061.00",0,published,Active,"99,061.00",464,2014-07-24
+2197,TA for national scale up of RBF in Zimbawe,EUR,"29,980.00",0,published,Active,"29,980.00",949,2014-07-24
+2198,Emergency Aid Floods Bosnia and Herzegovina,EUR,"25,000.00",0,published,Active,"25,000.00",2208,2014-07-24
+2199,Projet renforcement de communication FADEFSO,USD,"31,966.46",3,published,Active,"31,966.47",405,2014-07-26
+2200,Adopteer een school in Kenia!,EUR,"25,000.00",0,published,H,0.00,43,2014-07-29
+2201,SNV Asia,EUR,"13,116.00",0,published,Active,"13,116.00",42,2014-07-29
+2202,Sport for Development,EUR,"9,700.00",0,published,Completed,"9,700.00",42,2014-08-04
+2203,CommonSites Strategic Partnership,EUR,"5,000.00",0,published,Active,"4,999.99",42,2014-08-04
+2204,Dutch Ministry of Foreign Affairs ICE,EUR,"24,537.00",0,published,Active,"24,537.00",42,2014-08-05
+2205,AMREF 'Staying Alive!',EUR,"76,394.00",0,published,Active,"76,394.00",42,2014-08-05
+2206,The Netherlands Red Cross Society,EUR,"16,084.00",0,published,Active,"16,084.00",2250,2014-08-05
+2207,Agriprofocus,EUR,"12,070.00",0,published,Completed,"12,070.00",1555,2014-08-05
+2208,Unicef Ivory Coast - WCARO,EUR,"78,676.00",0,published,Active,"78,676.00",908,2014-08-05
+2209,"Millennium Water Alliance, Ethiopia",EUR,"25,700.00",0,published,Active,"32,395.00",947,2014-08-05
+2210,PPP Phase 2 2011-2014,EUR,"2,500,000.00",0,published,Completed,"2,500,000.00",464,2014-08-05
+2211,PPP Phase 3 - South Asia,EUR,"67,500.00",0,published,Active,"67,500.00",42,2014-08-05
+2212,PPP Phase 3 - South East Asia,EUR,"82,500.00",0,published,Active,"82,500.00",42,2014-08-05
+2213,PPP Phase 3 - East Africa,EUR,"47,500.00",0,published,Active,"47,500.00",42,2014-08-05
+2214,PPP Phase 3 - West Africa,EUR,"57,500.00",0,published,Active,"57,500.00",464,2014-08-05
+2215,Edukans,EUR,"57,150.00",0,published,Active,"57,150.00",42,2014-08-05
+2216,Wandelen voor Water (Walking for Water),EUR,"25,200.00",0,published,Active,"25,200.00",113,2014-08-05
+2217,Water Sanitation at 2 rural schools,EUR,"8,014.00",1,published,H,600.00,188,2014-08-14
+2218,Quality improvement network,EUR,"2,136,000.00",0,published,Active,"2,136,000.00",2119,2014-08-25
+2219,Spatial Information Natural Risk Management,EUR,"12,000.00",0,published,Active,"12,000.00",1686,2014-08-25
+2220,Water and sanitation in Indonesia,EUR,"12,000.00",0,published,Active,"12,000.00",1690,2014-08-25
+2221,Dutch Water Technology in Indonesia,EUR,"12,000.00",1,published,Active,"12,000.00",1684,2014-08-25
+2222,Market Assistance Programme,EUR,"12,000.00",1,published,Active,"12,000.00",881,2014-08-25
+2223,Nakuru County Sanitation Programme,EUR,"12,000.00",3,published,Active,"12,000.00",1684,2014-08-25
+2224,Water consultant in Ethiopia ,EUR,"12,000.00",1,published,Active,"12,000.00",1686,2014-08-25
+2226,Sustainable Sugarcane Initiative,EUR,"140,000.00",0,published,Active,0.00,2237,2014-08-26
+2227,Increase access to water supply in Rwanda,EUR,"10,553.00",0,published,H,48.82,2150,2014-08-27
+2230,Plataforma TIC: â€œEl Gusto Bolivianoâ€,EUR,"16,500.00",0,published,Active,"16,500.00",2241,2014-09-01
+2231,Local Governance Support Programme/Phase-2,USD,"3,000,000.00",3,published,Active,"861,638.00",2235,2014-09-03
+2233,Ga Waste Project,EUR,"17,000,000.00",0,published,Active,"17,000,000.00",2121,2014-09-04
+2235,Home for Street Children in Yogyakarta,EUR,"54,740.00",7,published,Active,"54,740.00",405,2014-09-06
+2237,Rice Duck Program 2012-2014,EUR,"150,000.00",43,published,Active,"97,267.00",2256,2014-09-12
+2238,UNICEF and SNV PCA IV ,USD,"8,685.00",0,published,Active,"8,685.00",2263,2014-09-15
+2239,Rural retail hubs,EUR,"4,400,000.00",0,published,Active,"4,400,000.00",2225,2014-09-15
+2240,Sustainable Agriculture in Central Java,EUR,"199,978.00",9,published,Active,"199,978.00",405,2014-09-16
+2241,ICCO - South East Asia,EUR,"22,003.00",4,published,Active,"22,003.00",405,2014-09-16
+2242,ï¿¼Arts &Music Performance for Youth in Prison,EUR,"42,210.00",1,published,Active,"42,210.00",405,2014-09-16
+2243,Strengthening Afghan Female Magistrates,EUR,"109,210.00",0,published,Active,"109,210.00",273,2014-09-16
+2244,Emergency aid for affected civilians in Gaza,EUR,"200,000.00",0,published,Active,"200,000.00",273,2014-09-16
+2245,Peace Building Education for Children,EUR,"65,000.00",4,published,Active,"65,000.00",405,2014-09-17
+2246,Access to Finance,EUR,"780,000.00",0,published,Active,"780,000.00",464,2014-09-17
+2247,ï¿¼Children Protection from Violence,EUR,"68,916.00",6,published,Active,"68,916.00",405,2014-09-18
+2256,Communal pond expansion and rehabilitation,EUR,"49,987.00",0,published,Completed,0.00,35,2014-09-18
+2261,Enhanced Rainwater for MUS,EUR,0.00,0,published,Completed,0.00,35,2014-09-18
+2275,Amelioration de l'access a l'eau et 3R/MUS,EUR,"128,156.00",0,published,Active,0.00,35,2014-09-18
+2285,Rainwater harvesting for water supply,EUR,"45,759.00",0,published,Completed,0.00,518,2014-09-18
+2286,3R integration WUMP,EUR,"57,038.00",0,published,Completed,0.00,464,2014-09-18
+2287,3R approach in Salyan,EUR,"64,649.12",0,published,Completed,0.00,153,2014-09-18
+2288,3R approach in Salyan,EUR,"84,537.00",0,published,Active,0.00,464,2014-09-18
+2289,Piloting the 3R approach,EUR,"169,857.00",0,published,Active,0.00,518,2014-09-18
+2290,Demonstrating MUS of RWH in Surkhet,EUR,"73,714.00",0,published,Active,0.00,464,2014-09-18
+2291,Joint activities 2013 Nepal WASH alliance,EUR,"57,645.00",0,published,Completed,0.00,464,2014-09-18
+2301,Environmental Sustinability pilot in Rwambu,EUR,"89,427.00",0,published,Completed,0.00,35,2014-09-18
+2302,Raising awareness on rainwater harvesting,EUR,"49,791.00",0,published,Completed,0.00,35,2014-09-18
+2306,Promoting rain4food through SEARNET,EUR,"30,000.00",0,published,Active,0.00,35,2014-09-18
+2324,Sand dam construction at Enyana school in All,EUR,"16,208.00",0,published,Completed,0.00,35,2014-09-18
+2325,De lâ€™eau pour la commune de TankougounadjÃ©,EUR,"218,470.00",0,published,Active,0.00,35,2014-09-18
+2326,Identification des sites pour approche 3R,EUR,"3,154.00",0,published,Completed,0.00,35,2014-09-18
+2327,Advice 3R measures - Tankougounadi,EUR,"13,500.00",0,published,Completed,0.00,35,2014-09-18
+2328,Partnership for Sustainable Sanitation,EUR,"3,775,916.00",0,published,Active,"3,775,974.00",883,2014-09-19
+2329,Replacement of hand pumps on existing wells,EUR,"5,190.00",0,published,H,460.00,43,2014-09-19
+2330,The lost fleet of St. Eustatius,EUR,"4,000.00",0,published,H,846.46,2317,2014-09-23
+2331,WASH in Schools,EUR,"650,000.00",0,published,Active,"650,000.00",2121,2014-09-25
+2332,PIND Foundation,EUR,"24,139",0,published,Active,"24,139",42,2014-09-25
+2333,Splash,EUR,"15,800",3,published,A,"15,800",42,2014-09-30
+2335,Football for Water - Ghana Wash Window,EUR,"2,000,000",0,published,A,"2,000,000",678,2014-09-30
+2336,UNICEF BÃ©nin,EUR,"37,350",1,published,A,"37,350",42,2014-10-01
+2339,WakaWaka,EUR,"15,012",2,published,A,"15,012",42,2014-10-03
+2340,Max Value for WASH (Year 2: 2015),EUR,"154,616",0,published,A,"61,850",43,2014-10-06
+2342,Piped water project in Kateete-Kikwayi Uganda,EUR,"42,621",0,published,H,0,43,2014-10-08
+2344,Amazzi Nobuyonjo Bwebulamu Project,USD,"37,419",4,published,H,0,74,2014-10-13
+2346,Artists in residence : Paris,EUR,"105,000",1,published,A,"105,000",2105,2014-10-16
+2347,Artists in residence : Maastricht,EUR,"105,000",1,published,A,"105,000",2105,2014-10-16
+2348,UNICEF and SNV PCA IV Component 2,USD,"168,464",6,published,A,"168,464",2260,2014-10-16
+2349,Economic support for disabled people,EUR,"174,975",9,published,A,"174,975",405,2014-10-20
+2350,Bortianor and Gbawe Water Supply Project,EUR,"3,000,000",0,published,A,"3,000,000",2121,2014-10-21
+2365,Way to Menorca!,EUR,"1,500",0,published,H,49,2359,2014-10-28
+2368,School Improvement WASH Project in Lilongwe,EUR,"10,439",0,published,H,"9,217",43,2014-10-30
+2369,PAGERE,EUR,"131,866",0,published,A,0,35,2014-10-30


### PR DESCRIPTION
Data migration that populates almost all projects and organisations with a created_at timestamp

My running of this on a fresh RSR DB returns about half a dozen projects and one org missing a timestamp from both sources. Those could be hand patched, using the same date as the next lower numbered object. It's not strictly correct, but is probably good enough.