### PR TITLE
[#1290 #1299 #1309 #1316 #1317 #1321] Project admin

### DIFF
--- a/akvo/rsr/admin.py
+++ b/akvo/rsr/admin.py
@@ -539,7 +539,7 @@ class ProjectAdmin(TimestampsAdminDisplayMixin, ObjectPermissionsModelAdmin, Nes
         RelatedProjectInline, ProjectContactInline, PartnershipInline, ProjectDocumentInline, ProjectLocationInline,
         SectorInline, BudgetItemAdminInLine, TransactionInline, ResultInline, LinkInline, ProjectConditionInline,
         CountryBudgetInline, PlannedDisbursementInline, PolicyMarkerInline, RecipientCountryInline,
-        RecipientRegionInline, LegacyDataInline, BenchmarkInline, GoalInline,
+        RecipientRegionInline, LegacyDataInline,
     )
     save_as = True
 
@@ -551,6 +551,13 @@ class ProjectAdmin(TimestampsAdminDisplayMixin, ObjectPermissionsModelAdmin, Nes
             ),
             'fields': ('title', 'subtitle', 'iati_activity_id', 'status', 'date_start_planned', 'date_start_actual',
                        'date_end_planned', 'date_end_actual', 'language', 'currency', 'donate_button', 'hierarchy'),
+        }),
+        (_(u'IATI defaults'), {
+            'description': u'<p style="margin-left:0; padding-left:0; margin-top:1em; width:75%%;">%s</p>' % _(
+                u'Optionally, you can add default information based on the IATI standard.'
+            ),
+            'fields': ('default_aid_type', 'default_flow_type', 'default_tied_status','collaboration_type',
+                       'default_finance_type'),
         }),
         (_(u'Contact Information'), {
             'description': u'<p style="margin-left:0; padding-left:0; margin-top:1em; width:75%%;">%s</p>' % _(
@@ -616,7 +623,12 @@ class ProjectAdmin(TimestampsAdminDisplayMixin, ObjectPermissionsModelAdmin, Nes
             'description': u'<p style="margin-left:0; padding-left:0; margin-top:1em; width:75%%;">%s</p>' % _(
                 u'The project focus aims to define the broad areas of the project activities. This ensures that the '
                 u'project can be collectively grouped with other similar projects to help make the most out of the '
-                u'project resources.'
+                u'project resources.<br><br>'
+                u'Enter the sector code of the sectors that the project is working within. See these lists for the '
+                u'DAC-5 and DAC-3 sector codes:<br>'
+                u'- <a href="http://iatistandard.org/201/codelists/Sector/" target="_blank">DAC-5 sector codes</a><br>'
+                u'- <a href="http://iatistandard.org/201/codelists/SectorCategory/" target="_blank">DAC-3 sector '
+                u'codes</a>'
             ),
             'fields': (),
         }),
@@ -625,7 +637,7 @@ class ProjectAdmin(TimestampsAdminDisplayMixin, ObjectPermissionsModelAdmin, Nes
                 u'You can define the budget information as a total for the whole project or within sections and '
                 u'periods to provide more granular information about where the project funds are being spent.'
             ),
-            'fields': (),
+            'fields': ('capital_spend_percentage', ),
         }),
         (_(u'Project Financials - Transactions'), {
             'description': u'<p style="margin-left:0; padding-left:0; margin-top:1em; width:75%%;">%s</p>' % _(
@@ -661,6 +673,12 @@ class ProjectAdmin(TimestampsAdminDisplayMixin, ObjectPermissionsModelAdmin, Nes
             ),
             'fields': ('notes',),
         }),
+        (_(u'Additional IATI Information'), {
+            'description': u'<p style="margin-left:0; padding-left:0; margin-top:1em; width:75%%;">%s</p>' % _(
+                u'Optionally, you can add additional information based on the IATI standard.'
+            ),
+            'fields': (),
+        }),
         (_(u'Keywords'), {
             'description': u'<p style="margin-left:0; padding-left:0; margin-top:1em; width:75%%;">%s</p>' % _(
                 u'Add keywords belonging to your project. These keywords must be existing already in Akvo RSR. If '
@@ -669,25 +687,10 @@ class ProjectAdmin(TimestampsAdminDisplayMixin, ObjectPermissionsModelAdmin, Nes
             ),
             'fields': ('keywords',),
         }),
-        (_(u'Additional IATI information'), {
-            'description': u'<p style="margin-left:0; padding-left:0; margin-top:1em; width:75%%;">%s</p>' % _(
-                u'Optionally, you can add additional information based on the IATI standard.'
-            ),
-            'classes': ('collapse',),
-            'fields': ('capital_spend_percentage', 'default_aid_type', 'default_flow_type', 'default_tied_status',
-                       'collaboration_type', 'default_finance_type',),
-        }),
-        (_(u'Legacy RSR Data'), {
-            'description': u'<p style="margin-left:0; padding-left:0; margin-top:1em; width:75%%;">%s</p>' % _(
-                u'Data that was used in RSR v2, but is currently not used anymore. This is still available in order '
-                u'to see the old data.'
-            ),
-            'classes': ('collapse',),
-            'fields': ('categories', ),
-        }),
     )
     filter_horizontal = ('keywords',)
-    list_display = ('title', 'status', 'project_plan_summary', 'latest_update', 'show_current_image', 'is_published', 'show_keywords')
+    list_display = ('title', 'status', 'project_plan_summary', 'latest_update', 'show_current_image', 'is_published',
+                    'show_keywords')
     search_fields = ('title', 'status', 'project_plan_summary', 'partnerships__internal_id')
     list_filter = ('currency', 'status', 'keywords',)
     # created_at and last_modified_at MUST be readonly since they have the auto_now/_add attributes

--- a/akvo/rsr/admin.py
+++ b/akvo/rsr/admin.py
@@ -297,7 +297,7 @@ class RSR_PartnershipInlineForm(forms.ModelForm):
 
 class PartnershipInline(NestedTabularInline):
     model = get_model('rsr', 'Partnership')
-    fields = ('organisation', 'partner_type', 'funding_amount', 'internal_id', 'partner_type_extra')
+    fields = ('organisation', 'partner_type', 'funding_amount', 'internal_id')
     extra = 0
     form = RSR_PartnershipInlineForm
     formset = RSR_PartnershipInlineFormFormSet

--- a/akvo/rsr/admin.py
+++ b/akvo/rsr/admin.py
@@ -28,7 +28,7 @@ from akvo.utils import custom_get_or_create_country
 from akvo.rsr.fields import ValidXMLCharField
 
 from rules.contrib.admin import ObjectPermissionsModelAdmin
-from nested_inlines.admin import NestedModelAdmin, NestedStackedInline
+from nested_inlines.admin import NestedModelAdmin, NestedStackedInline, NestedTabularInline
 
 NON_FIELD_ERRORS = '__all__'
 csrf_protect_m = method_decorator(csrf_protect)
@@ -50,7 +50,7 @@ class CountryAdmin(admin.ModelAdmin):
 class OrganisationLocationInline(admin.StackedInline):
     model = get_model('rsr', 'organisationlocation')
     extra = 0
-    fields = ('id', 'latitude', 'longitude', 'city', 'state', 'address_1', 'address_2', 'postcode', 'country')
+    fields = ('latitude', 'longitude', 'city', 'state', 'address_1', 'address_2', 'postcode', 'country')
 
 
 class InternalOrganisationIDAdmin(admin.ModelAdmin):
@@ -122,9 +122,9 @@ class OrganisationAccountAdmin(admin.ModelAdmin):
 admin.site.register(get_model('rsr', 'organisationaccount'), OrganisationAccountAdmin)
 
 
-class LinkInline(NestedStackedInline):
+class LinkInline(NestedTabularInline):
     model = get_model('rsr', 'link')
-    fields = ('id', 'kind', 'url', 'caption')
+    fields = ('kind', 'url', 'caption')
 
     def get_extra(self, request, obj=None, **kwargs):
         if obj:
@@ -157,13 +157,13 @@ class BudgetItemAdminInLineFormSet(forms.models.BaseInlineFormSet):
             raise forms.ValidationError(_("The 'total' budget item cannot be used in combination with other budget items."))
 
 
-class BudgetItemAdminInLine(NestedStackedInline):
+class BudgetItemAdminInLine(NestedTabularInline):
     model = get_model('rsr', 'budgetitem')
     extra = 1
     formset = BudgetItemAdminInLineFormSet
     fieldsets = (
         (None, {
-            'fields': ('id', 'label', 'other_extra', 'type', 'amount', 'period_start', 'period_end', 'value_date')
+            'fields': ('label', 'other_extra', 'type', 'amount', 'period_start', 'period_end', 'value_date')
         }),
         ('IATI fields (advanced)', {
             'classes': ('collapse',),
@@ -207,25 +207,25 @@ class BenchmarknameInline(admin.TabularInline):
     extra = 3
 
 
-class BenchmarkInline(NestedStackedInline):
+class BenchmarkInline(NestedTabularInline):
     model = get_model('rsr', 'benchmark')
     # only show the value, category and benchmark are not to be edited here
     fieldsets = (
         (None, {
             'classes': ('collapse',),
-            'fields': ('id', 'value',)
+            'fields': ('value',)
         }),
     )
     extra = 0
     max_num = 0
 
 
-class GoalInline(NestedStackedInline):
+class GoalInline(NestedTabularInline):
     model = get_model('rsr', 'goal')
     fieldsets = (
         (None, {
             'classes': ('collapse',),
-            'fields': ('id', 'text',)
+            'fields': ('text',)
         }),
     )
     extra = 0
@@ -295,9 +295,9 @@ class RSR_PartnershipInlineForm(forms.ModelForm):
         return data
 
 
-class PartnershipInline(NestedStackedInline):
+class PartnershipInline(NestedTabularInline):
     model = get_model('rsr', 'Partnership')
-    fields = ('id', 'organisation', 'partner_type', 'funding_amount', 'internal_id', 'partner_type_extra')
+    fields = ('organisation', 'partner_type', 'funding_amount', 'internal_id', 'partner_type_extra')
     extra = 0
     form = RSR_PartnershipInlineForm
     formset = RSR_PartnershipInlineFormFormSet
@@ -323,7 +323,7 @@ class ProjectLocationInline(NestedStackedInline):
     model = get_model('rsr', 'projectlocation')
     fieldsets = (
         (None, {
-            'fields': ('id', 'latitude', 'longitude', 'country', 'city', 'state', 'address_1', 'address_2', 'postcode')
+            'fields': ('latitude', 'longitude', 'country', 'city', 'state', 'address_1', 'address_2', 'postcode')
         }),
         ('IATI fields (advanced)', {
             'classes': ('collapse',),
@@ -344,7 +344,7 @@ class ProjectDocumentInline(NestedStackedInline):
     model = get_model('rsr', 'ProjectDocument')
     fieldsets = (
         (None, {
-            'fields': ('id', 'url', 'document', 'title', 'format', 'category', 'language')
+            'fields': ('url', 'document', 'title', 'format', 'category', 'language')
         }),
     )
 
@@ -355,20 +355,20 @@ class ProjectDocumentInline(NestedStackedInline):
             return 1
 
 
-class CountryBudgetInline(NestedStackedInline):
+class CountryBudgetInline(NestedTabularInline):
     model = get_model('rsr', 'CountryBudgetItem')
     extra = 0
     fieldsets = (
         ('Country Budget Item', {
             'classes': ('collapse',),
-            'fields': ('id', 'code', 'description', 'vocabulary', 'percentage')
+            'fields': ('code', 'description', 'vocabulary', 'percentage')
         }),
     )
 
 
-class IndicatorPeriodInline(NestedStackedInline):
+class IndicatorPeriodInline(NestedTabularInline):
     model = get_model('rsr', 'IndicatorPeriod')
-    fields = ('id', 'period_start', 'period_end', 'target_value', 'target_comment', 'actual_value', 'actual_comment')
+    fields = ('period_start', 'period_end', 'target_value', 'target_comment', 'actual_value', 'actual_comment')
 
     def get_extra(self, request, obj=None, **kwargs):
         if obj:
@@ -377,9 +377,9 @@ class IndicatorPeriodInline(NestedStackedInline):
             return 1
 
 
-class IndicatorInline(NestedStackedInline):
+class IndicatorInline(NestedTabularInline):
     model = get_model('rsr', 'Indicator')
-    fields = ('id', 'title', 'description', 'measure', 'ascending', 'baseline_year', 'baseline_value',
+    fields = ('title', 'description', 'measure', 'ascending', 'baseline_year', 'baseline_value',
               'baseline_comment')
     inlines = (IndicatorPeriodInline,)
 
@@ -390,10 +390,10 @@ class IndicatorInline(NestedStackedInline):
             return 1
 
 
-class ResultInline(NestedStackedInline):
+class ResultInline(NestedTabularInline):
     model = get_model('rsr', 'Result')
     inlines = (IndicatorInline,)
-    fields = ('id', 'title', 'description', 'type', 'aggregation_status')
+    fields = ('title', 'description', 'type', 'aggregation_status')
 
     def get_extra(self, request, obj=None, **kwargs):
         if obj:
@@ -402,35 +402,35 @@ class ResultInline(NestedStackedInline):
             return 1
 
 
-class PlannedDisbursementInline(NestedStackedInline):
+class PlannedDisbursementInline(NestedTabularInline):
     model = get_model('rsr', 'PlannedDisbursement')
     extra = 0
     fieldsets = (
         ('Planned Disbursement', {
             'classes': ('collapse',),
-            'fields': ('id', 'currency', 'value', 'value_date', 'period_start', 'period_end', 'type', 'updated')
+            'fields': ('currency', 'value', 'value_date', 'period_start', 'period_end', 'type', 'updated')
         }),
     )
 
 
-class PolicyMarkerInline(NestedStackedInline):
+class PolicyMarkerInline(NestedTabularInline):
     model = get_model('rsr', 'PolicyMarker')
     extra = 0
     fieldsets = (
         ('Policy Marker', {
             'classes': ('collapse',),
-            'fields': ('id', 'policy_marker', 'significance', 'vocabulary', 'description')
+            'fields': ('policy_marker', 'significance', 'vocabulary', 'description')
         }),
     )
 
 
-class ProjectConditionInline(NestedStackedInline):
+class ProjectConditionInline(NestedTabularInline):
     model = get_model('rsr', 'ProjectCondition')
     extra = 0
     fieldsets = (
         ('Project Condition', {
             'classes': ('collapse',),
-            'fields': ('id', 'type', 'text', 'attached')
+            'fields': ('type', 'text', 'attached')
         }),
     )
 
@@ -439,7 +439,7 @@ class ProjectContactInline(NestedStackedInline):
     model = get_model('rsr', 'ProjectContact')
     fieldsets = (
         (None, {
-            'fields': ('id', 'type', 'person_name', 'email', 'job_title', 'organisation', 'telephone',
+            'fields': ('type', 'person_name', 'email', 'job_title', 'organisation', 'telephone',
                        'mailing_address',)
         }),
         ('Additional fields', {
@@ -455,31 +455,31 @@ class ProjectContactInline(NestedStackedInline):
             return 1
 
 
-class RecipientCountryInline(NestedStackedInline):
+class RecipientCountryInline(NestedTabularInline):
     model = get_model('rsr', 'RecipientCountry')
     extra = 0
     fieldsets = (
         ('Recipient Country', {
             'classes': ('collapse',),
-            'fields': ('id', 'country', 'percentage', 'text')
+            'fields': ('country', 'percentage', 'text')
         }),
     )
 
 
-class RecipientRegionInline(NestedStackedInline):
+class RecipientRegionInline(NestedTabularInline):
     model = get_model('rsr', 'RecipientRegion')
     extra = 0
     fieldsets = (
         ('Recipient Region', {
             'classes': ('collapse',),
-            'fields': ('id', 'region', 'region_vocabulary', 'percentage', 'text')
+            'fields': ('region', 'region_vocabulary', 'percentage', 'text')
         }),
     )
 
 
-class SectorInline(NestedStackedInline):
+class SectorInline(NestedTabularInline):
     model = get_model('rsr', 'Sector')
-    fields = ('id', 'sector_code', 'vocabulary', 'percentage', 'text')
+    fields = ('sector_code', 'vocabulary', 'percentage', 'text')
 
     def get_extra(self, request, obj=None, **kwargs):
         if obj:
@@ -492,7 +492,7 @@ class TransactionInline(NestedStackedInline):
     model = get_model('rsr', 'Transaction')
     fieldsets = (
         (None, {
-            'fields': ('id', 'reference', 'transaction_type', 'value', 'transaction_date', 'description')
+            'fields': ('reference', 'transaction_type', 'value', 'transaction_date', 'description')
         }),
         ('IATI fields (advanced)', {
             'classes': ('collapse',),
@@ -510,20 +510,20 @@ class TransactionInline(NestedStackedInline):
         else:
             return 1
 
-class LegacyDataInline(NestedStackedInline):
+class LegacyDataInline(NestedTabularInline):
     model = get_model('rsr', 'LegacyData')
     extra = 0
     fieldsets = (
         ('Legacy Data', {
             'classes': ('collapse',),
-            'fields': ('id', 'name', 'value', 'iati_equivalent')
+            'fields': ('name', 'value', 'iati_equivalent')
         }),
     )
 
 
 class RelatedProjectInline(NestedStackedInline):
     model = get_model('rsr', 'RelatedProject')
-    fields = ('id', 'related_project', 'relation')
+    fields = ('related_project', 'relation')
     fk_name = 'project'
 
     def get_extra(self, request, obj=None, **kwargs):
@@ -687,7 +687,7 @@ class ProjectAdmin(TimestampsAdminDisplayMixin, ObjectPermissionsModelAdmin, Nes
         }),
     )
     filter_horizontal = ('keywords',)
-    list_display = ('id', 'title', 'status', 'project_plan_summary', 'latest_update', 'show_current_image', 'is_published', 'show_keywords')
+    list_display = ('title', 'status', 'project_plan_summary', 'latest_update', 'show_current_image', 'is_published', 'show_keywords')
     search_fields = ('title', 'status', 'project_plan_summary', 'partnerships__internal_id')
     list_filter = ('currency', 'status', 'keywords',)
     # created_at and last_modified_at MUST be readonly since they have the auto_now/_add attributes
@@ -817,7 +817,7 @@ admin.site.register(get_model('rsr', 'project'), ProjectAdmin)
 
 class ApiKeyInline(admin.StackedInline):
     model = get_model('tastypie', 'apikey')
-    fields = ('id', 'key',)
+    fields = ('key',)
     readonly_fields = ('key',)
 
     def has_delete_permission(self, request, obj=None, **kwargs):
@@ -881,12 +881,12 @@ admin.site.register(get_model('rsr', 'projectcomment'), ProjectCommentAdmin)
 class ProjectUpdateLocationInline(admin.StackedInline):
     model = get_model('rsr', 'projectupdatelocation')
     extra = 0
-    fields = ('id', 'latitude', 'longitude', 'city', 'state', 'address_1', 'address_2', 'postcode', 'country')
+    fields = ('latitude', 'longitude', 'city', 'state', 'address_1', 'address_2', 'postcode', 'country')
 
 
 class ProjectUpdateAdmin(TimestampsAdminDisplayMixin, AdminVideoMixin, admin.ModelAdmin):
 
-    list_display = ('id', 'project', 'user', 'text', 'language', 'created_at', 'img',)
+    list_display = ('project', 'user', 'text', 'language', 'created_at', 'img',)
     list_filter = ('created_at', 'project', )
     search_fields = ('project__id', 'project__title', 'user__first_name', 'user__last_name',)
     inlines = (ProjectUpdateLocationInline,)
@@ -917,7 +917,7 @@ admin.site.register(get_model('rsr', 'projectupdate'), ProjectUpdateAdmin)
 
 
 class InvoiceAdmin(admin.ModelAdmin):
-    list_display = ('id', 'project', 'user', 'name', 'email', 'time', 'engine', 'status', 'test', 'is_anonymous')
+    list_display = ('project', 'user', 'name', 'email', 'time', 'engine', 'status', 'test', 'is_anonymous')
     list_filter = ('engine', 'status', 'test', 'is_anonymous')
     actions = ('void_invoices',)
 

--- a/akvo/rsr/admin.py
+++ b/akvo/rsr/admin.py
@@ -497,10 +497,9 @@ class TransactionInline(NestedStackedInline):
         ('IATI fields (advanced)', {
             'classes': ('collapse',),
             'fields': ('currency',  'value_date', 'transaction_type_text', 'provider_organisation',
-                       'provider_organisation_ref', 'provider_organisation_activity', 'receiver_organisation',
-                       'receiver_organisation_ref', 'receiver_organisation_activity', 'aid_type', 'aid_type_text',
-                       'disbursement_channel', 'disbursement_channel_text', 'finance_type', 'finance_type_text',
-                       'flow_type', 'flow_type_text', 'tied_status', 'tied_status_text', )
+                       'provider_organisation_activity', 'receiver_organisation', 'receiver_organisation_activity',
+                       'aid_type', 'aid_type_text', 'disbursement_channel', 'disbursement_channel_text', 'finance_type',
+                       'finance_type_text', 'flow_type', 'flow_type_text', 'tied_status', 'tied_status_text', )
         }),
     )
 

--- a/akvo/rsr/admin.py
+++ b/akvo/rsr/admin.py
@@ -521,13 +521,25 @@ class LegacyDataInline(NestedStackedInline):
     )
 
 
+class RelatedProjectInline(NestedStackedInline):
+    model = get_model('rsr', 'RelatedProject')
+    fields = ('id', 'related_project', 'relation')
+    fk_name = 'project'
+
+    def get_extra(self, request, obj=None, **kwargs):
+        if obj:
+            return 1 if obj.related_projects.count() == 0 else 0
+        else:
+            return 1
+
+
 class ProjectAdmin(TimestampsAdminDisplayMixin, ObjectPermissionsModelAdmin, NestedModelAdmin):
     model = get_model('rsr', 'project')
     inlines = (
-        ProjectContactInline, PartnershipInline, ProjectDocumentInline, ProjectLocationInline, SectorInline,
-        BudgetItemAdminInLine, TransactionInline, ResultInline, LinkInline, ProjectConditionInline, CountryBudgetInline,
-        PlannedDisbursementInline, PolicyMarkerInline, RecipientCountryInline, RecipientRegionInline, LegacyDataInline,
-        BenchmarkInline, GoalInline,
+        RelatedProjectInline, ProjectContactInline, PartnershipInline, ProjectDocumentInline, ProjectLocationInline,
+        SectorInline, BudgetItemAdminInLine, TransactionInline, ResultInline, LinkInline, ProjectConditionInline,
+        CountryBudgetInline, PlannedDisbursementInline, PolicyMarkerInline, RecipientCountryInline,
+        RecipientRegionInline, LegacyDataInline, BenchmarkInline, GoalInline,
     )
     save_as = True
 
@@ -537,9 +549,8 @@ class ProjectAdmin(TimestampsAdminDisplayMixin, ObjectPermissionsModelAdmin, Nes
                 u'This section should contain the top-level information about your project which will be publicly '
                 u'available and used within searches. Try to keep your Title and Subtitle short and snappy.'
             ),
-            'fields': ('title', 'subtitle', 'iati_activity_id', 'status', 'hierarchy', 'date_start_planned',
-                       'date_start_actual', 'date_end_planned', 'date_end_actual', 'language', 'currency',
-                       'donate_button'),
+            'fields': ('title', 'subtitle', 'iati_activity_id', 'status', 'date_start_planned', 'date_start_actual',
+                       'date_end_planned', 'date_end_actual', 'language', 'currency', 'donate_button', 'hierarchy'),
         }),
         (_(u'Contact Information'), {
             'description': u'<p style="margin-left:0; padding-left:0; margin-top:1em; width:75%%;">%s</p>' % _(
@@ -1047,10 +1058,3 @@ class EmploymentAdmin(admin.ModelAdmin):
         return super(EmploymentAdmin, self).formfield_for_foreignkey(db_field, request, **kwargs)
 
 admin.site.register(get_model('rsr', 'Employment'), EmploymentAdmin)
-
-
-class RelatedProjectAdmin(admin.ModelAdmin):
-    model = get_model('rsr', 'RelatedProject')
-    list_display = ('project', 'related_project', 'relation')
-
-admin.site.register(get_model('rsr', 'RelatedProject'), RelatedProjectAdmin)

--- a/akvo/rsr/migrations/0089_auto__del_field_transaction_receiver_organisation_ref__del_field_trans.py
+++ b/akvo/rsr/migrations/0089_auto__del_field_transaction_receiver_organisation_ref__del_field_trans.py
@@ -1,0 +1,653 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Transaction.receiver_organisation_ref'
+        db.delete_column(u'rsr_transaction', 'receiver_organisation_ref')
+
+        # Deleting field 'Transaction.receiver_organisation'
+        db.delete_column(u'rsr_transaction', 'receiver_organisation')
+
+        # Deleting field 'Transaction.provider_organisation_ref'
+        db.delete_column(u'rsr_transaction', 'provider_organisation_ref')
+
+        # Deleting field 'Transaction.provider_organisation'
+        db.delete_column(u'rsr_transaction', 'provider_organisation')
+
+        # Adding field 'Transaction.provider_organisation'
+        db.add_column(u'rsr_transaction', 'provider_organisation',
+                      self.gf('django.db.models.fields.related.ForeignKey')(blank=True, related_name='providing_transactions', null=True, on_delete=models.SET_NULL, to=orm['rsr.Organisation']),
+                      keep_default=False)
+
+        # Adding field 'Transaction.receiver_organisation'
+        db.add_column(u'rsr_transaction', 'receiver_organisation',
+                      self.gf('django.db.models.fields.related.ForeignKey')(blank=True, related_name='receiving_transactions', null=True, on_delete=models.SET_NULL, to=orm['rsr.Organisation']),
+                      keep_default=False)
+
+        # Changing field 'Transaction.transaction_date'
+        db.alter_column(u'rsr_transaction', 'transaction_date', self.gf('django.db.models.fields.DateField')(null=True))
+
+        # Changing field 'Transaction.value'
+        db.alter_column(u'rsr_transaction', 'value', self.gf('django.db.models.fields.DecimalField')(null=True, max_digits=11, decimal_places=2))
+
+
+    def backwards(self, orm):
+        # Adding field 'Transaction.receiver_organisation_ref'
+        db.add_column(u'rsr_transaction', 'receiver_organisation_ref',
+                      self.gf('akvo.rsr.fields.ValidXMLCharField')(default='', max_length=50, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Transaction.receiver_organisation'
+        db.add_column(u'rsr_transaction', 'receiver_organisation',
+                      self.gf('akvo.rsr.fields.ValidXMLCharField')(default='', max_length=100, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Transaction.provider_organisation_ref'
+        db.add_column(u'rsr_transaction', 'provider_organisation_ref',
+                      self.gf('akvo.rsr.fields.ValidXMLCharField')(default='', max_length=50, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Transaction.provider_organisation'
+        db.add_column(u'rsr_transaction', 'provider_organisation',
+                      self.gf('akvo.rsr.fields.ValidXMLCharField')(default='', max_length=100, blank=True),
+                      keep_default=False)
+
+        # Deleting field 'Transaction.provider_organisation'
+        db.delete_column(u'rsr_transaction', 'provider_organisation_id')
+
+        # Deleting field 'Transaction.receiver_organisation'
+        db.delete_column(u'rsr_transaction', 'receiver_organisation_id')
+
+        # Changing field 'Transaction.transaction_date'
+        db.alter_column(u'rsr_transaction', 'transaction_date', self.gf('django.db.models.fields.DateField')(default=''))
+
+        # Changing field 'Transaction.value'
+        db.alter_column(u'rsr_transaction', 'value', self.gf('django.db.models.fields.DecimalField')(null=True, max_digits=11, decimal_places=1))
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'rsr.benchmark': {
+            'Meta': {'ordering': "('category__name', 'name__order')", 'object_name': 'Benchmark'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Category']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Benchmarkname']"}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'benchmarks'", 'to': "orm['rsr.Project']"}),
+            'value': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'rsr.benchmarkname': {
+            'Meta': {'ordering': "['order', 'name']", 'object_name': 'Benchmarkname'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '80'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        'rsr.budgetitem': {
+            'Meta': {'ordering': "('label',)", 'unique_together': "(('project', 'label'),)", 'object_name': 'BudgetItem'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'max_digits': '10', 'decimal_places': '2'}),
+            'currency': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.BudgetItemLabel']"}),
+            'other_extra': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'period_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'period_end_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'period_start': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'period_start_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'budget_items'", 'to': "orm['rsr.Project']"}),
+            'type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'value_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'rsr.budgetitemlabel': {
+            'Meta': {'ordering': "('label',)", 'object_name': 'BudgetItemLabel'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '20', 'db_index': 'True'})
+        },
+        'rsr.category': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Category'},
+            'benchmarknames': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['rsr.Benchmarkname']", 'symmetrical': 'False', 'blank': 'True'}),
+            'focus_area': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'categories'", 'symmetrical': 'False', 'to': "orm['rsr.FocusArea']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'db_index': 'True'})
+        },
+        'rsr.country': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Country'},
+            'continent': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '20', 'db_index': 'True'}),
+            'continent_code': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'iso_code': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '2', 'db_index': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '50', 'db_index': 'True'})
+        },
+        'rsr.countrybudgetitem': {
+            'Meta': {'object_name': 'CountryBudgetItem'},
+            'code': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '6', 'blank': 'True'}),
+            'description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'percentage': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '1', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'country_budget_items'", 'to': "orm['rsr.Project']"}),
+            'vocabulary': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'})
+        },
+        'rsr.employment': {
+            'Meta': {'object_name': 'Employment'},
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Country']", 'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'employments'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_approved': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'job_title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'organisation': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'employees'", 'to': "orm['rsr.Organisation']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'employers'", 'to': "orm['rsr.User']"})
+        },
+        'rsr.focusarea': {
+            'Meta': {'ordering': "['name']", 'object_name': 'FocusArea'},
+            'description': ('akvo.rsr.fields.ValidXMLTextField', [], {'max_length': '500'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': (u'sorl.thumbnail.fields.ImageField', [], {'max_length': '100'}),
+            'link_to': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'})
+        },
+        'rsr.goal': {
+            'Meta': {'object_name': 'Goal'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'goals'", 'to': "orm['rsr.Project']"}),
+            'text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        'rsr.indicator': {
+            'Meta': {'object_name': 'Indicator'},
+            'ascending': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'baseline_comment': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'baseline_value': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'baseline_year': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '4', 'null': 'True', 'blank': 'True'}),
+            'description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'description_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'measure': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'result': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'indicators'", 'to': "orm['rsr.Result']"}),
+            'title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        'rsr.indicatorperiod': {
+            'Meta': {'object_name': 'IndicatorPeriod'},
+            'actual_comment': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'actual_value': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'indicator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'periods'", 'to': "orm['rsr.Indicator']"}),
+            'period_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'period_start': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'target_comment': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'target_value': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        'rsr.internalorganisationid': {
+            'Meta': {'unique_together': "(('recording_org', 'referenced_org'),)", 'object_name': 'InternalOrganisationID'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'identifier': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '200'}),
+            'recording_org': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'internal_ids'", 'to': "orm['rsr.Organisation']"}),
+            'referenced_org': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'reference_ids'", 'to': "orm['rsr.Organisation']"})
+        },
+        'rsr.invoice': {
+            'Meta': {'ordering': "['-id']", 'object_name': 'Invoice'},
+            'amount': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'amount_received': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '10', 'decimal_places': '2', 'blank': 'True'}),
+            'bank': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '4', 'blank': 'True'}),
+            'campaign_code': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '15', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'engine': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'paypal'", 'max_length': '10'}),
+            'http_referer': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ipn': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'is_anonymous': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'notes': ('akvo.rsr.fields.ValidXMLTextField', [], {'default': "''", 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'invoices'", 'to': "orm['rsr.Project']"}),
+            'status': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '1'}),
+            'test': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'time': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'transaction_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.User']", 'null': 'True', 'blank': 'True'})
+        },
+        'rsr.keyword': {
+            'Meta': {'ordering': "('label',)", 'object_name': 'Keyword'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '30', 'db_index': 'True'})
+        },
+        'rsr.legacydata': {
+            'Meta': {'object_name': 'LegacyData'},
+            'iati_equivalent': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'legacy_data'", 'to': "orm['rsr.Project']"}),
+            'value': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'})
+        },
+        'rsr.link': {
+            'Meta': {'object_name': 'Link'},
+            'caption': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'kind': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'links'", 'to': "orm['rsr.Project']"}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200'})
+        },
+        'rsr.minicms': {
+            'Meta': {'ordering': "['-active', '-id']", 'object_name': 'MiniCMS'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'feature_box': ('akvo.rsr.fields.ValidXMLTextField', [], {'max_length': '350'}),
+            'feature_image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50'}),
+            'lower_height': ('django.db.models.fields.IntegerField', [], {'default': '500'}),
+            'top_right_box': ('akvo.rsr.fields.ValidXMLTextField', [], {'max_length': '350'})
+        },
+        'rsr.molliegateway': {
+            'Meta': {'object_name': 'MollieGateway'},
+            'currency': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'EUR'", 'max_length': '3'}),
+            'description': ('akvo.rsr.fields.ValidXMLTextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255'}),
+            'notification_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'partner_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '10'})
+        },
+        'rsr.organisation': {
+            'Meta': {'ordering': "['name']", 'object_name': 'Organisation'},
+            'allow_edit': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'contact_email': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'contact_person': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '30', 'blank': 'True'}),
+            'content_owner': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Organisation']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'description': ('akvo.rsr.fields.ValidXMLTextField', [], {'blank': 'True'}),
+            'facebook': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'fax': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '20', 'blank': 'True'}),
+            'iati_org_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'db_index': 'True', 'max_length': '75', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'internal_org_ids': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'recording_organisation'", 'symmetrical': 'False', 'through': "orm['rsr.InternalOrganisationID']", 'to': "orm['rsr.Organisation']"}),
+            'language': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'en'", 'max_length': '2'}),
+            'last_modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'linkedin': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'logo': (u'sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'long_name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75', 'blank': 'True'}),
+            'mobile': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '20', 'blank': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '25', 'db_index': 'True'}),
+            'new_organisation_type': ('django.db.models.fields.IntegerField', [], {'default': '22', 'db_index': 'True'}),
+            'notes': ('akvo.rsr.fields.ValidXMLTextField', [], {'default': "''", 'blank': 'True'}),
+            'organisation_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'db_index': 'True'}),
+            'partner_types': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['rsr.PartnerType']", 'symmetrical': 'False'}),
+            'phone': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '20', 'blank': 'True'}),
+            'primary_location': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.OrganisationLocation']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'twitter': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        'rsr.organisationaccount': {
+            'Meta': {'object_name': 'OrganisationAccount'},
+            'account_level': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'archived'", 'max_length': '12'}),
+            'organisation': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['rsr.Organisation']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'rsr.organisationlocation': {
+            'Meta': {'ordering': "['id']", 'object_name': 'OrganisationLocation'},
+            'address_1': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'address_2': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'city': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Country']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('akvo.rsr.fields.LatitudeField', [], {'default': '0', 'db_index': 'True'}),
+            'location_target': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locations'", 'null': 'True', 'to': "orm['rsr.Organisation']"}),
+            'longitude': ('akvo.rsr.fields.LongitudeField', [], {'default': '0', 'db_index': 'True'}),
+            'postcode': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '10', 'blank': 'True'}),
+            'state': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        'rsr.partnership': {
+            'Meta': {'ordering': "['partner_type']", 'object_name': 'Partnership'},
+            'funding_amount': ('django.db.models.fields.DecimalField', [], {'db_index': 'True', 'null': 'True', 'max_digits': '10', 'decimal_places': '2', 'blank': 'True'}),
+            'iati_activity_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'db_index': 'True', 'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'iati_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'internal_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'db_index': 'True', 'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'organisation': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'partnerships'", 'to': "orm['rsr.Organisation']"}),
+            'partner_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '8', 'db_index': 'True'}),
+            'partner_type_extra': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'partnerships'", 'to': "orm['rsr.Project']"}),
+            'related_activity_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        'rsr.partnersite': {
+            'Meta': {'ordering': "('organisation__name',)", 'object_name': 'PartnerSite'},
+            'about_box': ('akvo.rsr.fields.ValidXMLTextField', [], {'max_length': '500', 'blank': 'True'}),
+            'about_image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'cname': ('akvo.rsr.fields.NullCharField', [], {'max_length': '100', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'custom_css': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'blank': 'True'}),
+            'custom_favicon': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'blank': 'True'}),
+            'custom_logo': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'blank': 'True'}),
+            'custom_return_url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'custom_return_url_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "''", 'max_length': '50', 'blank': 'True'}),
+            'default_language': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'en'", 'max_length': '5'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'exclude_keywords': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'facebook_app_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'facebook_button': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'google_translation': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hostname': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'keywords': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'partnersites'", 'blank': 'True', 'to': "orm['rsr.Keyword']"}),
+            'last_modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'notes': ('akvo.rsr.fields.ValidXMLTextField', [], {'default': "''", 'blank': 'True'}),
+            'organisation': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Organisation']"}),
+            'partner_projects': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'piwik_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'twitter_button': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'ui_translation': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'rsr.partnertype': {
+            'Meta': {'ordering': "('label',)", 'object_name': 'PartnerType'},
+            'id': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '8', 'primary_key': 'True'}),
+            'label': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'rsr.paymentgatewayselector': {
+            'Meta': {'object_name': 'PaymentGatewaySelector'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mollie_gateway': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': "orm['rsr.MollieGateway']"}),
+            'paypal_gateway': ('django.db.models.fields.related.ForeignKey', [], {'default': '1', 'to': "orm['rsr.PayPalGateway']"}),
+            'project': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['rsr.Project']", 'unique': 'True'})
+        },
+        'rsr.paypalgateway': {
+            'Meta': {'object_name': 'PayPalGateway'},
+            'account_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'}),
+            'currency': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'EUR'", 'max_length': '3'}),
+            'description': ('akvo.rsr.fields.ValidXMLTextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'US'", 'max_length': '2'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255'}),
+            'notification_email': ('django.db.models.fields.EmailField', [], {'max_length': '75'})
+        },
+        'rsr.planneddisbursement': {
+            'Meta': {'object_name': 'PlannedDisbursement'},
+            'currency': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'period_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'period_start': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'planned_disbursements'", 'to': "orm['rsr.Project']"}),
+            'type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'updated': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.DecimalField', [], {'max_digits': '10', 'decimal_places': '2', 'blank': 'True'}),
+            'value_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'rsr.policymarker': {
+            'Meta': {'object_name': 'PolicyMarker'},
+            'description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'policy_marker': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'policy_markers'", 'to': "orm['rsr.Project']"}),
+            'significance': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'vocabulary': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '5', 'blank': 'True'})
+        },
+        'rsr.project': {
+            'Meta': {'ordering': "['-id']", 'object_name': 'Project'},
+            'background': ('akvo.rsr.fields.ProjectLimitedTextField', [], {'blank': 'True'}),
+            'budget': ('django.db.models.fields.DecimalField', [], {'decimal_places': '2', 'default': '0', 'max_digits': '10', 'blank': 'True', 'null': 'True', 'db_index': 'True'}),
+            'capital_spend_percentage': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '1', 'blank': 'True'}),
+            'categories': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'projects'", 'blank': 'True', 'to': "orm['rsr.Category']"}),
+            'collaboration_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'currency': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'EUR'", 'max_length': '3'}),
+            'current_image': (u'sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'current_image_caption': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'current_image_credit': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'current_status': ('akvo.rsr.fields.ProjectLimitedTextField', [], {'blank': 'True'}),
+            'date_end_actual': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_end_planned': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_start_actual': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_start_planned': ('django.db.models.fields.DateField', [], {'default': 'datetime.date.today'}),
+            'default_aid_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'default_finance_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'default_flow_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'default_tied_status': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'donate_button': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'funds': ('django.db.models.fields.DecimalField', [], {'decimal_places': '2', 'default': '0', 'max_digits': '10', 'blank': 'True', 'null': 'True', 'db_index': 'True'}),
+            'funds_needed': ('django.db.models.fields.DecimalField', [], {'decimal_places': '2', 'default': '0', 'max_digits': '10', 'blank': 'True', 'null': 'True', 'db_index': 'True'}),
+            'goals_overview': ('akvo.rsr.fields.ProjectLimitedTextField', [], {}),
+            'hierarchy': ('django.db.models.fields.PositiveIntegerField', [], {'max_length': '1', 'null': 'True', 'blank': 'True'}),
+            'iati_activity_id': ('akvo.rsr.fields.ValidXMLCharField', [], {'db_index': 'True', 'max_length': '100', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'keywords': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'projects'", 'blank': 'True', 'to': "orm['rsr.Keyword']"}),
+            'language': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'en'", 'max_length': '2'}),
+            'last_modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'last_update': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'the_project'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['rsr.ProjectUpdate']"}),
+            'notes': ('akvo.rsr.fields.ValidXMLTextField', [], {'default': "''", 'blank': 'True'}),
+            'partners': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'projects'", 'symmetrical': 'False', 'through': "orm['rsr.Partnership']", 'to': "orm['rsr.Organisation']"}),
+            'primary_location': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.ProjectLocation']", 'null': 'True', 'on_delete': 'models.SET_NULL'}),
+            'project_plan': ('akvo.rsr.fields.ValidXMLTextField', [], {'blank': 'True'}),
+            'project_plan_summary': ('akvo.rsr.fields.ProjectLimitedTextField', [], {}),
+            'project_rating': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'project_scope': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'status': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'N'", 'max_length': '1', 'db_index': 'True'}),
+            'subtitle': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75'}),
+            'sustainability': ('akvo.rsr.fields.ValidXMLTextField', [], {}),
+            'sync_owner': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Organisation']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'sync_owner_secondary_reporter': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'target_group': ('akvo.rsr.fields.ProjectLimitedTextField', [], {'blank': 'True'}),
+            'title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '45', 'db_index': 'True'})
+        },
+        'rsr.projectcomment': {
+            'Meta': {'ordering': "('-id',)", 'object_name': 'ProjectComment'},
+            'comment': ('akvo.rsr.fields.ValidXMLTextField', [], {}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'comments'", 'to': "orm['rsr.Project']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.User']"})
+        },
+        'rsr.projectcondition': {
+            'Meta': {'object_name': 'ProjectCondition'},
+            'attached': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'conditions'", 'to': "orm['rsr.Project']"}),
+            'text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'})
+        },
+        'rsr.projectcontact': {
+            'Meta': {'object_name': 'ProjectContact'},
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'contacts'", 'null': 'True', 'to': "orm['rsr.Country']"}),
+            'department': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'job_title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'mailing_address': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'organisation': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'person_name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'contacts'", 'to': "orm['rsr.Project']"}),
+            'state': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'telephone': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '15', 'blank': 'True'}),
+            'type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        'rsr.projectdocument': {
+            'Meta': {'ordering': "['-id']", 'object_name': 'ProjectDocument'},
+            'category': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'document': ('django.db.models.fields.files.FileField', [], {'max_length': '100', 'blank': 'True'}),
+            'format': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'documents'", 'to': "orm['rsr.Project']"}),
+            'title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'title_language': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'url': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        'rsr.projectlocation': {
+            'Meta': {'ordering': "['id']", 'object_name': 'ProjectLocation'},
+            'activity_description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'address_1': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'address_2': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'administrative_code': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '25', 'blank': 'True'}),
+            'administrative_level': ('django.db.models.fields.PositiveSmallIntegerField', [], {'max_length': '1', 'null': 'True', 'blank': 'True'}),
+            'administrative_vocabulary': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'city': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Country']"}),
+            'description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'exactness': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'feature_designation': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '5', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('akvo.rsr.fields.LatitudeField', [], {'default': '0', 'db_index': 'True'}),
+            'location_class': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'location_code': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '25', 'blank': 'True'}),
+            'location_reach': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'location_target': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locations'", 'null': 'True', 'to': "orm['rsr.Project']"}),
+            'longitude': ('akvo.rsr.fields.LongitudeField', [], {'default': '0', 'db_index': 'True'}),
+            'name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'postcode': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '10', 'blank': 'True'}),
+            'reference': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'state': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'vocabulary': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'})
+        },
+        'rsr.projectupdate': {
+            'Meta': {'ordering': "['-id']", 'object_name': 'ProjectUpdate'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'en'", 'max_length': '2'}),
+            'last_modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'notes': ('akvo.rsr.fields.ValidXMLTextField', [], {'default': "''", 'blank': 'True'}),
+            'photo': (u'sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'blank': 'True'}),
+            'photo_caption': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75', 'blank': 'True'}),
+            'photo_credit': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '25', 'blank': 'True'}),
+            'primary_location': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.ProjectUpdateLocation']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'project_updates'", 'to': "orm['rsr.Project']"}),
+            'text': ('akvo.rsr.fields.ValidXMLTextField', [], {'blank': 'True'}),
+            'title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'update_method': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'W'", 'max_length': '1', 'db_index': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.User']"}),
+            'user_agent': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "''", 'max_length': '200', 'blank': 'True'}),
+            'uuid': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "''", 'max_length': '40', 'db_index': 'True', 'blank': 'True'}),
+            'video': ('embed_video.fields.EmbedVideoField', [], {'max_length': '200', 'blank': 'True'}),
+            'video_caption': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '75', 'blank': 'True'}),
+            'video_credit': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '25', 'blank': 'True'})
+        },
+        'rsr.projectupdatelocation': {
+            'Meta': {'ordering': "['id']", 'object_name': 'ProjectUpdateLocation'},
+            'address_1': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'address_2': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'city': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'country': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rsr.Country']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'latitude': ('akvo.rsr.fields.LatitudeField', [], {'default': '0', 'db_index': 'True'}),
+            'location_target': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'locations'", 'null': 'True', 'to': "orm['rsr.ProjectUpdate']"}),
+            'longitude': ('akvo.rsr.fields.LongitudeField', [], {'default': '0', 'db_index': 'True'}),
+            'postcode': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '10', 'blank': 'True'}),
+            'state': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        'rsr.publishingstatus': {
+            'Meta': {'ordering': "('-status', 'project')", 'object_name': 'PublishingStatus'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['rsr.Project']", 'unique': 'True'}),
+            'status': ('akvo.rsr.fields.ValidXMLCharField', [], {'default': "'unpublished'", 'max_length': '30'})
+        },
+        'rsr.recipientcountry': {
+            'Meta': {'object_name': 'RecipientCountry'},
+            'country': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'percentage': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '1', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'recipient_countries'", 'to': "orm['rsr.Project']"}),
+            'text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        'rsr.recipientregion': {
+            'Meta': {'object_name': 'RecipientRegion'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'percentage': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '1', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'recipient_regions'", 'to': "orm['rsr.Project']"}),
+            'region': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'region_vocabulary': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        'rsr.relatedproject': {
+            'Meta': {'ordering': "['project']", 'object_name': 'RelatedProject'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_projects'", 'to': "orm['rsr.Project']"}),
+            'related_project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_to_projects'", 'to': "orm['rsr.Project']"}),
+            'relation': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1'})
+        },
+        'rsr.result': {
+            'Meta': {'object_name': 'Result'},
+            'aggregation_status': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'description_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'results'", 'to': "orm['rsr.Project']"}),
+            'title': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'})
+        },
+        'rsr.sector': {
+            'Meta': {'object_name': 'Sector'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'percentage': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '4', 'decimal_places': '1', 'blank': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'sectors'", 'to': "orm['rsr.Project']"}),
+            'sector_code': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '5', 'blank': 'True'}),
+            'text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'vocabulary': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '5', 'blank': 'True'})
+        },
+        'rsr.transaction': {
+            'Meta': {'object_name': 'Transaction'},
+            'aid_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'aid_type_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'currency': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'description': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '255', 'blank': 'True'}),
+            'disbursement_channel': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'disbursement_channel_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'finance_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '3', 'blank': 'True'}),
+            'finance_type_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'flow_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'flow_type_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'project': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'transactions'", 'to': "orm['rsr.Project']"}),
+            'provider_organisation': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'providing_transactions'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['rsr.Organisation']"}),
+            'provider_organisation_activity': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'receiver_organisation': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'receiving_transactions'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': "orm['rsr.Organisation']"}),
+            'receiver_organisation_activity': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '50', 'blank': 'True'}),
+            'reference': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '25', 'blank': 'True'}),
+            'tied_status': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '1', 'blank': 'True'}),
+            'tied_status_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'transaction_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'transaction_type': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '2', 'blank': 'True'}),
+            'transaction_type_text': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '100', 'blank': 'True'}),
+            'value': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '11', 'decimal_places': '2', 'blank': 'True'}),
+            'value_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'rsr.user': {
+            'Meta': {'ordering': "['username']", 'object_name': 'User'},
+            'avatar': (u'sorl.thumbnail.fields.ImageField', [], {'max_length': '100', 'null': 'True'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '254'}),
+            'first_name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_admin': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_support': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('akvo.rsr.fields.ValidXMLCharField', [], {'max_length': '30', 'blank': 'True'}),
+            'notes': ('akvo.rsr.fields.ValidXMLTextField', [], {'default': "''", 'blank': 'True'}),
+            'organisations': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'users'", 'blank': 'True', 'through': "orm['rsr.Employment']", 'to': "orm['rsr.Organisation']"}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('akvo.rsr.fields.ValidXMLCharField', [], {'unique': 'True', 'max_length': '254'})
+        }
+    }
+
+    complete_apps = ['rsr']

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -199,7 +199,7 @@ class Project(TimestampsMixin, models.Model):
 
     # synced projects
     sync_owner = models.ForeignKey(
-        'Organisation', verbose_name=_(u'reporting organisation'), null=True, on_delete=models.SET_NULL,
+        'Organisation', verbose_name=_(u'reporting organisation'), null=True, blank=True, on_delete=models.SET_NULL,
         help_text=_(u'Select the reporting organisation of the project.')
     )
     sync_owner_secondary_reporter = models.NullBooleanField(

--- a/akvo/rsr/models/transaction.py
+++ b/akvo/rsr/models/transaction.py
@@ -52,7 +52,7 @@ class Transaction(models.Model):
         _(u'tied status text'), max_length=100, blank=True, help_text=_(u'(max 100 characters)')
     )
     transaction_date = models.DateField(
-        _(u'transaction date'), blank=True,
+        _(u'transaction date'), blank=True, null=True,
         help_text=u'Enter the financial reporting date that the transaction was/will be undertaken.'
     )
     transaction_type = ValidXMLCharField(
@@ -63,18 +63,22 @@ class Transaction(models.Model):
         _(u'transaction type text'), max_length=100, blank=True, help_text=_(u'(max 100 characters)')
     )
     value = models.DecimalField(
-        _(u'value'), blank=True, null=True, max_digits=11, decimal_places=1,
+        _(u'value'), blank=True, null=True, max_digits=11, decimal_places=2,
         help_text=u'Enter the transaction amount.'
     )
     value_date = models.DateField(_(u'value date'), blank=True, null=True)
     currency = ValidXMLCharField(_(u'currency'), blank=True, max_length=3, choices=codelist_choices(Currency))
-    provider_organisation = ValidXMLCharField(_(u'provider organisation'), blank=True, max_length=100)
-    provider_organisation_ref = ValidXMLCharField(_(u'provider organisation reference'), blank=True, max_length=50)
+    provider_organisation = models.ForeignKey(
+        'Organisation', verbose_name=_(u'provider organisation'), related_name='providing_transactions', blank=True,
+        null=True, on_delete=models.SET_NULL
+    )
     provider_organisation_activity = ValidXMLCharField(
         _(u'provider organisation activity id'), blank=True, max_length=50
     )
-    receiver_organisation = ValidXMLCharField(_(u'receiver organisation'), blank=True, max_length=100)
-    receiver_organisation_ref = ValidXMLCharField(_(u'receiver organisation reference'), blank=True, max_length=50)
+    receiver_organisation = models.ForeignKey(
+        'Organisation', verbose_name=_(u'receiver organisation'), related_name='receiving_transactions', blank=True,
+        null=True, on_delete=models.SET_NULL
+    )
     receiver_organisation_activity = ValidXMLCharField(
         _(u'receiver organisation activity id'), blank=True, max_length=50
     )

--- a/akvo/rsr/static/rsr/admin/css/akvo_admin.css
+++ b/akvo/rsr/static/rsr/admin/css/akvo_admin.css
@@ -21,3 +21,7 @@
 .rsr-project .inline-group {
     margin-top: -10px;
 }
+
+td.original {
+    display: none;
+}

--- a/akvo/templates/admin/rsr/organisation/change_form.html
+++ b/akvo/templates/admin/rsr/organisation/change_form.html
@@ -3,11 +3,6 @@
 
 {% block extrastyle %}
   {{block.super}}
-  <style>
-      .field-id {
-          display: none;
-      }
-  </style>
 {% endblock %}
 
 {% block pretitle %}

--- a/akvo/templates/admin/rsr/project/change_form.html
+++ b/akvo/templates/admin/rsr/project/change_form.html
@@ -5,11 +5,6 @@
 {% block extrastyle %}
   {{block.super}}
   <link rel="stylesheet" type="text/css" href="{{STATIC_URL}}rsr/admin/css/akvo_admin.css" />
-  <style>
-      .field-id {
-          display: none;
-      }
-  </style>
 {% endblock %}
 
 {% block pretitle %}

--- a/akvo/templates/admin/rsr/project/change_form.html
+++ b/akvo/templates/admin/rsr/project/change_form.html
@@ -70,47 +70,47 @@
                   {% include inline_admin_formset.opts.template %}
                 {% endwith %}
               {% endif %}
-              {% if forloop.counter == 2 %}
+              {% if forloop.counter == 3 %}
                 {% with inline_admin_formset=inline_admin_formsets.1 %}
                   {% include inline_admin_formset.opts.template %}
                 {% endwith %}
               {% endif %}
-              {% if forloop.counter == 4 %}
+              {% if forloop.counter == 5 %}
                   {% with inline_admin_formset=inline_admin_formsets.2 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 7 %}
+              {% if forloop.counter == 8 %}
                   {% with inline_admin_formset=inline_admin_formsets.3 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 8 %}
+              {% if forloop.counter == 9 %}
                   {% with inline_admin_formset=inline_admin_formsets.4 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 9 %}
+              {% if forloop.counter == 10 %}
                   {% with inline_admin_formset=inline_admin_formsets.5 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 10 %}
+              {% if forloop.counter == 11 %}
                   {% with inline_admin_formset=inline_admin_formsets.6 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 11 %}
+              {% if forloop.counter == 12 %}
                   {% with inline_admin_formset=inline_admin_formsets.7 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 12 %}
+              {% if forloop.counter == 13 %}
                   {% with inline_admin_formset=inline_admin_formsets.8 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 13 %}
+              {% if forloop.counter == 14 %}
                   {% with inline_admin_formset=inline_admin_formsets.9 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
@@ -138,14 +138,6 @@
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 16 %}
-                  {% with inline_admin_formset=inline_admin_formsets.17 %}
-                      {% include inline_admin_formset.opts.template %}
-                  {% endwith %}
-                  {% with inline_admin_formset=inline_admin_formsets.18 %}
-                      {% include inline_admin_formset.opts.template %}
-                  {% endwith %}
-              {% endif %}
           {% endfor %}
 
           {% block after_field_sets %}{% endblock %}
@@ -159,9 +151,11 @@
           {# JavaScript for prepopulated fields #}
           {% prepopulated_fields_js %}
 
+          {# remove colspan="2" on table headers #}
           {# Disable save buttons after they have been clicked #}
           <script type="text/javascript">
               (function($) {
+                  $("th").removeAttr("colspan");
                   var buttons = $(".submit-row").find("input:submit");
                   buttons.click(function(){
                     buttons.fadeTo("fast", 0.3);

--- a/akvo/templates/admin/rsr/project/change_form.html
+++ b/akvo/templates/admin/rsr/project/change_form.html
@@ -70,55 +70,57 @@
 
           {% for fieldset in adminform %}
               {% include "admin/includes/fieldset.html" %}
-              {% if forloop.counter == 2 %}
+              {% if forloop.counter == 1 %}
                 {% with inline_admin_formset=inline_admin_formsets.0 %}
                   {% include inline_admin_formset.opts.template %}
                 {% endwith %}
               {% endif %}
-              {% if forloop.counter == 4 %}
-                  {% with inline_admin_formset=inline_admin_formsets.1 %}
-                      {% include inline_admin_formset.opts.template %}
-                  {% endwith %}
+              {% if forloop.counter == 2 %}
+                {% with inline_admin_formset=inline_admin_formsets.1 %}
+                  {% include inline_admin_formset.opts.template %}
+                {% endwith %}
               {% endif %}
-              {% if forloop.counter == 7 %}
+              {% if forloop.counter == 4 %}
                   {% with inline_admin_formset=inline_admin_formsets.2 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 8 %}
+              {% if forloop.counter == 7 %}
                   {% with inline_admin_formset=inline_admin_formsets.3 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 9 %}
+              {% if forloop.counter == 8 %}
                   {% with inline_admin_formset=inline_admin_formsets.4 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 10 %}
+              {% if forloop.counter == 9 %}
                   {% with inline_admin_formset=inline_admin_formsets.5 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 11 %}
+              {% if forloop.counter == 10 %}
                   {% with inline_admin_formset=inline_admin_formsets.6 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 12 %}
+              {% if forloop.counter == 11 %}
                   {% with inline_admin_formset=inline_admin_formsets.7 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 13 %}
+              {% if forloop.counter == 12 %}
                   {% with inline_admin_formset=inline_admin_formsets.8 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}
-              {% if forloop.counter == 15 %}
+              {% if forloop.counter == 13 %}
                   {% with inline_admin_formset=inline_admin_formsets.9 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
+              {% endif %}
+              {% if forloop.counter == 15 %}
                   {% with inline_admin_formset=inline_admin_formsets.10 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
@@ -137,12 +139,15 @@
                   {% with inline_admin_formset=inline_admin_formsets.15 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
-              {% endif %}
-              {% if forloop.counter == 16 %}
                   {% with inline_admin_formset=inline_admin_formsets.16 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
+              {% endif %}
+              {% if forloop.counter == 16 %}
                   {% with inline_admin_formset=inline_admin_formsets.17 %}
+                      {% include inline_admin_formset.opts.template %}
+                  {% endwith %}
+                  {% with inline_admin_formset=inline_admin_formsets.18 %}
                       {% include inline_admin_formset.opts.template %}
                   {% endwith %}
               {% endif %}

--- a/scripts/deployment/pip/requirements/2_rsr.txt
+++ b/scripts/deployment/pip/requirements/2_rsr.txt
@@ -77,4 +77,4 @@ raven==4.2.3
 rules==0.3
 
 # Nested inlines in admin
--e git+git://github.com/Soaa-/django-nested-inlines.git#egg=django-nested-inlines
+-e git+git://github.com/silverfix/django-nested-inlines.git#egg=django-nested-inlines


### PR DESCRIPTION
Note that the 'user process' PR needs to be merged in first (because of migrations). Done in this PR:
- #1299 Make reporting organisation non-required in admin
- #1290 Add 'related projects' to project admin
- #1309 Updated django nested inlines library
  - Bugfixes from that library
  - Allows for tabbed inlines (some of the inlines have been set to tabbed instead of stacked)
- #1316 Remove categories, benchmarks and goals from project admin
- #1317 Update transactions
  - Receiver and provider organisations now are related to the organisation model
  - Transaction date can be null
  - Transaction value can have 2 digits behind comma
- #1321 Remove partner types extra from partnerships in admin