### PR TITLE
[1018] Disabled DDT by default

### DIFF
--- a/akvo/settings/66_local.template
+++ b/akvo/settings/66_local.template
@@ -14,22 +14,22 @@ PIPELINE_ENABLED = False
 # The console email backend will print emails to console, useful for dev server
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-# Django Debug Toolbar
-INSTALLED_APPS += ('debug_toolbar',)
-MIDDLEWARE_CLASSES = (
-    ('debug_toolbar.middleware.DebugToolbarMiddleware',)
-    + MIDDLEWARE_CLASSES)
-DEBUG_TOOLBAR_PANELS = [
-    # 'debug_toolbar.panels.versions.VersionsPanel',
-    'debug_toolbar.panels.timer.TimerPanel',
-    'debug_toolbar.panels.settings.SettingsPanel',
-    'debug_toolbar.panels.headers.HeadersPanel',
-    'debug_toolbar.panels.request.RequestPanel',
-    'debug_toolbar.panels.sql.SQLPanel',
-    'debug_toolbar.panels.staticfiles.StaticFilesPanel',
-    'debug_toolbar.panels.templates.TemplatesPanel',
-    'debug_toolbar.panels.cache.CachePanel',
-    'debug_toolbar.panels.signals.SignalsPanel',
-    'debug_toolbar.panels.logging.LoggingPanel',
-    'debug_toolbar.panels.redirects.RedirectsPanel',
-]
+# Django Debug Toolbar - disabled by default
+# INSTALLED_APPS += ('debug_toolbar',)
+# MIDDLEWARE_CLASSES = (
+#     ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+#     + MIDDLEWARE_CLASSES)
+# DEBUG_TOOLBAR_PANELS = [
+#     # 'debug_toolbar.panels.versions.VersionsPanel',
+#     'debug_toolbar.panels.timer.TimerPanel',
+#     'debug_toolbar.panels.settings.SettingsPanel',
+#     'debug_toolbar.panels.headers.HeadersPanel',
+#     'debug_toolbar.panels.request.RequestPanel',
+#     'debug_toolbar.panels.sql.SQLPanel',
+#     'debug_toolbar.panels.staticfiles.StaticFilesPanel',
+#     'debug_toolbar.panels.templates.TemplatesPanel',
+#     'debug_toolbar.panels.cache.CachePanel',
+#     'debug_toolbar.panels.signals.SignalsPanel',
+#     'debug_toolbar.panels.logging.LoggingPanel',
+#     'debug_toolbar.panels.redirects.RedirectsPanel',
+# ]


### PR DESCRIPTION
Since the Django Debug Toolbar is slow, we should not enable it by
default. Hence commenting out the section in the local settings template.