### PR TITLE
1333 gulp errors

### DIFF
--- a/scripts/devhelpers/gulpfile.js
+++ b/scripts/devhelpers/gulpfile.js
@@ -8,30 +8,35 @@ var gulp = require('gulp');
 
 // Include Plugins
 var jshint = require('gulp-jshint');
+var plumber = require('gulp-plumber');
 var react = require('gulp-react');
 var sass = require('gulp-sass');
 
+
 gulp.task('lint', function() {
-    return gulp.src('../../akvo/rsr/static/rsr/v3/**/*.js')
-        .pipe(jshint())
-        .pipe(jshint.reporter('default'));
+  return gulp.src('../../akvo/rsr/static/rsr/v3/**/*.js')
+    .pipe(plumber())
+    .pipe(jshint())
+    .pipe(jshint.reporter('default'));
 });
 
 gulp.task('jsx', function () {
-    return gulp.src('../../akvo/rsr/static/rsr/v3/**/*.jsx')
-        .pipe(react())
-        .pipe(gulp.dest('../../akvo/rsr/static/rsr/v3'));
+  return gulp.src('../../akvo/rsr/static/rsr/v3/**/*.jsx')
+    .pipe(plumber())
+    .pipe(react())
+    .pipe(gulp.dest('../../akvo/rsr/static/rsr/v3'));
 });
 
 gulp.task('sass', function() {
-    return gulp.src('../../akvo/rsr/static/rsr/v3/**/*.scss')
+  return gulp.src('../../akvo/rsr/static/rsr/v3/**/*.scss')
+    .pipe(plumber())
     .pipe(sass({errLogToConsole: true}))
-          .pipe(gulp.dest('../../akvo/rsr/static/rsr/v3'));
+    .pipe(gulp.dest('../../akvo/rsr/static/rsr/v3'));
 });
 
 gulp.task('watch', function() {
-    gulp.watch('../../akvo/rsr/static/rsr/v3/js/**/*.jsx', ['jsx']);
     gulp.watch('../../akvo/rsr/static/rsr/v3/css/**/*.scss', ['sass']);
+    gulp.watch('../../akvo/rsr/static/rsr/v3/js/**/*.jsx', ['jsx']);
 });
 
 // Default Task

--- a/scripts/devhelpers/gulpfile.js
+++ b/scripts/devhelpers/gulpfile.js
@@ -1,3 +1,8 @@
+// Akvo RSR is covered by the GNU Affero General Public License.
+// See more details in the license.txt file located at the root folder of the
+// Akvo RSR module. For additional details on the GNU license please see
+// < http://www.gnu.org/licenses/agpl.html >.
+
 // Include Gulp
 var gulp = require('gulp');
 

--- a/scripts/devhelpers/gulpfile.js
+++ b/scripts/devhelpers/gulpfile.js
@@ -20,7 +20,7 @@ gulp.task('jsx', function () {
 
 gulp.task('sass', function() {
     return gulp.src('../../akvo/rsr/static/rsr/v3/**/*.scss')
-          .pipe(sass())
+    .pipe(sass({errLogToConsole: true}))
           .pipe(gulp.dest('../../akvo/rsr/static/rsr/v3'));
 });
 

--- a/scripts/devhelpers/package.json
+++ b/scripts/devhelpers/package.json
@@ -1,18 +1,19 @@
 {
-    "name": "akvo-rsr-asset-pipeline",
-    "version": "0.0.1",
-    "description": "Asset pipeline for Akvo-rsr",
-    "main": "gulpfile.js",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "private": true,
-    "author": "Akvo foundation",
-    "license": "AGPL",
-    "devDependencies": {
-        "gulp": "^3.8.10",
-        "gulp-jshint": "^1.9.0",
-        "gulp-react": "^0.4.0",
-        "gulp-sass": "^1.1.0"
-    }
+  "name": "akvo-rsr-asset-pipeline",
+  "version": "0.0.2",
+  "description": "Asset pipeline for Akvo-rsr",
+  "main": "gulpfile.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "private": true,
+  "author": "Akvo foundation",
+  "license": "AGPL",
+  "devDependencies": {
+    "gulp": "^3.8.11",
+    "gulp-jshint": "^1.9.2",
+    "gulp-react": "^3.0.1",
+    "gulp-sass": "^1.3.3",
+    "gulp-plumber": "^1.0.0"
+  }
 }


### PR DESCRIPTION
Besides adding plumber this also updates dependencies. Have to admit that I'm no nom expert so I first did npm update which I think updates my global gulp. Then I killed the scripts/devhelpers/node_modules dir and while in scripts/devhelpers issued npm install to get new modules.

If there is an error in a sass file or a jsx file file and row should be printed now.
