### PR TITLE
1293 iati identifier

### DIFF
--- a/akvo/rsr/static/rsr/v3/css/src/main.css
+++ b/akvo/rsr/static/rsr/v3/css/src/main.css
@@ -199,7 +199,7 @@ span.twitter-typeahead .tt-suggestion > p {
   padding: 3px 20px;
   clear: both;
   font-weight: normal;
-  line-height: 1.42857;
+  line-height: 1.42857143;
   color: #333;
   white-space: nowrap; }
 
@@ -1283,6 +1283,9 @@ div.textBlock {
   -o-border-radius: 5px;
   -webkit-border-radius: 5px;
   border-radius: 5px; }
+.organisationDetail .orgUrl, .organisationDetail .orgIati, .organisationDetail .orgEmail {
+  display: block;
+  padding-bottom: 0.75em; }
 
 /* Update Page */
 .updateMain h2 {

--- a/akvo/rsr/static/rsr/v3/css/src/main.scss
+++ b/akvo/rsr/static/rsr/v3/css/src/main.scss
@@ -1549,6 +1549,12 @@ div.textBlock {
         background: rgba(white, 0.45);
         @include border-radius(5px);
     }
+    .orgUrl,
+    .orgIati,
+    .orgEmail {
+        display: block;
+        padding-bottom: 0.75em;
+    }
 }
 
 /* Update Page */

--- a/akvo/templates/organisation_main.html
+++ b/akvo/templates/organisation_main.html
@@ -22,7 +22,12 @@
 
         <ul class="noStyleUl">
           <li>
-            {% if organisation.url %}<a href="{{organisation.url}}">{{organisation.url}}</a>{% endif %}
+            {% if organisation.url %}<a class="orgUrl" href="{{organisation.url}}">{{organisation.url}}</a>{% endif %}
+          </li>
+          <li>
+            {% if organisation.iati_org_id %}
+            <span class="orgIati">IATI: {{organisation.iati_org_id}}</span>
+            {% endif %}
           </li>
           <li>
             {% if organisation.primary_location.address_1 %}{{organisation.primary_location.address_1}}
@@ -56,7 +61,7 @@
         <ul class="noStyleUl">
           <li>
             {% if organisation.contact_email %}
-              <a href="mailto:{{organisation.contact_email}}">{{organisation.contact_email}}</a>
+              <a class="orgEmail" href="mailto:{{organisation.contact_email}}">{{organisation.contact_email}}</a>
             {% endif %}
           </li>
           <li>


### PR DESCRIPTION
The cleanest place to put the identifier seemed to be in "Details", above the address.

I also added some light spacing between the different blocks

before: 
![pre](https://cloud.githubusercontent.com/assets/2589977/6683854/3f31e9a6-cc83-11e4-9db9-c01c8643e911.png)

after:
![post](https://cloud.githubusercontent.com/assets/2589977/6683855/4153f7c4-cc83-11e4-918e-5cb0178105b9.png)

