### PR TITLE
[#1454] Organisation sort SQL error fix

### DIFF
--- a/akvo/rsr/models/organisation.py
+++ b/akvo/rsr/models/organisation.py
@@ -46,7 +46,7 @@ class OrgManager(models.Manager):
     def get_queryset(self):
         return self.model.QuerySet(self.model).extra(
             select={
-                'lower_name': 'lower(name)'
+                'lower_name': 'lower(rsr_organisation.name)'
             }
         ).order_by('lower_name')
 


### PR DESCRIPTION
## Test plan
1. Go to organisation list page
2. Filter on location
3. Page should not break when showing at least one organisation