### PR TITLE
[#1458] Sorting remains when switching pages

### DIFF
--- a/akvo/rsr/views/project.py
+++ b/akvo/rsr/views/project.py
@@ -60,7 +60,7 @@ def directory(request):
 
     # Set show_filters to "in" if any filter is selected
     show_filters = "in"  # To simplify template use bootstrap class
-    available_filters = ['location', 'status', 'organisation', 'sector', ]
+    available_filters = ['location', 'status', 'organisation', 'sector', 'sort_by']
     if frozenset(qs.keys()).isdisjoint(available_filters):
         show_filters = ""
 

--- a/akvo/utils.py
+++ b/akvo/utils.py
@@ -425,7 +425,6 @@ def filter_query_string(qs):
     """
     q = dict(qs.iterlists())  # to Python dict
     q.pop('page', None)
-    q.pop('sort_by', None)
 
     if not bool(q):
         return ''


### PR DESCRIPTION
## Test plan
1. Go to project list
2. Sort by something
3. Switch page, sorting should stay in place