### PR TITLE
[fixes #1052] Add react typeahead to organisation filter for project directory

### DIFF
--- a/akvo/rsr/static/lib/scripts/react-typeahead-1.0.4.js
+++ b/akvo/rsr/static/lib/scripts/react-typeahead-1.0.4.js
@@ -1,0 +1,869 @@
+!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.ReactTypeahead=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+function classNames() {
+	var classes = '';
+	var arg;
+
+	for (var i = 0; i < arguments.length; i++) {
+		arg = arguments[i];
+		if (!arg) {
+			continue;
+		}
+
+		if ('string' === typeof arg || 'number' === typeof arg) {
+			classes += ' ' + arg;
+		} else if (Object.prototype.toString.call(arg) === '[object Array]') {
+			classes += ' ' + classNames.apply(null, arg);
+		} else if ('object' === typeof arg) {
+			for (var key in arg) {
+				if (!arg.hasOwnProperty(key) || !arg[key]) {
+					continue;
+				}
+				classes += ' ' + key;
+			}
+		}
+	}
+	return classes.substr(1);
+}
+
+// safely export classNames in case the script is included directly on a page
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = classNames;
+}
+
+},{}],2:[function(require,module,exports){
+/*
+ * Fuzzy
+ * https://github.com/myork/fuzzy
+ *
+ * Copyright (c) 2012 Matt York
+ * Licensed under the MIT license.
+ */
+
+(function() {
+
+var root = this;
+
+var fuzzy = {};
+
+// Use in node or in browser
+if (typeof exports !== 'undefined') {
+  module.exports = fuzzy;
+} else {
+  root.fuzzy = fuzzy;
+}
+
+// Return all elements of `array` that have a fuzzy
+// match against `pattern`.
+fuzzy.simpleFilter = function(pattern, array) {
+  return array.filter(function(string) {
+    return fuzzy.test(pattern, string);
+  });
+};
+
+// Does `pattern` fuzzy match `string`?
+fuzzy.test = function(pattern, string) {
+  return fuzzy.match(pattern, string) !== null;
+};
+
+// If `pattern` matches `string`, wrap each matching character
+// in `opts.pre` and `opts.post`. If no match, return null
+fuzzy.match = function(pattern, string, opts) {
+  opts = opts || {};
+  var patternIdx = 0
+    , result = []
+    , len = string.length
+    , totalScore = 0
+    , currScore = 0
+    // prefix
+    , pre = opts.pre || ''
+    // suffix
+    , post = opts.post || ''
+    // String to compare against. This might be a lowercase version of the
+    // raw string
+    , compareString =  opts.caseSensitive && string || string.toLowerCase()
+    , ch, compareChar;
+
+  pattern = opts.caseSensitive && pattern || pattern.toLowerCase();
+
+  // For each character in the string, either add it to the result
+  // or wrap in template if its the next string in the pattern
+  for(var idx = 0; idx < len; idx++) {
+    ch = string[idx];
+    if(compareString[idx] === pattern[patternIdx]) {
+      ch = pre + ch + post;
+      patternIdx += 1;
+
+      // consecutive characters should increase the score more than linearly
+      currScore += 1 + currScore;
+    } else {
+      currScore = 0;
+    }
+    totalScore += currScore;
+    result[result.length] = ch;
+  }
+
+  // return rendered string if we have a match for every char
+  if(patternIdx === pattern.length) {
+    return {rendered: result.join(''), score: totalScore};
+  }
+
+  return null;
+};
+
+// The normal entry point. Filters `arr` for matches against `pattern`.
+// It returns an array with matching values of the type:
+//
+//     [{
+//         string:   '<b>lah' // The rendered string
+//       , index:    2        // The index of the element in `arr`
+//       , original: 'blah'   // The original element in `arr`
+//     }]
+//
+// `opts` is an optional argument bag. Details:
+//
+//    opts = {
+//        // string to put before a matching character
+//        pre:     '<b>'
+//
+//        // string to put after matching character
+//      , post:    '</b>'
+//
+//        // Optional function. Input is an element from the passed in
+//        // `arr`, output should be the string to test `pattern` against.
+//        // In this example, if `arr = [{crying: 'koala'}]` we would return
+//        // 'koala'.
+//      , extract: function(arg) { return arg.crying; }
+//    }
+fuzzy.filter = function(pattern, arr, opts) {
+  opts = opts || {};
+  return arr
+          .reduce(function(prev, element, idx, arr) {
+            var str = element;
+            if(opts.extract) {
+              str = opts.extract(element);
+            }
+            var rendered = fuzzy.match(pattern, str, opts);
+            if(rendered != null) {
+              prev[prev.length] = {
+                  string: rendered.rendered
+                , score: rendered.score
+                , index: idx
+                , original: element
+              };
+            }
+            return prev;
+          }, [])
+
+          // Sort by score. Browsers are inconsistent wrt stable/unstable
+          // sorting, so force stable by using the index in the case of tie.
+          // See http://ofb.net/~sethml/is-sort-stable.html
+          .sort(function(a,b) {
+            var compare = b.score - a.score;
+            if(compare) return compare;
+            return a.index - b.index;
+          });
+};
+
+
+}());
+
+
+},{}],3:[function(require,module,exports){
+/**
+ * PolyFills make me sad
+ */
+var KeyEvent = KeyEvent || {};
+KeyEvent.DOM_VK_UP = KeyEvent.DOM_VK_UP || 38;
+KeyEvent.DOM_VK_DOWN = KeyEvent.DOM_VK_DOWN || 40;
+KeyEvent.DOM_VK_BACK_SPACE = KeyEvent.DOM_VK_BACK_SPACE || 8;
+KeyEvent.DOM_VK_RETURN = KeyEvent.DOM_VK_RETURN || 13;
+KeyEvent.DOM_VK_ENTER = KeyEvent.DOM_VK_ENTER || 14;
+KeyEvent.DOM_VK_ESCAPE = KeyEvent.DOM_VK_ESCAPE || 27;
+KeyEvent.DOM_VK_TAB = KeyEvent.DOM_VK_TAB || 9;
+
+module.exports = KeyEvent;
+
+
+
+},{}],4:[function(require,module,exports){
+var Typeahead = require('./typeahead');
+var Tokenizer = require('./tokenizer');
+
+module.exports = {
+  Typeahead: Typeahead,
+  Tokenizer: Tokenizer
+};
+
+
+
+},{"./tokenizer":5,"./typeahead":7}],5:[function(require,module,exports){
+/**
+ * @jsx React.DOM
+ */
+
+var React = window.React || require('react');
+var Token = require('./token');
+var KeyEvent = require('../keyevent');
+var Typeahead = require('../typeahead');
+var classNames = require('classnames');
+
+/**
+ * A typeahead that, when an option is selected, instead of simply filling
+ * the text entry widget, prepends a renderable "token", that may be deleted
+ * by pressing backspace on the beginning of the line with the keyboard.
+ */
+var TypeaheadTokenizer = React.createClass({displayName: "TypeaheadTokenizer",
+  propTypes: {
+    name: React.PropTypes.string,
+    options: React.PropTypes.array,
+    customClasses: React.PropTypes.object,
+    allowCustomValues: React.PropTypes.number,
+    defaultSelected: React.PropTypes.array,
+    defaultValue: React.PropTypes.string,
+    placeholder: React.PropTypes.string,
+    onTokenRemove: React.PropTypes.func,
+    onTokenAdd: React.PropTypes.func,
+    filterOption: React.PropTypes.func,
+    maxVisible: React.PropTypes.number
+  },
+
+  getInitialState: function() {
+    return {
+      // We need to copy this to avoid incorrect sharing
+      // of state across instances (e.g., via getDefaultProps())
+      selected: this.props.defaultSelected.slice(0)
+    };
+  },
+
+  getDefaultProps: function() {
+    return {
+      options: [],
+      defaultSelected: [],
+      customClasses: {},
+      allowCustomValues: 0,
+      defaultValue: "",
+      placeholder: "",
+      onTokenAdd: function() {},
+      onTokenRemove: function() {}
+    };
+  },
+
+  // TODO: Support initialized tokens
+  //
+  _renderTokens: function() {
+    var tokenClasses = {};
+    tokenClasses[this.props.customClasses.token] = !!this.props.customClasses.token;
+    var classList = classNames(tokenClasses);
+    var result = this.state.selected.map(function(selected) {
+      return (
+        React.createElement(Token, {key:  selected, className: classList, 
+          onRemove:  this._removeTokenForValue, 
+          name:  this.props.name}, 
+           selected 
+        )
+      );
+    }, this);
+    return result;
+  },
+
+  _getOptionsForTypeahead: function() {
+    // return this.props.options without this.selected
+    return this.props.options;
+  },
+
+  _onKeyDown: function(event) {
+    // We only care about intercepting backspaces
+    if (event.keyCode !== KeyEvent.DOM_VK_BACK_SPACE) {
+      return;
+    }
+
+    // No tokens
+    if (!this.state.selected.length) {
+      return;
+    }
+
+    // Remove token ONLY when bksp pressed at beginning of line
+    // without a selection
+    var entry = this.refs.typeahead.refs.entry.getDOMNode();
+    if (entry.selectionStart == entry.selectionEnd &&
+        entry.selectionStart == 0) {
+      this._removeTokenForValue(
+        this.state.selected[this.state.selected.length - 1]);
+      event.preventDefault();
+    }
+  },
+
+  _removeTokenForValue: function(value) {
+    var index = this.state.selected.indexOf(value);
+    if (index == -1) {
+      return;
+    }
+
+    this.state.selected.splice(index, 1);
+    this.setState({selected: this.state.selected});
+    this.props.onTokenRemove(this.state.selected);
+    return;
+  },
+
+  _addTokenForValue: function(value) {
+    if (this.state.selected.indexOf(value) != -1) {
+      return;
+    }
+    this.state.selected.push(value);
+    this.setState({selected: this.state.selected});
+    this.refs.typeahead.setEntryText("");
+    this.props.onTokenAdd(this.state.selected);
+  },
+
+  render: function() {
+    var classes = {};
+    classes[this.props.customClasses.typeahead] = !!this.props.customClasses.typeahead;
+    var classList = classNames(classes);
+    return (
+      React.createElement("div", {className: "typeahead-tokenizer"}, 
+         this._renderTokens(), 
+        React.createElement(Typeahead, {ref: "typeahead", 
+          className: classList, 
+          placeholder: this.props.placeholder, 
+          allowCustomValues: this.props.allowCustomValues, 
+          customClasses: this.props.customClasses, 
+          options: this._getOptionsForTypeahead(), 
+          defaultValue: this.props.defaultValue, 
+          maxVisible: this.props.maxVisible, 
+          onOptionSelected: this._addTokenForValue, 
+          onKeyDown: this._onKeyDown, 
+          filterOption: this.props.filterOption})
+      )
+    );
+  }
+});
+
+module.exports = TypeaheadTokenizer;
+
+
+
+},{"../keyevent":3,"../typeahead":7,"./token":6,"classnames":1,"react":"react"}],6:[function(require,module,exports){
+/**
+ * @jsx React.DOM
+ */
+
+var React = window.React || require('react');
+var classNames = require('classnames');
+
+/**
+ * Encapsulates the rendering of an option that has been "selected" in a
+ * TypeaheadTokenizer
+ */
+var Token = React.createClass({displayName: "Token",
+  propTypes: {
+    className: React.PropTypes.string,
+    name: React.PropTypes.string,
+    children: React.PropTypes.string,
+    onRemove: React.PropTypes.func
+  },
+
+  render: function() {
+    var className = classNames([
+      "typeahead-token",
+      this.props.className
+    ]);
+
+    return (
+      React.createElement("div", {className: className}, 
+        this._renderHiddenInput(), 
+        this.props.children, 
+        this._renderCloseButton()
+      )
+    );
+  },
+
+  _renderHiddenInput: function() {
+    // If no name was set, don't create a hidden input
+    if (!this.props.name) {
+      return null;
+    }
+
+    return (
+      React.createElement("input", {
+        type: "hidden", 
+        name:  this.props.name + '[]', 
+        value:  this.props.children}
+      )
+    );
+  },
+
+  _renderCloseButton: function() {
+    if (!this.props.onRemove) {
+      return "";
+    }
+    return (
+      React.createElement("a", {className: "typeahead-token-close", href: "#", onClick: function(event) {
+          this.props.onRemove(this.props.children);
+          event.preventDefault();
+        }.bind(this)}, "×")
+    );
+  }
+});
+
+module.exports = Token;
+
+
+
+},{"classnames":1,"react":"react"}],7:[function(require,module,exports){
+/**
+ * @jsx React.DOM
+ */
+
+var React = window.React || require('react/addons');
+var TypeaheadSelector = require('./selector');
+var KeyEvent = require('../keyevent');
+var fuzzy = require('fuzzy');
+var classNames = require('classnames');
+
+/**
+ * A "typeahead", an auto-completing text input
+ *
+ * Renders an text input that shows options nearby that you can use the
+ * keyboard or mouse to select.  Requires CSS for MASSIVE DAMAGE.
+ */
+var Typeahead = React.createClass({displayName: "Typeahead",
+  propTypes: {
+    name: React.PropTypes.string,
+    customClasses: React.PropTypes.object,
+    maxVisible: React.PropTypes.number,
+    options: React.PropTypes.array,
+    allowCustomValues: React.PropTypes.number,
+    defaultValue: React.PropTypes.string,
+    placeholder: React.PropTypes.string,
+    onOptionSelected: React.PropTypes.func,
+    onKeyDown: React.PropTypes.func,
+    filterOption: React.PropTypes.func
+  },
+
+  getDefaultProps: function() {
+    return {
+      options: [],
+      customClasses: {},
+      allowCustomValues: 0,
+      defaultValue: "",
+      placeholder: "",
+      onOptionSelected: function(option) {},
+      onKeyDown: function(event) {},
+      filterOption: null
+    };
+  },
+
+  getInitialState: function() {
+    return {
+      // The currently visible set of options
+      visible: this.getOptionsForValue(this.props.defaultValue, this.props.options),
+
+      // This should be called something else, "entryValue"
+      entryValue: this.props.defaultValue,
+
+      // A valid typeahead value
+      selection: null
+    };
+  },
+
+  getOptionsForValue: function(value, options) {
+    var result;
+    if (this.props.filterOption) {
+      result = options.filter((function(o) { return this.props.filterOption(value, o); }).bind(this));
+    } else {
+      result = fuzzy.filter(value, options).map(function(res) {
+        return res.string;
+      });
+    }
+    if (this.props.maxVisible) {
+      result = result.slice(0, this.props.maxVisible);
+    }
+    return result;
+  },
+
+  setEntryText: function(value) {
+    this.refs.entry.getDOMNode().value = value;
+    this._onTextEntryUpdated();
+  },
+
+  _hasCustomValue: function() {
+    if (this.props.allowCustomValues > 0 &&
+      this.state.entryValue.length >= this.props.allowCustomValues &&
+      this.state.visible.indexOf(this.state.entryValue) < 0) {
+      return true;
+    }
+    return false;
+  },
+
+  _getCustomValue: function() {
+    if (this._hasCustomValue()) {
+      return this.state.entryValue;
+    }
+    return null
+  },
+
+  _renderIncrementalSearchResults: function() {
+    // Nothing has been entered into the textbox
+    if (!this.state.entryValue) {
+      return "";
+    }
+
+    // Something was just selected
+    if (this.state.selection) {
+      return "";
+    }
+
+    // There are no typeahead / autocomplete suggestions
+    if (!this.state.visible.length && !(this.props.allowCustomValues > 0)) {
+      return "";
+    }
+
+    if (this._hasCustomValue()) {
+      return (
+        React.createElement(TypeaheadSelector, {
+          ref: "sel", options: this.state.visible, 
+          customValue: this.state.entryValue, 
+          onOptionSelected: this._onOptionSelected, 
+          customClasses: this.props.customClasses})
+      );
+    }
+
+    return (
+      React.createElement(TypeaheadSelector, {
+        ref: "sel", options:  this.state.visible, 
+        onOptionSelected:  this._onOptionSelected, 
+        customClasses: this.props.customClasses})
+   );
+  },
+
+  _onOptionSelected: function(option, event) {
+    var nEntry = this.refs.entry.getDOMNode();
+    nEntry.focus();
+    nEntry.value = option;
+    this.setState({visible: this.getOptionsForValue(option, this.props.options),
+                   selection: option,
+                   entryValue: option});
+    return this.props.onOptionSelected(option, event);
+  },
+
+  _onTextEntryUpdated: function() {
+    var value = this.refs.entry.getDOMNode().value;
+    this.setState({visible: this.getOptionsForValue(value, this.props.options),
+                   selection: null,
+                   entryValue: value});
+  },
+
+  _onEnter: function(event) {
+    if (!this.refs.sel.state.selection) {
+      return this.props.onKeyDown(event);
+    }
+    return this._onOptionSelected(this.refs.sel.state.selection, event);
+  },
+
+  _onEscape: function() {
+    this.refs.sel.setSelectionIndex(null)
+  },
+
+  _onTab: function(event) {
+    var option = this.refs.sel.state.selection ?
+      this.refs.sel.state.selection : (this.state.visible.length > 0 ? this.state.visible[0] : null);
+
+    if (option === null && this._hasCustomValue()) {
+      option = this._getCustomValue();
+    }
+
+    if (option !== null) {
+      return this._onOptionSelected(option, event);
+    }
+  },
+
+  eventMap: function(event) {
+    var events = {};
+
+    events[KeyEvent.DOM_VK_UP] = this.refs.sel.navUp;
+    events[KeyEvent.DOM_VK_DOWN] = this.refs.sel.navDown;
+    events[KeyEvent.DOM_VK_RETURN] = events[KeyEvent.DOM_VK_ENTER] = this._onEnter;
+    events[KeyEvent.DOM_VK_ESCAPE] = this._onEscape;
+    events[KeyEvent.DOM_VK_TAB] = this._onTab;
+
+    return events;
+  },
+
+  _onKeyDown: function(event) {
+    // If there are no visible elements, don't perform selector navigation.
+    // Just pass this up to the upstream onKeydown handler
+    if (!this.refs.sel) {
+      return this.props.onKeyDown(event);
+    }
+
+    var handler = this.eventMap()[event.keyCode];
+
+    if (handler) {
+      handler(event);
+    } else {
+      return this.props.onKeyDown(event);
+    }
+    // Don't propagate the keystroke back to the DOM/browser
+    event.preventDefault();
+  },
+
+  componentWillReceiveProps: function(nextProps) {
+    this.setState({
+      visible: this.getOptionsForValue(this.state.entryValue, nextProps.options)
+    });
+  },
+
+  render: function() {
+    var inputClasses = {}
+    inputClasses[this.props.customClasses.input] = !!this.props.customClasses.input;
+    var inputClassList = classNames(inputClasses);
+
+    var classes = {
+      typeahead: true
+    }
+    classes[this.props.className] = !!this.props.className;
+    var classList = classNames(classes);
+
+    return (
+      React.createElement("div", {className: classList}, 
+         this._renderHiddenInput(), 
+        React.createElement("input", {ref: "entry", type: "text", 
+          placeholder: this.props.placeholder, 
+          className: inputClassList, 
+          value: this.state.entryValue, 
+          defaultValue: this.props.defaultValue, 
+          onChange: this._onTextEntryUpdated, onKeyDown: this._onKeyDown}), 
+         this._renderIncrementalSearchResults() 
+      )
+    );
+  },
+
+  _renderHiddenInput: function() {
+    if (!this.props.name) {
+      return null;
+    }
+
+    return (
+      React.createElement("input", {
+        type: "hidden", 
+        name:  this.props.name, 
+        value:  this.state.selection}
+      )
+    );
+  }
+});
+
+module.exports = Typeahead;
+
+
+
+},{"../keyevent":3,"./selector":9,"classnames":1,"fuzzy":2,"react/addons":"react/addons"}],8:[function(require,module,exports){
+/**
+ * @jsx React.DOM
+ */
+
+var React = window.React || require('react/addons');
+var classNames = require('classnames');
+
+/**
+ * A single option within the TypeaheadSelector
+ */
+var TypeaheadOption = React.createClass({displayName: "TypeaheadOption",
+  propTypes: {
+    customClasses: React.PropTypes.object,
+    customValue: React.PropTypes.string,
+    onClick: React.PropTypes.func,
+    children: React.PropTypes.string,
+    hover: React.PropTypes.bool
+  },
+
+  getDefaultProps: function() {
+    return {
+      customClasses: {},
+      onClick: function(event) {
+        event.preventDefault();
+      }
+    };
+  },
+
+  getInitialState: function() {
+    return {};
+  },
+
+  render: function() {
+    var classes = {};
+    classes[this.props.customClasses.hover || "hover"] = !!this.props.hover;
+    classes[this.props.customClasses.listItem] = !!this.props.customClasses.listItem;
+
+    if (this.props.customValue) {
+      classes[this.props.customClasses.customAdd] = !!this.props.customClasses.customAdd;
+    }
+
+    var classList = classNames(classes);
+
+    return (
+      React.createElement("li", {className: classList, onClick: this._onClick}, 
+        React.createElement("a", {href: "javascript: void 0;", className: this._getClasses(), ref: "anchor"}, 
+           this.props.children
+        )
+      )
+    );
+  },
+
+  _getClasses: function() {
+    var classes = {
+      "typeahead-option": true,
+    };
+    classes[this.props.customClasses.listAnchor] = !!this.props.customClasses.listAnchor;
+
+    return classNames(classes);
+  },
+
+  _onClick: function(event) {
+    event.preventDefault();
+    return this.props.onClick(event);
+  }
+});
+
+
+module.exports = TypeaheadOption;
+
+
+
+},{"classnames":1,"react/addons":"react/addons"}],9:[function(require,module,exports){
+/**
+ * @jsx React.DOM
+ */
+
+var React = window.React || require('react/addons');
+var TypeaheadOption = require('./option');
+var classNames = require('classnames');
+
+/**
+ * Container for the options rendered as part of the autocompletion process
+ * of the typeahead
+ */
+var TypeaheadSelector = React.createClass({displayName: "TypeaheadSelector",
+  propTypes: {
+    options: React.PropTypes.array,
+    customClasses: React.PropTypes.object,
+    customValue: React.PropTypes.string,
+    selectionIndex: React.PropTypes.number,
+    onOptionSelected: React.PropTypes.func
+  },
+
+  getDefaultProps: function() {
+    return {
+      selectionIndex: null,
+      customClasses: {},
+      customValue: null,
+      onOptionSelected: function(option) { }
+    };
+  },
+
+  getInitialState: function() {
+    return {
+      selectionIndex: this.props.selectionIndex,
+      selection: this.getSelectionForIndex(this.props.selectionIndex)
+    };
+  },
+
+  render: function() {
+    var classes = {
+      "typeahead-selector": true
+    };
+    classes[this.props.customClasses.results] = this.props.customClasses.results;
+    var classList = classNames(classes);
+
+    var results = [];
+    // CustomValue should be added to top of results list with different class name
+    if (this.props.customValue !== null) {
+
+      results.push(
+        React.createElement(TypeaheadOption, {ref: this.props.customValue, key: this.props.customValue, 
+          hover: this.state.selectionIndex === results.length, 
+          customClasses: this.props.customClasses, 
+          customValue: this.props.customValue, 
+          onClick: this._onClick.bind(this, this.props.customValue)}, 
+           this.props.customValue
+        ));
+    }
+
+    this.props.options.forEach(function(result, i) {
+      results.push (
+        React.createElement(TypeaheadOption, {ref: result, key: result, 
+          hover: this.state.selectionIndex === results.length, 
+          customClasses: this.props.customClasses, 
+          onClick: this._onClick.bind(this, result)}, 
+           result 
+        )
+      );
+    }, this);
+
+
+    return React.createElement("ul", {className: classList},  results );
+  },
+
+  setSelectionIndex: function(index) {
+    this.setState({
+      selectionIndex: index,
+      selection: this.getSelectionForIndex(index),
+    });
+  },
+
+  getSelectionForIndex: function(index) {
+    if (index === null) {
+      return null;
+    }
+    if (index === 0 && this.props.customValue !== null) {
+      return this.props.customValue;
+    }
+
+    if (this.props.customValue !== null) {
+      index -= 1;
+    }
+
+    return this.props.options[index];
+  },
+
+  _onClick: function(result, event) {
+    return this.props.onOptionSelected(result, event);
+  },
+
+  _nav: function(delta) {
+    if (!this.props.options && this.props.customValue === null) {
+      return;
+    }
+    var newIndex = this.state.selectionIndex === null ? (delta == 1 ? 0 : delta) : this.state.selectionIndex + delta;
+    var length = this.props.options.length;
+    if (this.props.customValue !== null) {
+      length += 1;
+    }
+
+    if (newIndex < 0) {
+      newIndex += length;
+    } else if (newIndex >= length) {
+      newIndex -= length;
+    }
+
+    var newSelection = this.getSelectionForIndex(newIndex);
+    this.setState({selectionIndex: newIndex,
+                   selection: newSelection});
+  },
+
+  navDown: function() {
+    this._nav(1);
+  },
+
+  navUp: function() {
+    this._nav(-1);
+  }
+
+});
+
+module.exports = TypeaheadSelector;
+
+
+
+},{"./option":8,"classnames":1,"react/addons":"react/addons"}]},{},[4])(4)
+});

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.js
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.js
@@ -9,16 +9,14 @@ function loadAsync(url, retryCount, retryLimit) {
 
             if(xmlHttp.status == 200){
                 processResponse(xmlHttp.responseText);
-
             } else {
                 if (retryCount >= retryLimit) {
                     return;
-
                 } else {
-                    loadAsync(url, retryCount++, retryLimit);
+                    retryCount = retryCount + 1;
+                    loadAsync(url, retryCount, retryLimit);
                 }
             }
-
         } else {
             return;
         }            
@@ -49,7 +47,7 @@ function processResponse(response) {
         var id, idElement;
 
         id = getIdFromName(option, orgs);
-        idElement = document.querySelector('#org-filter-input');
+        idElement = document.getElementById('org-filter-input');
 
         idElement.value = id;
     };
@@ -104,7 +102,7 @@ function getIdFromName(name, orgs) {
 function updateIdElement(filter) {
     var idElement, typeaheadPlaceholder;
 
-    idElement = document.querySelector('#org-filter-input');
+    idElement = document.getElementById('org-filter-input');
     idElement.value = filter.id;
 }
 
@@ -140,7 +138,7 @@ function buildReactComponents(placeholder, typeaheadOptions, typeaheadCallback) 
                         {placeholder:placeholder,
                         options:typeaheadOptions,
                         onOptionSelected:typeaheadCallback,
-                        maxVisible:"10",
+                        maxVisible:10,
                         customClasses:{
                           typeahead: "",
                           input: "form-group form-control",

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.js
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.js
@@ -1,0 +1,163 @@
+/** @jsx React.DOM */
+function loadAsync(url, retryCount, retryLimit) {
+    var xmlHttp;
+
+    xmlHttp = new XMLHttpRequest();
+
+    xmlHttp.onreadystatechange = function() {
+        if (xmlHttp.readyState == XMLHttpRequest.DONE) {
+
+            if(xmlHttp.status == 200){
+                processResponse(xmlHttp.responseText);
+
+            } else {
+                if (retryCount >= retryLimit) {
+                    return;
+
+                } else {
+                    loadAsync(url, retryCount++, retryLimit);
+                }
+            }
+
+        } else {
+            return;
+        }            
+    }
+
+    xmlHttp.open("GET", url, true);
+    xmlHttp.send();
+}
+
+function processResponse(response) {
+    var orgs, typeaheadOptions, typeaheadPlaceholder, typeaheadCallback, allEntry, currentFilter;
+
+    orgs = JSON.parse(response);
+    orgs = orgs.results;
+
+    // Add an "All" entry so user can reset filter
+    allEntry = {};
+    allEntry.id = "";
+    allEntry.name = "All";
+    orgs.unshift(allEntry);    
+
+    currentFilter = getCurrentOrgFilter(orgs);
+    updateIdElement(currentFilter);
+
+    typeaheadOptions = getTypeaheadOptions(orgs);    
+    typeaheadPlaceholder = getPlaceholder(currentFilter);
+    typeaheadCallback = function(option) {
+        var id, idElement;
+
+        id = getIdFromName(option, orgs);
+        idElement = document.querySelector('#org-filter-input');
+
+        idElement.value = id;
+    }
+
+    buildReactComponents(typeaheadPlaceholder, typeaheadOptions, typeaheadCallback);
+}
+
+function getTypeaheadOptions(orgs) {
+    var orgNames;
+
+    orgNames = [];
+
+    for (var i = 0; i < orgs.length; i++) {
+        orgNames[i] = orgs[i].name;
+    }
+
+    return orgNames;
+}
+
+function getCurrentOrgFilter(orgs) {
+
+    var currentFilterId, currentFilterName, filter;
+
+    currentFilterId = JSON.parse(document.getElementById("react-typeahead-org").innerHTML).currentOrg;
+    currentFilterName = getNameFromId(currentFilterId, orgs);
+
+    filter = {};
+    filter.id = currentFilterId;
+    filter.name = currentFilterName;
+
+    return filter;
+}
+
+function getNameFromId(id, orgs) {
+    for (var i = 0; i < orgs.length; i++) {
+        if (id.toString().toLowerCase() === orgs[i].id.toString().toLowerCase()) {
+            return orgs[i].name;
+        }
+    }
+    return "All";
+}
+
+function getIdFromName(name, orgs) {
+    for (var i = 0; i < orgs.length; i++) {
+        if (name.toString().toLowerCase() === orgs[i].name.toString().toLowerCase()) {
+            return orgs[i].id;
+        }
+    }
+    return "";
+}
+
+function updateIdElement(filter) {
+    var idElement, typeaheadPlaceholder;
+
+    idElement = document.querySelector('#org-filter-input');
+    idElement.value = filter.id;
+}
+
+function getPlaceholder(filter) {
+    var placeholder;
+
+    placeholder = filter.name;
+
+    return placeholder;
+}
+
+function buildReactComponents(placeholder, typeaheadOptions, typeaheadCallback) {
+    var Typeahead, TypeaheadLabel, TypeaheadContainer;
+
+    Typeahead = ReactTypeahead.Typeahead;
+
+    TypeaheadLabel = React.createClass({displayName: 'TypeaheadLabel',
+        render: function() {
+            return (
+                React.DOM.div(null, 
+                    React.DOM.label( {className:'control-label'}, "organisation")
+                )
+            )
+        }
+    });    
+
+    TypeaheadContainer = React.createClass({displayName: 'TypeaheadContainer',
+        render: function() {
+            return (
+                React.DOM.div(null, 
+                    TypeaheadLabel(null ),
+                    Typeahead(
+                        {placeholder:placeholder,
+                        options:typeaheadOptions,
+                        onOptionSelected: typeaheadCallback,
+                        customClasses:{
+                          typeahead: "",
+                          input: "form-control",
+                          results: "",
+                          listItem: "",
+                          token: "",
+                          customAdd: ""            
+                        },
+                        className:"partnerTest"} )
+                )
+            )
+        }
+    });
+
+    React.render(
+        TypeaheadContainer(null ),
+        document.getElementById('org-filter-container')
+    );
+}
+
+loadAsync('/rest/v1/typeaheads/organisations?format=json', 0, 3);

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.js
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.js
@@ -142,7 +142,7 @@ function buildReactComponents(placeholder, typeaheadOptions, typeaheadCallback) 
                         onOptionSelected: typeaheadCallback,
                         customClasses:{
                           typeahead: "",
-                          input: "form-control",
+                          input: "form-group form-control",
                           results: "",
                           listItem: "",
                           token: "",

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.js
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.js
@@ -139,7 +139,8 @@ function buildReactComponents(placeholder, typeaheadOptions, typeaheadCallback) 
                     Typeahead(
                         {placeholder:placeholder,
                         options:typeaheadOptions,
-                        onOptionSelected: typeaheadCallback,
+                        onOptionSelected:typeaheadCallback,
+                        maxVisible:"10",
                         customClasses:{
                           typeahead: "",
                           input: "form-group form-control",

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.js
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.js
@@ -22,7 +22,7 @@ function loadAsync(url, retryCount, retryLimit) {
         } else {
             return;
         }            
-    }
+    };
 
     xmlHttp.open("GET", url, true);
     xmlHttp.send();
@@ -52,7 +52,7 @@ function processResponse(response) {
         idElement = document.querySelector('#org-filter-input');
 
         idElement.value = id;
-    }
+    };
 
     buildReactComponents(typeaheadPlaceholder, typeaheadOptions, typeaheadCallback);
 }
@@ -127,7 +127,7 @@ function buildReactComponents(placeholder, typeaheadOptions, typeaheadCallback) 
                 React.DOM.div(null, 
                     React.DOM.label( {className:'control-label'}, "organisation")
                 )
-            )
+            );
         }
     });    
 
@@ -151,7 +151,7 @@ function buildReactComponents(placeholder, typeaheadOptions, typeaheadCallback) 
                         },
                         className:"partnerTest"} )
                 )
-            )
+            );
         }
     });
 

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.js
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.js
@@ -1,4 +1,10 @@
 /** @jsx React.DOM */
+
+// Akvo RSR is covered by the GNU Affero General Public License.
+// See more details in the license.txt file located at the root folder of the
+// Akvo RSR module. For additional details on the GNU license please see
+// < http://www.gnu.org/licenses/agpl.html >.
+
 function loadAsync(url, retryCount, retryLimit) {
     var xmlHttp;
 

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.jsx
@@ -138,7 +138,8 @@ function buildReactComponents(placeholder, typeaheadOptions, typeaheadCallback) 
                     <Typeahead
                         placeholder={placeholder}
                         options={typeaheadOptions}
-                        onOptionSelected= {typeaheadCallback}
+                        onOptionSelected={typeaheadCallback}
+                        maxVisible="10"
                         customClasses={{
                           typeahead: "",
                           input: "form-group form-control",

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.jsx
@@ -1,3 +1,10 @@
+/** @jsx React.DOM */
+
+// Akvo RSR is covered by the GNU Affero General Public License.
+// See more details in the license.txt file located at the root folder of the
+// Akvo RSR module. For additional details on the GNU license please see
+// < http://www.gnu.org/licenses/agpl.html >.
+
 function loadAsync(url, retryCount, retryLimit) {
     var xmlHttp;
 

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.jsx
@@ -1,0 +1,162 @@
+function loadAsync(url, retryCount, retryLimit) {
+    var xmlHttp;
+
+    xmlHttp = new XMLHttpRequest();
+
+    xmlHttp.onreadystatechange = function() {
+        if (xmlHttp.readyState == XMLHttpRequest.DONE) {
+
+            if(xmlHttp.status == 200){
+                processResponse(xmlHttp.responseText);
+
+            } else {
+                if (retryCount >= retryLimit) {
+                    return;
+
+                } else {
+                    loadAsync(url, retryCount++, retryLimit);
+                }
+            }
+
+        } else {
+            return;
+        }            
+    }
+
+    xmlHttp.open("GET", url, true);
+    xmlHttp.send();
+}
+
+function processResponse(response) {
+    var orgs, typeaheadOptions, typeaheadPlaceholder, typeaheadCallback, allEntry, currentFilter;
+
+    orgs = JSON.parse(response);
+    orgs = orgs.results;
+
+    // Add an "All" entry so user can reset filter
+    allEntry = {};
+    allEntry.id = "";
+    allEntry.name = "All";
+    orgs.unshift(allEntry);    
+
+    currentFilter = getCurrentOrgFilter(orgs);
+    updateIdElement(currentFilter);
+
+    typeaheadOptions = getTypeaheadOptions(orgs);    
+    typeaheadPlaceholder = getPlaceholder(currentFilter);
+    typeaheadCallback = function(option) {
+        var id, idElement;
+
+        id = getIdFromName(option, orgs);
+        idElement = document.querySelector('#org-filter-input');
+
+        idElement.value = id;
+    }
+
+    buildReactComponents(typeaheadPlaceholder, typeaheadOptions, typeaheadCallback);
+}
+
+function getTypeaheadOptions(orgs) {
+    var orgNames;
+
+    orgNames = [];
+
+    for (var i = 0; i < orgs.length; i++) {
+        orgNames[i] = orgs[i].name;
+    }
+
+    return orgNames;
+}
+
+function getCurrentOrgFilter(orgs) {
+
+    var currentFilterId, currentFilterName, filter;
+
+    currentFilterId = JSON.parse(document.getElementById("react-typeahead-org").innerHTML).currentOrg;
+    currentFilterName = getNameFromId(currentFilterId, orgs);
+
+    filter = {};
+    filter.id = currentFilterId;
+    filter.name = currentFilterName;
+
+    return filter;
+}
+
+function getNameFromId(id, orgs) {
+    for (var i = 0; i < orgs.length; i++) {
+        if (id.toString().toLowerCase() === orgs[i].id.toString().toLowerCase()) {
+            return orgs[i].name;
+        }
+    }
+    return "All";
+}
+
+function getIdFromName(name, orgs) {
+    for (var i = 0; i < orgs.length; i++) {
+        if (name.toString().toLowerCase() === orgs[i].name.toString().toLowerCase()) {
+            return orgs[i].id;
+        }
+    }
+    return "";
+}
+
+function updateIdElement(filter) {
+    var idElement, typeaheadPlaceholder;
+
+    idElement = document.querySelector('#org-filter-input');
+    idElement.value = filter.id;
+}
+
+function getPlaceholder(filter) {
+    var placeholder;
+
+    placeholder = filter.name;
+
+    return placeholder;
+}
+
+function buildReactComponents(placeholder, typeaheadOptions, typeaheadCallback) {
+    var Typeahead, TypeaheadLabel, TypeaheadContainer;
+
+    Typeahead = ReactTypeahead.Typeahead;
+
+    TypeaheadLabel = React.createClass({
+        render: function() {
+            return (
+                <div>
+                    <label className={'control-label'}>organisation</label>
+                </div>
+            )
+        }
+    });    
+
+    TypeaheadContainer = React.createClass({
+        render: function() {
+            return (
+                <div>
+                    <TypeaheadLabel />
+                    <Typeahead
+                        placeholder={placeholder}
+                        options={typeaheadOptions}
+                        onOptionSelected= {typeaheadCallback}
+                        customClasses={{
+                          typeahead: "",
+                          input: "form-control",
+                          results: "",
+                          listItem: "",
+                          token: "",
+                          customAdd: ""            
+                        }}
+                        className="partnerTest" />
+                </div>
+            )
+        }
+    });
+
+    React.render(
+        <TypeaheadContainer />,
+        document.getElementById('org-filter-container')
+    );
+}
+
+loadAsync('/rest/v1/typeaheads/organisations?format=json', 0, 3);

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.jsx
@@ -21,7 +21,7 @@ function loadAsync(url, retryCount, retryLimit) {
         } else {
             return;
         }            
-    }
+    };
 
     xmlHttp.open("GET", url, true);
     xmlHttp.send();
@@ -51,7 +51,7 @@ function processResponse(response) {
         idElement = document.querySelector('#org-filter-input');
 
         idElement.value = id;
-    }
+    };
 
     buildReactComponents(typeaheadPlaceholder, typeaheadOptions, typeaheadCallback);
 }
@@ -126,7 +126,7 @@ function buildReactComponents(placeholder, typeaheadOptions, typeaheadCallback) 
                 <div>
                     <label className={'control-label'}>organisation</label>
                 </div>
-            )
+            );
         }
     });    
 
@@ -150,7 +150,7 @@ function buildReactComponents(placeholder, typeaheadOptions, typeaheadCallback) 
                         }}
                         className="partnerTest" />
                 </div>
-            )
+            );
         }
     });
 

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.jsx
@@ -8,16 +8,14 @@ function loadAsync(url, retryCount, retryLimit) {
 
             if(xmlHttp.status == 200){
                 processResponse(xmlHttp.responseText);
-
             } else {
                 if (retryCount >= retryLimit) {
                     return;
-
                 } else {
-                    loadAsync(url, retryCount++, retryLimit);
+                    retryCount = retryCount + 1;
+                    loadAsync(url, retryCount, retryLimit);
                 }
             }
-
         } else {
             return;
         }            
@@ -48,7 +46,7 @@ function processResponse(response) {
         var id, idElement;
 
         id = getIdFromName(option, orgs);
-        idElement = document.querySelector('#org-filter-input');
+        idElement = document.getElementById('org-filter-input');
 
         idElement.value = id;
     };
@@ -103,7 +101,7 @@ function getIdFromName(name, orgs) {
 function updateIdElement(filter) {
     var idElement, typeaheadPlaceholder;
 
-    idElement = document.querySelector('#org-filter-input');
+    idElement = document.getElementById('org-filter-input');
     idElement.value = filter.id;
 }
 
@@ -139,7 +137,7 @@ function buildReactComponents(placeholder, typeaheadOptions, typeaheadCallback) 
                         placeholder={placeholder}
                         options={typeaheadOptions}
                         onOptionSelected={typeaheadCallback}
-                        maxVisible="10"
+                        maxVisible={10}
                         customClasses={{
                           typeahead: "",
                           input: "form-group form-control",

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.jsx
@@ -141,7 +141,7 @@ function buildReactComponents(placeholder, typeaheadOptions, typeaheadCallback) 
                         onOptionSelected= {typeaheadCallback}
                         customClasses={{
                           typeahead: "",
-                          input: "form-control",
+                          input: "form-group form-control",
                           results: "",
                           listItem: "",
                           token: "",

--- a/akvo/rsr/static/scripts-src/project-directory.js
+++ b/akvo/rsr/static/scripts-src/project-directory.js
@@ -187,6 +187,6 @@ $(document).ready(function() {
   applyFilterButton= document.getElementById('apply-filter');
   applyFilterButton.onclick = function() {
       document.getElementById('filterForm').submit();
-  }
+  };
 
 }());

--- a/akvo/rsr/static/scripts-src/project-directory.js
+++ b/akvo/rsr/static/scripts-src/project-directory.js
@@ -26,11 +26,6 @@ function insertParam(key, value)
 
 $(document).ready(function() {
 
-  // Submit filter form on select change
-  $('#filter select').change(function() {
-    $('#filterForm').submit();
-  });
-
   var projects_text = JSON.parse(document.getElementById("typeahead-header-text").innerHTML).projects_text;
   var organisations_text = JSON.parse(document.getElementById("typeahead-header-text").innerHTML).organisations_text;
   var locations_text = JSON.parse(document.getElementById("typeahead-header-text").innerHTML).locations_text;
@@ -184,3 +179,14 @@ $(document).ready(function() {
   }));
 
 });
+
+(function() {
+
+  var applyFilterButton;
+
+  applyFilterButton= document.getElementById('apply-filter');
+  applyFilterButton.onclick = function() {
+      document.getElementById('filterForm').submit();
+  }
+
+}());

--- a/akvo/rsr/static/styles-src/main.css
+++ b/akvo/rsr/static/styles-src/main.css
@@ -1303,6 +1303,28 @@ div.textBlock {
     .tooltip .tooltip-inner a {
       font-weight: bold; }
 
+/* Project Directory Typeahead Styling */
+#filterForm #org-filter-container ul.typeahead-selector {
+  margin: -15px 0 0 0;
+  padding: 0.25em;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  border-left: 1px solid #ccc;
+  background-color: #fff;
+  list-style: none;
+  -moz-border-radius: 4px;
+  -o-border-radius: 4px;
+  -webkit-border-radius: 4px;
+  border-radius: 4px; }
+  #filterForm #org-filter-container ul.typeahead-selector li {
+    padding-left: 6px;
+    padding-top: 4px;
+    padding-bottom: 4px; }
+    #filterForm #org-filter-container ul.typeahead-selector li:hover, #filterForm #org-filter-container ul.typeahead-selector li.hover {
+      font-weight: bold; }
+    #filterForm #org-filter-container ul.typeahead-selector li a {
+      color: #555555; }
+
 /* Organisation Page */
 .organisationDetail .organisationHeader {
   background: rgba(32, 32, 36, 0.05); }

--- a/akvo/rsr/static/styles-src/main.css
+++ b/akvo/rsr/static/styles-src/main.css
@@ -1321,7 +1321,8 @@ div.textBlock {
     padding-top: 4px;
     padding-bottom: 4px; }
     #filterForm #org-filter-container ul.typeahead-selector li:hover, #filterForm #org-filter-container ul.typeahead-selector li.hover {
-      font-weight: bold; }
+      font-weight: bold;
+      cursor: pointer; }
     #filterForm #org-filter-container ul.typeahead-selector li a {
       color: #555555; }
 

--- a/akvo/rsr/static/styles-src/main.scss
+++ b/akvo/rsr/static/styles-src/main.scss
@@ -1583,6 +1583,34 @@ div.textBlock {
     }
 }
 
+/* Project Directory Typeahead Styling */
+#filterForm {
+    #org-filter-container {
+        ul.typeahead-selector {
+            margin: -15px 0 0 0;            
+            padding: 0.25em;
+            border-right: 1px solid #ccc;
+            border-bottom: 1px solid #ccc;
+            border-left: 1px solid #ccc;
+            background-color: #fff;
+            list-style: none;
+            @include border-radius(4px);
+            li {
+                padding-left: 6px;
+                padding-top: 4px;
+                padding-bottom: 4px;
+                &:hover,
+                &.hover {
+                    font-weight: bold;
+                }
+                a {
+                    color: rgb(85, 85, 85);
+                }
+            }
+        }
+    }
+}
+
 /* Organisation Page */
 .organisationDetail {
     .organisationHeader {

--- a/akvo/rsr/static/styles-src/main.scss
+++ b/akvo/rsr/static/styles-src/main.scss
@@ -1602,6 +1602,7 @@ div.textBlock {
                 &:hover,
                 &.hover {
                     font-weight: bold;
+                    cursor: pointer;
                 }
                 a {
                     color: rgb(85, 85, 85);

--- a/akvo/rsr/views/project.py
+++ b/akvo/rsr/views/project.py
@@ -56,6 +56,7 @@ def _project_directory_coll(request):
 
 def directory(request):
     """The project list view."""
+
     qs = remove_empty_querydict_items(request.GET)
 
     # Set show_filters to "in" if any filter is selected
@@ -78,6 +79,9 @@ def directory(request):
     page = request.GET.get('page')
     page, paginator, page_range = pagination(page, sorted_projects, 10)
 
+    # Get the current org filter for typeahead
+    org_filter = request.GET.get('organisation', '')   
+
     context = {
         'project_count': sorted_projects.count(),
         'filter': f,
@@ -87,6 +91,7 @@ def directory(request):
         'show_filters': show_filters,
         'q': filter_query_string(qs),
         'sorting': sorting,
+        'current_org': org_filter,
     }
     return render(request, 'project_directory.html', context)
 

--- a/akvo/settings/40-pipeline.conf
+++ b/akvo/settings/40-pipeline.conf
@@ -66,6 +66,18 @@ PIPELINE_CSS = {
 }
 
 PIPELINE_JS = {
+    'project_directory_typeahead': {
+        'source_filenames': (
+            'scripts-src/project-directory-typeahead.js',
+        ),
+        'output_filename': 'scripts/project-directory-typeahead.min.js',
+    },
+    'react_typeahead': {
+        'source_filenames': (
+            'lib/scripts/react-typeahead-1.0.4.js',
+        ),
+        'output_filename': 'scripts/react-typeahead.min.js',
+    },
     'rsr': {
         'source_filenames': (
             'scripts-src/rsr.js',

--- a/akvo/templates/base.html
+++ b/akvo/templates/base.html
@@ -78,10 +78,6 @@
     <script src="//code.jquery.com/jquery-1.11.2.min.js"></script>
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.0/js/bootstrap.min.js"></script>
 
-    {# React #}
-    {#<script src="http://fb.me/react-0.13.1.js"></script>#}
-    <script src="//fb.me/react-0.12.0.js"></script>
-
     {% compressed_js 'rsr' %}
     {% compressed_js 'rsr_lib' %}
     <script src="{{ STATIC_URL }}scripts-src/cookie.js"></script>

--- a/akvo/templates/base.html
+++ b/akvo/templates/base.html
@@ -80,7 +80,7 @@
 
     {# React #}
     {#<script src="http://fb.me/react-0.13.1.js"></script>#}
-    <script src="//fb.me/react-0.10.0.js"></script>
+    <script src="//fb.me/react-0.12.0.js"></script>
 
     {% compressed_js 'rsr' %}
     {% compressed_js 'rsr_lib' %}

--- a/akvo/templates/myrsr/my_details.html
+++ b/akvo/templates/myrsr/my_details.html
@@ -4,6 +4,11 @@
 
 {% block title %}{% trans 'MyRSR' %} - {{ user.first_name }} {{ user.last_name }}{% endblock %}
 
+{% block head_js %}
+{# React #}
+<script src="//fb.me/react-0.10.0.js"></script>
+{% endblock head_js %}
+
 {% block head %}
 
 <style>

--- a/akvo/templates/myrsr/user_management.html
+++ b/akvo/templates/myrsr/user_management.html
@@ -4,6 +4,11 @@
 
 {% block title %}{% trans 'MyRSR - My updates' %}{% endblock %}
 
+{% block head_js %}
+{# React #}
+<script src="//fb.me/react-0.10.0.js"></script>
+{% endblock head_js %}
+
 {% block myrsr_main %}
     <h3>{% trans 'User management' %}</h3>
     {% has_perm 'rsr.change_employment' user as can_change_employments %}

--- a/akvo/templates/project_directory.html
+++ b/akvo/templates/project_directory.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 {% load i18n maps rsr_utils thumbnail humanize bootstrap3 compressed %}
 {% block title %}{% trans 'Projects' %}{% endblock %}
+{% block head_js %}
+{# React #}
+<script src="//fb.me/react-0.12.0.js"></script>
+{% endblock head_js %}
 {% block maincontent %}
 
   <section id="map" class="touch-navbar">
@@ -195,7 +199,7 @@
      {
        "currentOrg": "{{ current_org }}"
      }
-    </script>     
+    </script>
 
   {% compressed_js 'project_directory' %}
   {% compressed_js 'project_directory_typeahead' %}

--- a/akvo/templates/project_directory.html
+++ b/akvo/templates/project_directory.html
@@ -42,9 +42,9 @@
                   </div>
                 </div>
             <div>
-                <div class="btn-group">
-                  {% bootstrap_field filter.form.organisation %}
+                <div class="btn-group" id="org-filter-container"> 
                 </div>
+                <input type="hidden" name="organisation" id="org-filter-input" type="text">
             </div>
             <div>
               <div class="btn-group">
@@ -54,6 +54,7 @@
             <div>
               <nav>
                 <ul class="nav nav-pills nav-stacked">
+                  <li><a class="showFilters text-center" id="apply-filter">{% trans 'Apply filter' %}</a></li>
                   <li><a class="showFilters menu-toggle text-center"><i class="fa fa-toggle-off"></i> {% trans 'Close this' %}</a></li>
                 </ul>
               </nav>
@@ -190,7 +191,15 @@
     }
     </script>
 
+    <script type="application/json" id="react-typeahead-org">
+     {
+       "currentOrg": "{{ current_org }}"
+     }
+    </script>     
+
   {% compressed_js 'project_directory' %}
+  {% compressed_js 'project_directory_typeahead' %}
+  {% compressed_js 'react_typeahead' %} 
 {% endblock js %}
 
 {% block jq %}

--- a/akvo/templates/project_main.html
+++ b/akvo/templates/project_main.html
@@ -3,6 +3,8 @@
 {% load rsr_filters %}
 {% block title %}{{project.title}}{% endblock title%}
 {% block head_js %}
+{# React #}
+<script src="//fb.me/react-0.10.0.js"></script>
 <link rel="stylesheet" type="text/css" href="http://cdn.knightlab.com/libs/timeline/latest/css/timeline.css">
 <style>
 </style>

--- a/akvo/templates/sign_in.html
+++ b/akvo/templates/sign_in.html
@@ -4,6 +4,11 @@
 
 {% block title %}{% trans 'Sign in to your Akvo RSR account' %}{% endblock %}
 
+{% block head_js %}
+{# React #}
+<script src="//fb.me/react-0.10.0.js"></script>
+{% endblock head_js %}
+
 {% block maincontent %}
 <div class="container">
     <h2 class="text-center verticalPadding">Sign in</h2>


### PR DESCRIPTION
#1052 

React-typeahead requires a React version of at least 0.12, so this PR bumps the version from 0.10. This might have wider consequences, but I haven't seen any so far.