### PR TITLE
Updated setup_etc_hosts.sh devhelper script

### DIFF
--- a/scripts/devhelpers/setup_etc_hosts.sh
+++ b/scripts/devhelpers/setup_etc_hosts.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-echo "Hello. This script will edit /etc/hosts and therefore requires your administrator password."
-sudo bash -c 'echo "192.168.50.101 rsr.localdev.akvo.org   # localdev_rsr" >> /etc/hosts'
+echo "Hello. This script will edit /etc/hosts and therefore may require your administrator password."
+sudo bash -c 'printf "\n192.168.50.101 rsr.localdev.akvo.org   # Akvo RSR local development\n" >> /etc/hosts'

--- a/scripts/devhelpers/setup_etc_hosts.sh
+++ b/scripts/devhelpers/setup_etc_hosts.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "Hello. This script will edit /etc/hosts and therefore may require your administrator password."
-sudo bash -c 'printf "\n192.168.50.101 rsr.localdev.akvo.org   # Akvo RSR local development\n" >> /etc/hosts'
+sudo bash -c 'printf "\n192.168.50.101 rsr.localdev.akvo.org   # localdev_rsr\n" >> /etc/hosts'


### PR DESCRIPTION
The script now uses printf in place of echo and adds newlines at the
start end end of the Akvo RSR entry. This clearly separates the Akvo
RSR-specific entry from other entries which may be in the user's
/etc/hosts file.