### PR TITLE
[Fixes #1632] Not logging on no cordinates

### DIFF
--- a/akvo/rsr/templatetags/maps.py
+++ b/akvo/rsr/templatetags/maps.py
@@ -52,7 +52,7 @@ def avatar(item, geometry='60x60', quality=99):
             url = get_thumbnail(item.photo, geometry,
                                 crop='center', quality=quality).url
     except Exception, e:
-        logger.warning(e)
+        # logger.warning(e)
         pass
 
     return url
@@ -97,7 +97,7 @@ def coll_map(coll, width='100%', height='100%', dynamic='dynamic'):
                  'pk': str(item.pk),
                  'text': text})
         except Exception, e:
-            logger.warning(e)
+            # logger.warning(e)
             pass
 
     return {
@@ -145,7 +145,7 @@ def get_location(item):
                 'pk': str(item.pk),
                 'text': text}
     except Exception, e:
-        logger.warning(e)
+        # logger.warning(e)
         return []
 
 


### PR DESCRIPTION
Akvo used to do a lot of logging when traversing locations for
lat / longs. This swamped the log file and also was not really
useful since lack of lat / long is ok for those collections.