### PR TITLE
[Fixes #1616] Adds keyword logos to Akvo Pages.

### DIFF
--- a/akvo/rsr/admin.py
+++ b/akvo/rsr/admin.py
@@ -1044,7 +1044,7 @@ class PartnerSiteAdmin(TimestampsAdminDisplayMixin, admin.ModelAdmin):
                                'piwik_id',))),
         (u'Style and content',
             dict(fields=('all_maps', 'about_box', 'about_image', 'custom_css', 'custom_logo',
-                         'custom_favicon',))),
+                         'custom_favicon', 'show_keyword_logos',))),
         (u'Languages and translation', dict(fields=('google_translation',))),
         (u'Social', dict(fields=('twitter_button', 'facebook_button', 'facebook_app_id',))),
         (_(u'Project selection'), {

--- a/akvo/rsr/migrations/0012_partnersite_show_keyword_logos.py
+++ b/akvo/rsr/migrations/0012_partnersite_show_keyword_logos.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rsr', '0011_auto_20150630_0823'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='partnersite',
+            name='show_keyword_logos',
+            field=models.BooleanField(default=False, verbose_name='Show keyword logos on project pages'),
+            preserve_default=True,
+        ),
+    ]

--- a/akvo/rsr/models/partner_site.py
+++ b/akvo/rsr/models/partner_site.py
@@ -90,6 +90,8 @@ class PartnerSite(TimestampsMixin, models.Model):
             u'location bar, on tabs and in the bookmark menu.</p>'
         )
     )
+    show_keyword_logos = models.BooleanField(_(u'Show keyword logos on project pages'),
+                                             default=False)
     about_box = ValidXMLTextField(
         _(u'about box text'), max_length=500, blank=True, help_text=_(
             u'Enter HTML that will make up the top left box of the home page. (500 characters)'

--- a/akvo/templates/partials/project_header.html
+++ b/akvo/templates/partials/project_header.html
@@ -3,7 +3,7 @@
 <header class="projectHeader">
     <div class="container">
         <div class="row">
-            {% if not rsr_page and project.keyword_logos %}
+            {% if not rsr_page and project.keyword_logos or rsr_page and rsr_page.show_keyword_logos and project.keyword_logos %}
             <div class="col-sm-6">
             {% else %}
             <div class="col-sm-8">
@@ -14,7 +14,7 @@
                     <p class="small"><span class="glyphicon glyphicon-globe"></span> {{project.primary_location.country}}, {{project.primary_location.country.continent}} &nbsp; <a href="#" onclick="maptoggle()" class="map-toggle">{% trans 'Show map' %} +</a></p>
                 </div>
             </div>
-            {% if not rsr_page and project.keyword_logos %}
+            {% if not rsr_page and project.keyword_logos or rsr_page and rsr_page.show_keyword_logos and project.keyword_logos %}
             <div class="col-sm-2 shareBlock">
                 {% for keyword in project.keyword_logos|slice:":2" %}
                     {% img keyword 125 60 keyword.label %}


### PR DESCRIPTION
If a project is tagged with a keyword that has a logo and the
'show keyword logos' is enabled on a Akvo Page 2 keyword logos
can be seen on the project main page. This option takes the
keyword logos from normal non Pages RSR to Pages but as opt in.