### PR TITLE
[#1532] Sort indicators periods on period_start

### DIFF
--- a/akvo/rsr/views/project.py
+++ b/akvo/rsr/views/project.py
@@ -129,7 +129,7 @@ def _get_accordion_data(project):
             result_data['title'] = result.title
             indicators_data = []
             for indicator in result.indicators.all():
-                for period in indicator.periods.all():
+                for period in indicator.periods.all().order_by('period_start'):
                     indicator_data = dict()
                     indicator_data['id'] = str(period.pk)
                     indicator_data['title'] = indicator.title


### PR DESCRIPTION
The indicator periods are listed in the order they are entered in the
admin.

Add order_by() call to sort by the IndicatorPeriod.period_start field.