### PR TITLE
[Fixes #1713] Use the meta name='Description' tag

### DIFF
--- a/akvo/templates/base.html
+++ b/akvo/templates/base.html
@@ -10,28 +10,28 @@
     <meta property="og:site_name" content="Akvo RSR"/>
     <meta property="og:url" content="http://{{request.META.HTTP_HOST}}{{request.path}}"/>
     {% if update %}
-    <meta property="og:title" content="{{update.title}} - {{project.title}}"/>
-    <meta property="og:description" content="{{update.text|truncatechars_html:500}}"/>
-    <meta name="Description" content="{{update.text|truncatechars_html:500}}"/>
-    {% if update.photo %}
-    <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{update.photo.url}}"/>
-    {% else %}
-    <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{STATIC_URL}}images/rsrLogo.svg"/>
-    {% endif %}
+      <meta property="og:title" content="{{update.title}} - {{project.title}}"/>
+      <meta property="og:description" content="{{update.text|truncatechars_html:500}}"/>
+      <meta name="Description" content="{{update.text|truncatechars_html:500}}"/>
+      {% if update.photo %}
+        <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{update.photo.url}}"/>
+      {% else %}
+        <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{STATIC_URL}}images/rsrLogo.svg"/>
+      {% endif %}
     {% elif project %}
-    <meta property="og:title" content="{{project.title}}"/>
-    <meta property="og:description" content="{{project.subtitle}}"/>
-    <meta name="Description" content="{{project.subtitle}}"/>
-    {% if project.current_image %}
-    <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{project.current_image.url}}"/>
+      <meta property="og:title" content="{{project.title}}"/>
+      <meta property="og:description" content="{{project.subtitle}}"/>
+      <meta name="Description" content="{{project.subtitle}}"/>
+      {% if project.current_image %}
+        <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{project.current_image.url}}"/>
+      {% else %}
+        <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{STATIC_URL}}images/rsrLogo.svg"/>
+      {% endif %}
     {% else %}
-    <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{STATIC_URL}}images/rsrLogo.svg"/>
-    {% endif %}
-    {% else %}
-    <meta property="og:title" content="Akvo RSR"/>
-    <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{STATIC_URL}}images/rsrLogo.svg"/>
-    <meta property="og:description" content="{% trans 'Akvo Really Simple Reporting is a web and Android-based system that makes it easy for development aid teams to bring complex networks of projects online and instantly share progress with everyone involved and interested.' %}"/>
-    <meta name="Description" content="{% trans 'Akvo Really Simple Reporting is a web and Android-based system that makes it easy for development aid teams to bring complex networks of projects online and instantly share progress with everyone involved and interested.' %}"/>
+      <meta property="og:title" content="Akvo RSR"/>
+      <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{STATIC_URL}}images/rsrLogo.svg"/>
+      <meta property="og:description" content="{% trans 'Akvo Really Simple Reporting is a web and Android-based system that makes it easy for development aid teams to bring complex networks of projects online and instantly share progress with everyone involved and interested.' %}"/>
+      <meta name="Description" content="{% trans 'Akvo Really Simple Reporting is a web and Android-based system that makes it easy for development aid teams to bring complex networks of projects online and instantly share progress with everyone involved and interested.' %}"/>
     {% endif %}
     {% if facebook_app_id %}
     <meta property="fb:app_id" content="{{facebook_app_id}}"/>

--- a/akvo/templates/base.html
+++ b/akvo/templates/base.html
@@ -12,6 +12,7 @@
     {% if update %}
     <meta property="og:title" content="{{update.title}} - {{project.title}}"/>
     <meta property="og:description" content="{{update.text|truncatechars_html:500}}"/>
+    <meta name="Description" content="{{update.text|truncatechars_html:500}}"/>
     {% if update.photo %}
     <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{update.photo.url}}"/>
     {% else %}
@@ -20,6 +21,7 @@
     {% elif project %}
     <meta property="og:title" content="{{project.title}}"/>
     <meta property="og:description" content="{{project.subtitle}}"/>
+    <meta name="Description" content="{{project.subtitle}}"/>
     {% if project.current_image %}
     <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{project.current_image.url}}"/>
     {% else %}
@@ -29,6 +31,7 @@
     <meta property="og:title" content="Akvo RSR"/>
     <meta property="og:image" content="http://{{request.META.HTTP_HOST}}{{STATIC_URL}}images/rsrLogo.svg"/>
     <meta property="og:description" content="{% trans 'Akvo Really Simple Reporting is a web and Android-based system that makes it easy for development aid teams to bring complex networks of projects online and instantly share progress with everyone involved and interested.' %}"/>
+    <meta name="Description" content="{% trans 'Akvo Really Simple Reporting is a web and Android-based system that makes it easy for development aid teams to bring complex networks of projects online and instantly share progress with everyone involved and interested.' %}"/>
     {% endif %}
     {% if facebook_app_id %}
     <meta property="fb:app_id" content="{{facebook_app_id}}"/>


### PR DESCRIPTION
I hope this'll fix the issue.. Can't really test, but as far as I can tell Google doesn't use the ```og:description``` property. I think Facebook does use that though, so I've left it it. But also added the normal ```description``` tag that I believe Google uses.