### PR TITLE
[#1785] Cached API results of local storage

### DIFF
--- a/akvo/rsr/static/scripts-src/myrsr-admin.js
+++ b/akvo/rsr/static/scripts-src/myrsr-admin.js
@@ -973,7 +973,12 @@ function loadAsync(url, retryCount, retryLimit, callback) {
 
         lsData = JSON.stringify(localStorageResponses);
 
-        localStorage.setItem(localStorageName, lsData);
+        try {
+            localStorage.setItem(localStorageName, lsData);
+        } catch (error) {
+            // Not enough space in local storage
+            localStorage.setItem(localStorageName, JSON.stringify({}));
+        }
     }
 }
 

--- a/akvo/rsr/static/scripts-src/myrsr-admin.jsx
+++ b/akvo/rsr/static/scripts-src/myrsr-admin.jsx
@@ -973,7 +973,12 @@ function loadAsync(url, retryCount, retryLimit, callback) {
 
         lsData = JSON.stringify(localStorageResponses);
 
-        localStorage.setItem(localStorageName, lsData);
+        try {
+            localStorage.setItem(localStorageName, lsData);
+        } catch (error) {
+            // Not enough space in local storage
+            localStorage.setItem(localStorageName, JSON.stringify({}));
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1785

Added a try, except clause to make sure that we don't try to store the API results to the local storage if there is not enough space in the local storage.