### PR TITLE
[#1765] test for classList.forEach before using

### DIFF
--- a/akvo/rsr/static/scripts-src/myrsr-admin.js
+++ b/akvo/rsr/static/scripts-src/myrsr-admin.js
@@ -2060,7 +2060,7 @@ function setUnsavedChangesMessage() {
 /* General Helper Functions */
 
 function elHasClass(el, className) {
-    if (el.classList) {
+    if (el.classList && el.classList.forEach) {
         var result = false;
         el.classList.forEach( function(entry) {
             if (entry.toString() === className.toString()) {

--- a/akvo/rsr/static/scripts-src/myrsr-admin.jsx
+++ b/akvo/rsr/static/scripts-src/myrsr-admin.jsx
@@ -2060,7 +2060,7 @@ function setUnsavedChangesMessage() {
 /* General Helper Functions */
 
 function elHasClass(el, className) {
-    if (el.classList) {
+    if (el.classList && el.classList.forEach) {
         var result = false;
         el.classList.forEach( function(entry) {
             if (entry.toString() === className.toString()) {


### PR DESCRIPTION
Safari throws an error when using the new elHasClass helper function.

Test if classList.forEach is defined - if not, default back to using the regex to test for class presence.

#1765 