### PR TITLE
[#1790] Check element exists before invoking React

### DIFF
--- a/akvo/rsr/static/scripts-src/my-iati.js
+++ b/akvo/rsr/static/scripts-src/my-iati.js
@@ -116,4 +116,6 @@ function loadComponent(component_id) {
 }
 
 i18n = JSON.parse(document.getElementById("perform-checks-text").innerHTML);
-loadComponent('react_iati_checks');
+if (document.getElementById('react_iati_checks')) {
+    loadComponent('react_iati_checks');
+}

--- a/akvo/rsr/static/scripts-src/my-iati.jsx
+++ b/akvo/rsr/static/scripts-src/my-iati.jsx
@@ -116,4 +116,6 @@ function loadComponent(component_id) {
 }
 
 i18n = JSON.parse(document.getElementById("perform-checks-text").innerHTML);
-loadComponent('react_iati_checks');
+if (document.getElementById('react_iati_checks')) {
+    loadComponent('react_iati_checks');
+}


### PR DESCRIPTION
#1790 

The target container for the React components only appears in the MyIATA page if certain template conditions are met. This PR checks for the existence of the target DOM element before attempting to invoke React.