### PR TITLE
[#1900] Slight change in primary project partner

### DIFF
--- a/akvo/rsr/templatetags/rsr_utils.py
+++ b/akvo/rsr/templatetags/rsr_utils.py
@@ -42,6 +42,8 @@ def img(context, obj, width, height, alt):
 
     return {"default_img": default_img,
             "geometry": geometry,
+            "height": height,
+            "width": width,
             "img": img,
             "alt": alt}
 

--- a/akvo/templates/project_directory.html
+++ b/akvo/templates/project_directory.html
@@ -101,8 +101,8 @@
             {% endif %}
             {% if project.primary_organisation %}
               <a href="{% url 'organisation-main' project.primary_organisation.pk %}">{{project.primary_organisation}}</a>
+              {% more_link project %}
             {% endif %}
-            {% more_link project %}
             <div class="visible-xs-block hidden-sm">
               <p>
               {% if project.sector_categories %}

--- a/akvo/templates/project_main_tabs/summary.html
+++ b/akvo/templates/project_main_tabs/summary.html
@@ -92,10 +92,6 @@
                   </div>
                 </li>
                 {% endif %}
-                <li class="financeBlock">
-                  <span class="detailedInfo">{% trans "financial info" %}</span>
-                  <a href="#finance" class="text-center tab-link"><i class="fa fa-line-chart"></i>{% trans 'See all financial info' %}</a>
-                </li>
                 {% if project.accepts_donations %}
                   <li class="donateSection text-center topMargin">
                     <dl class="dl-horizontal">

--- a/akvo/templates/rsr_utils/img.html
+++ b/akvo/templates/rsr_utils/img.html
@@ -6,6 +6,6 @@
     {% endthumbnail %}
 {% else %}
   {% with url=default_img %}
-    <img src="{{url}}" alt="{{alt}}" />
+    <img src="{{url}}" alt="{{alt}}" style="max-width: {{width}}px; max-height: {{height}}px;" />
   {% endwith %}
 {% endif %}


### PR DESCRIPTION
Fixes #1900: 
- Added the first 'can_create_projects' partner as the primary partner. I guess this will hold in almost all cases.

In addition, did two small changes as well..
- Removed the financial info part from the project main page (as there's a tab for that now).
- Set the geometry for the logo of partners without a logo correct on the finance page.