### PR TITLE
[#1932] Fix migration 0040

### DIFF
--- a/akvo/rsr/migrations/0040_auto_20151111_1300.py
+++ b/akvo/rsr/migrations/0040_auto_20151111_1300.py
@@ -7,9 +7,30 @@ from django.db import models, migrations
 from ..models.project import Project
 
 def add_primary_organisations(apps, schema_editor):
+    Project = apps.get_model("rsr", "Project")
 
     for project in Project.objects.all():
-        project.primary_organisation = project.find_primary_organisation()
+        primary_organisation = None
+
+        # Pick the partner that can publish the project first
+        if project.partners.filter(can_create_projects=True):
+            primary_organisation = project.partners.filter(can_create_projects=True)[0]
+
+        # Otherwise, if we have a reporting-org then we choose that
+        elif project.partnerships.filter(iati_organisation_role=101):
+            primary_organisation = project.partnerships.filter(
+                iati_organisation_role=101)[0].organisation
+
+        # Otherwise, grab the first accountable partner we find
+        elif project.partnerships.filter(iati_organisation_role=2):
+            primary_organisation = project.partnerships.filter(
+                iati_organisation_role=2)[0].organisation
+
+        # Panic mode: grab the first partner we find
+        elif project.partners.all():
+            primary_organisation = project.partners.all()[0]
+
+        project.primary_organisation = primary_organisation
         project.save(update_fields=['primary_organisation'])
 
 


### PR DESCRIPTION
Fixes #1932

Revert the migration code to not using the "real" Project model.