### PR TITLE
[#2100] Fix maps widget bug

### DIFF
--- a/akvo/templates/inclusion_tags/maps.html
+++ b/akvo/templates/inclusion_tags/maps.html
@@ -54,7 +54,7 @@
                         infowindow = new google.maps.InfoWindow({
                             content: window['contentString' + i]
                         });
-                        infowindows.push(infowindow);
+                        infoWindows.push(infowindow);
                         infoWindows.forEach(function(entry) {
 
                             // Close any existing windows


### PR DESCRIPTION
A lower case "w" trashes the js when clicking on pins. Fix by using upper case.