### PR TITLE
[#2095] Generic API filter

### DIFF
--- a/akvo/rest/filters.py
+++ b/akvo/rest/filters.py
@@ -4,6 +4,7 @@
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
+import ast
 from rest_framework import filters
 
 
@@ -12,32 +13,47 @@ class RSRGenericFilterBackend(filters.BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
         """
         Return a queryset possibly filtered by query param values.
-        The filter looks for the query param key filter and then filter2, filter3... up to filter24
-        For each of these query param keys it uses the value to construct a filter for the
-        queryset using the full Django queryset field lookups.
-        This is done by splitting the value on = and assigning the bits to the key and value of a
-        dict used as kwarg to filter()
+        The filter looks for the query param keys filter and exclude
+        For each of these query param the value is evaluated using ast.literal_eval() and used as
+        kwargs in queryset.filter and queryset.exclude respectively.
 
-        Example URL:
-            http://rsr.akvo.org/rest/v1/project/?filter=title__icontains=water&filter2=currency=EUR
+        Example URLs:
+            http://rsr.akvo.org/rest/v1/project/?filter={'title__icontains':'water','currency':'EUR'}
+            http://rsr.akvo.org/rest/v1/project/?filter={'title__icontains':'water'}&exclude={'currency':'EUR'}
 
-        TODO: this is a tech demo, there are a bunch of things that need addressing if we're to use
-        this, like supporting __in=[1 2 3], adding params so you can set select_related and
-        prefetch_related on models used in the filters and probably more.
+        It's also possible to specify models to be included in select_related() and
+        prefetch_related() calls on the queryset, but specifying these in lists of strings as the
+        values for the query sting params select_relates and prefetch_related.
+
+        Example:
+            http://rsr.akvo.org/rest/v1/project/?filter={'partners__in':[42,43]}&prefetch_related=['partners']
         """
-        def param_to_kwarg(param):
-            "split a string on = and return the bits as key and value of a dict"
-            bits = param.split('=')
-            return {bits[0]: bits[1]}
+        filter = request.QUERY_PARAMS.get('filter', None)
+        try:
+            filter_kwargs = ast.literal_eval(filter)
+            queryset = queryset.filter(**filter_kwargs)
+        except ValueError:
+            pass
 
-        params = request.QUERY_PARAMS
+        exclude = request.QUERY_PARAMS.get('exclude', None)
+        try:
+            exclude_kwargs = ast.literal_eval(exclude)
+            queryset = queryset.exclude(**exclude_kwargs)
+        except ValueError:
+            pass
 
-        if params.get('filter', False):
-            for i in [''] + range(2, 25):
-                key = 'filter{}'.format(i)
-                if params.get(key, False):
-                    queryset = queryset.filter(**param_to_kwarg(params[key]))
-                else:
-                    break
+        select_related = request.QUERY_PARAMS.get('select_related', None)
+        try:
+            select_related_args = ast.literal_eval(select_related)
+            queryset = queryset.select_related(*select_related_args)
+        except ValueError:
+            pass
 
-            return queryset
+        prefetch_related = request.QUERY_PARAMS.get('prefetch_related', None)
+        try:
+            prefetch_related_args = ast.literal_eval(prefetch_related)
+            queryset = queryset.prefetch_related(*prefetch_related_args)
+        except ValueError:
+            pass
+
+        return queryset

--- a/akvo/rest/filters.py
+++ b/akvo/rest/filters.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+from rest_framework import filters
+
+
+class RSRGenericFilterBackend(filters.BaseFilterBackend):
+
+    def filter_queryset(self, request, queryset, view):
+        """
+        Return a queryset possibly filtered by query param values.
+        The filter looks for the query param key filter and then filter2, filter3... up to filter24
+        For each of these query param keys it uses the value to construct a filter for the
+        queryset using the full Django queryset field lookups.
+        This is done by splitting the value on = and assigning the bits to the key and value of a
+        dict used as kwarg to filter()
+
+        Example URL:
+            http://rsr.akvo.org/rest/v1/project/?filter=title__icontains=water&filter2=currency=EUR
+
+        TODO: this is a tech demo, there are a bunch of things that need addressing if we're to use
+        this, like supporting __in=[1 2 3], adding params so you can set select_related and
+        prefetch_related on models used in the filters and probably more.
+        """
+        def param_to_kwarg(param):
+            "split a string on = and return the bits as key and value of a dict"
+            bits = param.split('=')
+            return {bits[0]: bits[1]}
+
+        params = request.QUERY_PARAMS
+
+        if params.get('filter', False):
+            for i in [''] + range(2, 25):
+                key = 'filter{}'.format(i)
+                if params.get(key, False):
+                    queryset = queryset.filter(**param_to_kwarg(params[key]))
+                else:
+                    break
+
+            return queryset

--- a/akvo/rest/views/benchmark.py
+++ b/akvo/rest/views/benchmark.py
@@ -16,4 +16,3 @@ class BenchmarkViewSet(PublicProjectViewSet):
     """
     queryset = Benchmark.objects.all()
     serializer_class = BenchmarkSerializer
-    filter_fields = ('project', )

--- a/akvo/rest/views/budget_item.py
+++ b/akvo/rest/views/budget_item.py
@@ -16,7 +16,6 @@ class BudgetItemViewSet(PublicProjectViewSet):
     """
     queryset = BudgetItem.objects.all()
     serializer_class = BudgetItemSerializer
-    filter_fields = ('project', 'label', 'type', )
 
 
 class CountryBudgetItemViewSet(PublicProjectViewSet):
@@ -24,4 +23,4 @@ class CountryBudgetItemViewSet(PublicProjectViewSet):
     """
     queryset = CountryBudgetItem.objects.all()
     serializer_class = CountryBudgetItemSerializer
-    filter_fields = ('project', 'code', )
+

--- a/akvo/rest/views/country.py
+++ b/akvo/rest/views/country.py
@@ -17,5 +17,3 @@ class CountryViewSet(BaseRSRViewSet):
     """
     queryset = Country.objects.all()
     serializer_class = CountrySerializer
-    filter_backends = (filters.DjangoFilterBackend, )
-    filter_fields = ('name', )

--- a/akvo/rest/views/crs_add.py
+++ b/akvo/rest/views/crs_add.py
@@ -16,7 +16,6 @@ class CrsAddViewSet(PublicProjectViewSet):
     """
     queryset = CrsAdd.objects.all()
     serializer_class = CrsAddSerializer
-    filter_fields = ('project', )
 
 
 class CrsAddOtherFlagViewSet(PublicProjectViewSet):
@@ -24,5 +23,4 @@ class CrsAddOtherFlagViewSet(PublicProjectViewSet):
     """
     queryset = CrsAddOtherFlag.objects.all()
     serializer_class = CrsAddOtherFlagSerializer
-    filter_fields = ('crs__project', 'crs', 'code', )
     project_relation = 'crs__project__'

--- a/akvo/rest/views/custom_field.py
+++ b/akvo/rest/views/custom_field.py
@@ -16,7 +16,6 @@ class OrganisationCustomFieldViewSet(BaseRSRViewSet):
     """
     queryset = OrganisationCustomField.objects.all()
     serializer_class = OrganisationCustomFieldSerializer
-    filter_fields = ('organisation', 'name', 'max_characters', 'section', )
 
 
 class ProjectCustomFieldViewSet(PublicProjectViewSet):
@@ -24,4 +23,3 @@ class ProjectCustomFieldViewSet(PublicProjectViewSet):
     """
     queryset = ProjectCustomField.objects.all()
     serializer_class = ProjectCustomFieldSerializer
-    filter_fields = ('project', 'name', 'max_characters', 'section', )

--- a/akvo/rest/views/employment.py
+++ b/akvo/rest/views/employment.py
@@ -21,7 +21,6 @@ class EmploymentViewSet(BaseRSRViewSet):
 
     queryset = Employment.objects.select_related('organisation')
     serializer_class = EmploymentSerializer
-    filter_fields = ('user', 'organisation', 'group', 'is_approved', )
 
 
 @api_view(['POST'])

--- a/akvo/rest/views/fss.py
+++ b/akvo/rest/views/fss.py
@@ -16,7 +16,6 @@ class FssViewSet(PublicProjectViewSet):
     """
     queryset = Fss.objects.all()
     serializer_class = FssSerializer
-    filter_fields = ('project', )
 
 
 class FssForecastViewSet(PublicProjectViewSet):
@@ -24,5 +23,4 @@ class FssForecastViewSet(PublicProjectViewSet):
     """
     queryset = FssForecast.objects.all()
     serializer_class = FssForecastSerializer
-    filter_fields = ('fss__project', 'fss', )
     project_relation = 'fss__project__'

--- a/akvo/rest/views/goal.py
+++ b/akvo/rest/views/goal.py
@@ -16,4 +16,3 @@ class GoalViewSet(PublicProjectViewSet):
     """
     queryset = Goal.objects.all()
     serializer_class = GoalSerializer
-    filter_fields = ('project', )

--- a/akvo/rest/views/humanitarian_scope.py
+++ b/akvo/rest/views/humanitarian_scope.py
@@ -16,4 +16,3 @@ class HumanitarianScopeViewSet(PublicProjectViewSet):
     """
     queryset = HumanitarianScope.objects.all()
     serializer_class = HumanitarianScopeSerializer
-    filter_fields = ('project', 'code', 'type', 'vocabulary', )

--- a/akvo/rest/views/iati_check.py
+++ b/akvo/rest/views/iati_check.py
@@ -15,4 +15,3 @@ class IatiCheckViewSet(BaseRSRViewSet):
     """
     queryset = IatiCheck.objects.all()
     serializer_class = IatiCheckSerializer
-    filter_fields = ('project', 'status')

--- a/akvo/rest/views/iati_export.py
+++ b/akvo/rest/views/iati_export.py
@@ -15,7 +15,6 @@ class IatiExportViewSet(BaseRSRViewSet):
     """
     queryset = IatiExport.objects.all()
     serializer_class = IatiExportSerializer
-    filter_fields = ('reporting_organisation', 'user', 'version', 'status', 'is_public')
 
 
 class IatiActivityExportViewSet(BaseRSRViewSet):
@@ -23,4 +22,3 @@ class IatiActivityExportViewSet(BaseRSRViewSet):
     """
     queryset = IatiActivityExport.objects.all()
     serializer_class = IatiActivityExportSerializer
-    filter_fields = ('iati_export', 'project', 'status')

--- a/akvo/rest/views/indicator.py
+++ b/akvo/rest/views/indicator.py
@@ -14,14 +14,6 @@ class IndicatorViewSet(PublicProjectViewSet):
     """
     queryset = Indicator.objects.all()
     serializer_class = IndicatorSerializer
-    filter_fields = {
-        'result': ['exact'],
-        'result__project': ['exact'],
-        'measure': ['exact'],
-        'ascending': ['exact'],
-        'baseline_year': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'baseline_value': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-    }
     project_relation = 'result__project__'
 
 
@@ -30,12 +22,4 @@ class IndicatorFrameworkViewSet(PublicProjectViewSet):
     """
     queryset = Indicator.objects.all()
     serializer_class = IndicatorFrameworkSerializer
-    filter_fields = {
-        'result': ['exact'],
-        'result__project': ['exact'],
-        'measure': ['exact'],
-        'ascending': ['exact'],
-        'baseline_year': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'baseline_value': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-    }
     project_relation = 'result__project__'

--- a/akvo/rest/views/indicator_period.py
+++ b/akvo/rest/views/indicator_period.py
@@ -16,16 +16,6 @@ class IndicatorPeriodViewSet(PublicProjectViewSet):
     """
     queryset = IndicatorPeriod.objects.all()
     serializer_class = IndicatorPeriodSerializer
-    filter_fields = {
-        'indicator': ['exact'],
-        'indicator__result': ['exact'],
-        'indicator__result__project': ['exact'],
-        'locked': ['exact'],
-        'period_start': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'period_end': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'target_value': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'actual_value': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-    }
     project_relation = 'indicator__result__project__'
 
 
@@ -34,14 +24,4 @@ class IndicatorPeriodFrameworkViewSet(PublicProjectViewSet):
     """
     queryset = IndicatorPeriod.objects.all()
     serializer_class = IndicatorPeriodFrameworkSerializer
-    filter_fields = {
-        'indicator': ['exact'],
-        'indicator__result': ['exact'],
-        'indicator__result__project': ['exact'],
-        'locked': ['exact'],
-        'period_start': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'period_end': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'target_value': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'actual_value': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-    }
     project_relation = 'indicator__result__project__'

--- a/akvo/rest/views/indicator_period_data.py
+++ b/akvo/rest/views/indicator_period_data.py
@@ -23,20 +23,6 @@ class IndicatorPeriodDataViewSet(PublicProjectViewSet):
     """
     queryset = IndicatorPeriodData.objects.all()
     serializer_class = IndicatorPeriodDataSerializer
-    filter_fields = {
-        'period': ['exact'],
-        'period__indicator': ['exact'],
-        'period__indicator__result': ['exact'],
-        'period__indicator__result__project': ['exact'],
-        'user': ['exact'],
-        'status': ['exact'],
-        'created_at': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'last_modified_at': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'relative_data': ['exact'],
-        'data': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'period_actual_value': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'update_method': ['exact']
-    }
 
     project_relation = 'period__indicator__result__project__'
 
@@ -46,20 +32,6 @@ class IndicatorPeriodDataFrameworkViewSet(PublicProjectViewSet):
     """
     queryset = IndicatorPeriodData.objects.all()
     serializer_class = IndicatorPeriodDataFrameworkSerializer
-    filter_fields = {
-        'period': ['exact'],
-        'period__indicator': ['exact'],
-        'period__indicator__result': ['exact'],
-        'period__indicator__result__project': ['exact'],
-        'user': ['exact'],
-        'status': ['exact'],
-        'created_at': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'last_modified_at': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'relative_data': ['exact'],
-        'data': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'period_actual_value': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'update_method': ['exact']
-    }
     project_relation = 'period__indicator__result__project__'
 
 
@@ -68,16 +40,6 @@ class IndicatorPeriodDataCommentViewSet(PublicProjectViewSet):
     """
     queryset = IndicatorPeriodDataComment.objects.all()
     serializer_class = IndicatorPeriodDataCommentSerializer
-    filter_fields = {
-        'data': ['exact'],
-        'data__period': ['exact'],
-        'data__period__indicator': ['exact'],
-        'data__period__indicator__result': ['exact'],
-        'data__period__indicator__result__project': ['exact'],
-        'user': ['exact'],
-        'created_at': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'last_modified_at': ['exact', 'gt', 'gte', 'lt', 'lte', ]
-    }
     project_relation = 'data__period__indicator__result__project__'
 
 

--- a/akvo/rest/views/indicator_period_dimension.py
+++ b/akvo/rest/views/indicator_period_dimension.py
@@ -17,7 +17,6 @@ class IndicatorPeriodActualDimensionViewSet(PublicProjectViewSet):
     """
     queryset = IndicatorPeriodActualDimension.objects.all()
     serializer_class = IndicatorPeriodActualDimensionSerializer
-    filter_fields = ('period', 'period__indicator__result__project', )
     project_relation = 'period__indicator__result__project__'
 
 
@@ -26,5 +25,4 @@ class IndicatorPeriodTargetDimensionViewSet(PublicProjectViewSet):
     """
     queryset = IndicatorPeriodTargetDimension.objects.all()
     serializer_class = IndicatorPeriodTargetDimensionSerializer
-    filter_fields = ('period', 'period__indicator__result__project', )
     project_relation = 'period__indicator__result__project__'

--- a/akvo/rest/views/indicator_period_location.py
+++ b/akvo/rest/views/indicator_period_location.py
@@ -17,7 +17,6 @@ class IndicatorPeriodActualLocationViewSet(PublicProjectViewSet):
     """
     queryset = IndicatorPeriodActualLocation.objects.all()
     serializer_class = IndicatorPeriodActualLocationSerializer
-    filter_fields = ('period', 'period__indicator__result__project')
     project_relation = 'period__indicator__result__project__'
 
 
@@ -26,5 +25,4 @@ class IndicatorPeriodTargetLocationViewSet(PublicProjectViewSet):
     """
     queryset = IndicatorPeriodTargetLocation.objects.all()
     serializer_class = IndicatorPeriodTargetLocationSerializer
-    filter_fields = ('period', 'period__indicator__result__project')
     project_relation = 'period__indicator__result__project__'

--- a/akvo/rest/views/indicator_reference.py
+++ b/akvo/rest/views/indicator_reference.py
@@ -16,10 +16,4 @@ class IndicatorReferenceViewSet(PublicProjectViewSet):
     """
     queryset = IndicatorReference.objects.all()
     serializer_class = IndicatorReferenceSerializer
-    filter_fields = {
-        'indicator': ['exact'],
-        'indicator__result': ['exact'],
-        'indicator__result__project': ['exact'],
-        'vocabulary': ['exact'],
-    }
     project_relation = 'indicator__result__project__'

--- a/akvo/rest/views/internal_organisation_id.py
+++ b/akvo/rest/views/internal_organisation_id.py
@@ -17,4 +17,3 @@ class InternalOrganisationIDViewSet(BaseRSRViewSet):
     """
     serializer_class = InternalOrganisationIDSerializer
     queryset = InternalOrganisationID.objects.all()
-    filter_fields = ('recording_org', 'referenced_org', 'identifier', )

--- a/akvo/rest/views/invoice.py
+++ b/akvo/rest/views/invoice.py
@@ -16,4 +16,3 @@ class InvoiceViewSet(PublicProjectViewSet):
 
     queryset = Invoice.objects.all()
     serializer_class = InvoiceSerializer
-    filter_fields = ('project', )

--- a/akvo/rest/views/legacy_data.py
+++ b/akvo/rest/views/legacy_data.py
@@ -16,4 +16,3 @@ class LegacyDataViewSet(PublicProjectViewSet):
     """
     queryset = LegacyData.objects.all()
     serializer_class = LegacyDataSerializer
-    filter_fields = ('project', )

--- a/akvo/rest/views/organisation.py
+++ b/akvo/rest/views/organisation.py
@@ -70,4 +70,3 @@ class OrganisationViewSet(BaseRSRViewSet):
     queryset = Organisation.objects.all()
     serializer_class = OrganisationSerializer
     parser_classes = (AkvoOrganisationParser, JSONParser,)
-    filter_fields = ('name', 'long_name', 'iati_org_id', 'content_owner')

--- a/akvo/rest/views/organisation_location.py
+++ b/akvo/rest/views/organisation_location.py
@@ -27,7 +27,6 @@ class MapOrganisationLocationViewSet(BaseRSRViewSet):
     __country__ (filter on country ID)
     """
 
-    filter_fields = ('location_target', 'country')
     max_paginate_by = 500
     paginate_by = 100
     queryset = OrganisationLocation.objects.select_related(

--- a/akvo/rest/views/partner_site.py
+++ b/akvo/rest/views/partner_site.py
@@ -16,4 +16,3 @@ class PartnerSiteViewSet(BaseRSRViewSet):
     """
     queryset = PartnerSite.objects.all()
     serializer_class = PartnerSiteSerializer
-    filter_fields = ('organisation', )

--- a/akvo/rest/views/partnership.py
+++ b/akvo/rest/views/partnership.py
@@ -16,7 +16,6 @@ class PartnershipViewSet(PublicProjectViewSet):
     """
     queryset = Partnership.objects.all()
     serializer_class = PartnershipSerializer
-    filter_fields = ('project', 'organisation', 'iati_organisation_role', )
 
     def get_queryset(self):
         """Allow filtering on partner_type."""
@@ -35,4 +34,3 @@ class PartnershipMoreLinkViewSet(PublicProjectViewSet):
     """
     queryset = Partnership.objects.all()
     serializer_class = PartnershipBasicSerializer
-    filter_fields = ('project', 'organisation', 'iati_organisation_role', )

--- a/akvo/rest/views/planned_disbursement.py
+++ b/akvo/rest/views/planned_disbursement.py
@@ -16,4 +16,3 @@ class PlannedDisbursementViewSet(PublicProjectViewSet):
     """
     queryset = PlannedDisbursement.objects.all()
     serializer_class = PlannedDisbursementSerializer
-    filter_fields = ('project', 'currency', 'type', )

--- a/akvo/rest/views/policy_marker.py
+++ b/akvo/rest/views/policy_marker.py
@@ -16,4 +16,3 @@ class PolicyMarkerViewSet(PublicProjectViewSet):
     """
     queryset = PolicyMarker.objects.all()
     serializer_class = PolicyMarkerSerializer
-    filter_fields = ('project', 'policy_marker', )

--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -16,36 +16,6 @@ class ProjectViewSet(PublicProjectViewSet):
 
     """
     Viewset providing Project data.
-
-    Allowed parameters are:
-    __limit__ (default 30, max 100),
-    __title__ (exact or icontains),
-    __subtitle__ (exact or icontains),
-    __status__,
-    __language__,
-    __currency__,
-    __date_start_planned__ (exact, gt, gte, lt or lte),
-    __date_start_actual__ (exact, gt, gte, lt or lte),
-    __date_end_planned__ (exact, gt, gte, lt or lte),
-    __date_end_actual__ (exact, gt, gte, lt or lte),
-    __created_at__ (exact, gt, gte, lt or lte),
-    __last_modified_at__ (exact, gt, gte, lt or lte),
-    __sync_owner__,
-    __iati_activity_id__ (exact or icontains),
-    __hierarchy__,
-    __project_scope__,
-    __collaboration_type__,
-    __default_aid_type__,
-    __default_finance_type__,
-    __default_flow_type__,
-    __default_tied_status__,
-    __budget__ (exact, gt, gte, lt or lte),
-    __funds__ (exact, gt, gte, lt or lte),
-    __funds_needed__ (exact, gt, gte, lt or lte),
-    __categories__ (exact, in),
-    __partners__ (exact, in),
-    __keywords__ (exact, in), and
-    __publishingstatus\__status__.
     """
     queryset = Project.objects.select_related(
         'categories',
@@ -55,36 +25,6 @@ class ProjectViewSet(PublicProjectViewSet):
         'publishingstatus',
     )
     serializer_class = ProjectSerializer
-    filter_fields = {
-        'id': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'title': ['exact', 'icontains'],
-        'subtitle': ['exact', 'icontains'],
-        'status': ['exact', ],
-        'language': ['exact', ],
-        'currency': ['exact', ],
-        'date_start_planned': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'date_start_actual': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'date_end_planned': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'date_end_actual': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'created_at': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'last_modified_at': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'iati_activity_id': ['exact', 'icontains', ],
-        'hierarchy': ['exact', ],
-        'project_scope': ['exact', ],
-        'collaboration_type': ['exact', ],
-        'default_aid_type': ['exact', ],
-        'default_finance_type': ['exact', ],
-        'default_flow_type': ['exact', ],
-        'default_tied_status': ['exact', ],
-        'budget': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'funds': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'funds_needed': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        'categories': ['exact', 'in', ],
-        'partners': ['exact', 'in', ],
-        'keywords': ['exact', 'in', ],
-        'publishingstatus__status': ['exact', ],
-    }
-
     project_relation = ''
 
     def get_queryset(self):
@@ -156,7 +96,6 @@ class ProjectExtraViewSet(ProjectViewSet):
     )
     serializer_class = ProjectExtraSerializer
     paginate_by_param = 'limit'
-    filter_fields = ('partnerships__organisation', 'publishingstatus__status')
 
 
 class ProjectUpViewSet(ProjectViewSet):
@@ -182,4 +121,3 @@ class ProjectUpViewSet(ProjectViewSet):
     serializer_class = ProjectUpSerializer
     paginate_by_param = 'limit'
     max_paginate_by = 100
-    filter_fields = ('partnerships__organisation', 'publishingstatus__status')

--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -53,7 +53,6 @@ class ProjectViewSet(PublicProjectViewSet):
     ).prefetch_related(
         'publishingstatus',
     )
-    filter_backends = (RSRGenericFilterBackend,)
     serializer_class = ProjectSerializer
     filter_fields = {
         'id': ['exact', 'gt', 'gte', 'lt', 'lte', ],

--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -5,9 +5,9 @@ See more details in the license.txt file located at the root folder of the Akvo 
 For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 """
 
-from akvo.rest.serializers.project import ProjectUpSerializer
 from akvo.rsr.models import Project
-from ..serializers import ProjectSerializer, ProjectExtraSerializer
+from ..filters import RSRGenericFilterBackend
+from ..serializers import ProjectSerializer, ProjectExtraSerializer, ProjectUpSerializer
 from ..viewsets import BaseRSRViewSet, PublicProjectViewSet
 
 
@@ -53,7 +53,7 @@ class ProjectViewSet(PublicProjectViewSet):
     ).prefetch_related(
         'publishingstatus',
     )
-
+    filter_backends = (RSRGenericFilterBackend,)
     serializer_class = ProjectSerializer
     filter_fields = {
         'id': ['exact', 'gt', 'gte', 'lt', 'lte', ],
@@ -92,6 +92,7 @@ class ProjectViewSet(PublicProjectViewSet):
         Allow custom filter for sync_owner, since this field has been replaced by the
         reporting org partnership.
         """
+
         sync_owner = self.request.QUERY_PARAMS.get('sync_owner', None)
         if sync_owner:
             self.queryset = self.queryset.filter(

--- a/akvo/rest/views/project_comment.py
+++ b/akvo/rest/views/project_comment.py
@@ -16,4 +16,3 @@ class ProjectCommentViewSet(PublicProjectViewSet):
     """
     queryset = ProjectComment.objects.all()
     serializer_class = ProjectCommentSerializer
-    filter_fields = ('project', 'user', )

--- a/akvo/rest/views/project_condition.py
+++ b/akvo/rest/views/project_condition.py
@@ -16,4 +16,3 @@ class ProjectConditionViewSet(PublicProjectViewSet):
     """
     queryset = ProjectCondition.objects.all()
     serializer_class = ProjectConditionSerializer
-    filter_fields = ('project', 'type', )

--- a/akvo/rest/views/project_contact.py
+++ b/akvo/rest/views/project_contact.py
@@ -16,4 +16,3 @@ class ProjectContactViewSet(PublicProjectViewSet):
     """
     queryset = ProjectContact.objects.all()
     serializer_class = ProjectContactSerializer
-    filter_fields = ('project', 'type', )

--- a/akvo/rest/views/project_document.py
+++ b/akvo/rest/views/project_document.py
@@ -16,7 +16,6 @@ class ProjectDocumentViewSet(PublicProjectViewSet):
     """
     queryset = ProjectDocument.objects.all()
     serializer_class = ProjectDocumentSerializer
-    filter_fields = ('project', 'language', 'title_language', 'document_date', )
 
 
 class ProjectDocumentCategoryViewSet(PublicProjectViewSet):
@@ -25,4 +24,3 @@ class ProjectDocumentCategoryViewSet(PublicProjectViewSet):
     queryset = ProjectDocumentCategory.objects.all()
     serializer_class = ProjectDocumentCategorySerializer
     filter_fields = ('document__project', 'document', 'category', )
-    project_relation = 'document__project__'

--- a/akvo/rest/views/project_location.py
+++ b/akvo/rest/views/project_location.py
@@ -15,7 +15,6 @@ class ProjectLocationViewSet(PublicProjectViewSet):
     """
     queryset = ProjectLocation.objects.all()
     serializer_class = ProjectLocationSerializer
-    filter_fields = ('location_target', 'country', )
     project_relation = 'location_target__'
 
 
@@ -24,7 +23,6 @@ class AdministrativeLocationViewSet(PublicProjectViewSet):
     """
     queryset = AdministrativeLocation.objects.all()
     serializer_class = AdministrativeLocationSerializer
-    filter_fields = ('location__location_target', 'location', 'code', )
     project_relation = 'location__location_target__'
 
 
@@ -39,11 +37,6 @@ class MapProjectLocationViewSet(BaseRSRViewSet):
     __country__ (filter on country ID)
     """
 
-    filter_fields = (
-        'location_target',
-        'location_target__partners',
-        'country'
-    )
     serializer_class = MapProjectLocationSerializer
     max_paginate_by = 500
     paginate_by = 100

--- a/akvo/rest/views/project_update.py
+++ b/akvo/rest/views/project_update.py
@@ -21,11 +21,6 @@ class ProjectUpdateViewSet(PublicProjectViewSet):
     queryset = ProjectUpdate.objects.select_related('project',
                                                     'user').prefetch_related('locations')
     serializer_class = ProjectUpdateSerializer
-    filter_fields = {
-        'project': ['exact', ],
-        'user': ['exact', ],
-        'uuid': ['exact', 'icontains', ],
-    }
 
     paginate_by_param = 'limit'
     max_paginate_by = 1000
@@ -86,14 +81,6 @@ class ProjectUpdateExtraViewSet(PublicProjectViewSet):
         'user__organisations__primary_location__country',
         'user__organisations__primary_location__location_target')
     serializer_class = ProjectUpdateExtraSerializer
-    filter_fields = {
-        'project': ['exact', ],
-        'user': ['exact', ],
-        'uuid': ['exact', 'icontains', ],
-        # These filters only accept a date, not a datetime
-        # 'created_at': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-        # 'last_modified_at': ['exact', 'gt', 'gte', 'lt', 'lte', ],
-    }
 
     def get_queryset(self):
         """

--- a/akvo/rest/views/project_update_location.py
+++ b/akvo/rest/views/project_update_location.py
@@ -31,11 +31,6 @@ class MapProjectUpdateLocationViewSet(BaseRSRViewSet):
     __location_target\__user\__employers__ (filter on organisation ID of the users' organisations)
     """
 
-    filter_fields = (
-        'location_target__project',
-        'location_target__project__partners',
-        'location_target__user__employers'
-    )
     max_paginate_by = 500
     paginate_by = 100
     # TODO: shouldn't this be subject to private project filtering?

--- a/akvo/rest/views/publishing_status.py
+++ b/akvo/rest/views/publishing_status.py
@@ -16,4 +16,3 @@ class PublishingStatusViewSet(PublicProjectViewSet):
     """
     queryset = PublishingStatus.objects.all()
     serializer_class = PublishingStatusSerializer
-    filter_fields = ('project', 'status', )

--- a/akvo/rest/views/recipient_country.py
+++ b/akvo/rest/views/recipient_country.py
@@ -16,4 +16,3 @@ class RecipientCountryViewSet(PublicProjectViewSet):
     """
     queryset = RecipientCountry.objects.all()
     serializer_class = RecipientCountrySerializer
-    filter_fields = ('project', 'country', )

--- a/akvo/rest/views/region.py
+++ b/akvo/rest/views/region.py
@@ -16,4 +16,3 @@ class RecipientRegionViewSet(PublicProjectViewSet):
     """
     queryset = RecipientRegion.objects.all()
     serializer_class = RecipientRegionSerializer
-    filter_fields = ('project', 'region', )

--- a/akvo/rest/views/related_project.py
+++ b/akvo/rest/views/related_project.py
@@ -16,4 +16,3 @@ class RelatedProjectViewSet(PublicProjectViewSet):
     """
     queryset = RelatedProject.objects.all()
     serializer_class = RelatedProjectSerializer
-    filter_fields = ('project', 'related_project', 'relation', )

--- a/akvo/rest/views/result.py
+++ b/akvo/rest/views/result.py
@@ -15,7 +15,6 @@ class ResultsViewSet(PublicProjectViewSet):
 
     queryset = Result.objects.all()
     serializer_class = ResultSerializer
-    filter_fields = ('project', 'type', 'aggregation_status', 'parent_result')
 
 
 class ResultsFrameworkViewSet(PublicProjectViewSet):
@@ -23,4 +22,3 @@ class ResultsFrameworkViewSet(PublicProjectViewSet):
 
     queryset = Result.objects.prefetch_related('indicators')
     serializer_class = ResultsFrameworkSerializer
-    filter_fields = ('project', 'type', 'aggregation_status', 'parent_result')

--- a/akvo/rest/views/sector.py
+++ b/akvo/rest/views/sector.py
@@ -16,4 +16,3 @@ class SectorViewSet(PublicProjectViewSet):
 
     queryset = Sector.objects.all()
     serializer_class = SectorSerializer
-    filter_fields = ('project', 'sector_code', )

--- a/akvo/rest/views/transaction.py
+++ b/akvo/rest/views/transaction.py
@@ -15,9 +15,6 @@ class TransactionViewSet(PublicProjectViewSet):
 
     queryset = Transaction.objects.all()
     serializer_class = TransactionSerializer
-    filter_fields = (
-        'project', 'reference', 'transaction_type', 'currency', 'provider_organisation',
-        'receiver_organisation')
 
 
 class TransactionSectorViewSet(PublicProjectViewSet):
@@ -25,5 +22,4 @@ class TransactionSectorViewSet(PublicProjectViewSet):
 
     queryset = TransactionSector.objects.all()
     serializer_class = TransactionSectorSerializer
-    filter_fields = ('transaction__project', 'transaction', 'code')
     project_relation = 'transaction__project__'

--- a/akvo/rest/views/user.py
+++ b/akvo/rest/views/user.py
@@ -36,8 +36,6 @@ class UserViewSet(BaseRSRViewSet):
         'organisations__primary_location__country',
         'organisations__primary_location__location_target',)
     serializer_class = UserSerializer
-    filter_fields = ('username', 'email', 'first_name', 'last_name', 'is_active', 'is_staff',
-                     'is_admin')
 
 
 @api_view(['POST'])

--- a/akvo/rest/viewsets.py
+++ b/akvo/rest/viewsets.py
@@ -3,10 +3,10 @@
 # Akvo RSR is covered by the GNU Affero General Public License.
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
-
 from akvo.rest.models import TastyTokenAuthentication
 from rest_framework import authentication, filters, permissions, viewsets
 
+from .filters import RSRGenericFilterBackend
 
 class SafeMethodsPermissions(permissions.DjangoObjectPermissions):
     """
@@ -26,7 +26,8 @@ class BaseRSRViewSet(viewsets.ModelViewSet):
     """
     authentication_classes = (authentication.SessionAuthentication, TastyTokenAuthentication, )
     permission_classes = (SafeMethodsPermissions, )
-    filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter, )
+    filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter,
+                       RSRGenericFilterBackend,)
     ordering_fields = '__all__'
 
 

--- a/akvo/rest/viewsets.py
+++ b/akvo/rest/viewsets.py
@@ -3,12 +3,15 @@
 # Akvo RSR is covered by the GNU Affero General Public License.
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
 from django.db.models.fields.related import ForeignKey, ForeignObject
 
 from akvo.rest.models import TastyTokenAuthentication
+
 from rest_framework import authentication, filters, permissions, viewsets
 
 from .filters import RSRGenericFilterBackend
+
 
 class SafeMethodsPermissions(permissions.DjangoObjectPermissions):
     """
@@ -28,8 +31,7 @@ class BaseRSRViewSet(viewsets.ModelViewSet):
     """
     authentication_classes = (authentication.SessionAuthentication, TastyTokenAuthentication, )
     permission_classes = (SafeMethodsPermissions, )
-    filter_backends = (filters.DjangoFilterBackend, filters.OrderingFilter,
-                       RSRGenericFilterBackend,)
+    filter_backends = (filters.OrderingFilter, RSRGenericFilterBackend,)
     ordering_fields = '__all__'
 
     def get_queryset(self):

--- a/akvo/rest/viewsets.py
+++ b/akvo/rest/viewsets.py
@@ -3,6 +3,8 @@
 # Akvo RSR is covered by the GNU Affero General Public License.
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+from django.db.models.fields.related import ForeignKey, ForeignObject
+
 from akvo.rest.models import TastyTokenAuthentication
 from rest_framework import authentication, filters, permissions, viewsets
 
@@ -30,6 +32,62 @@ class BaseRSRViewSet(viewsets.ModelViewSet):
                        RSRGenericFilterBackend,)
     ordering_fields = '__all__'
 
+    def get_queryset(self):
+
+        def django_filter_filters(request):
+            """
+            Support emulating the DjangoFilterBackend-based filtering that some views used to have
+            """
+            # query string keys reserved by the RSRGenericFilterBackend
+            qs_params = ['filter', 'exclude', 'select_related', 'prefetch_related', ]
+            # query string keys used by core DRF and OrderingFilter
+            exclude_params = ['limit', 'format', 'page', 'order_by', ]
+            filters = {}
+            for key in request.QUERY_PARAMS.keys():
+                if key not in qs_params + exclude_params:
+                    filters.update({key: request.QUERY_PARAMS.get(key)})
+            return filters
+
+        def get_lookups_from_filters(legacy_filters):
+            """
+            Cast the values in DjangoFilterBackend-styled query string filters to correct types to
+            be able to use them in regular queryset-filter() calls
+            """
+            # types of lookups supported by the views using DjangoFilterBackend
+            LEGACY_FIELD_LOOKUPS = ['exact', 'contains', 'icontains', 'gt', 'gte', 'lt',
+                                    'lte', ]
+            query_set_lookups = []
+            for key, value in legacy_filters.items():
+                parts = key.split('__')
+                if parts[-1] in LEGACY_FIELD_LOOKUPS:
+                    parts = parts[:-1]
+                    model = queryset.model
+                    for part in parts:
+                        field_object, related_model, direct, m2m = model._meta.get_field_by_name(
+                            part)
+                        if direct:
+                            if issubclass(field_object.__class__, ForeignObject):
+                                model = field_object.related.parent_model
+                            else:
+                                value = field_object.to_python(value)
+                                break
+                        else:
+                            model = related_model
+                query_set_lookups += [{key: value}]
+            return query_set_lookups
+
+        queryset = super(BaseRSRViewSet, self).get_queryset()
+
+        # support for old DjangoFilterBackend-based filtering
+        # find all "old styled" filters
+        legacy_filters = django_filter_filters(self.request)
+        # create lookup dicts from the filters found
+        lookups = get_lookups_from_filters(legacy_filters)
+        for lookup in lookups:
+            queryset = queryset.filter(**lookup)
+
+        return queryset
+
 
 class PublicProjectViewSet(BaseRSRViewSet):
     """
@@ -44,10 +102,12 @@ class PublicProjectViewSet(BaseRSRViewSet):
 
     def get_queryset(self):
 
-        queryset = super(PublicProjectViewSet, self).get_queryset()
-        user = self.request.user
+        request = self.request
+        user = request.user
 
-        if user.is_anonymous() or not (user.is_superuser or user.is_admin):
+        queryset = super(PublicProjectViewSet, self).get_queryset()
+
+        def projects_filter_for_non_privileged_users(user, queryset):
             # Construct the public projects filter field lookup.
             project_filter = self.project_relation + 'is_public'
 
@@ -72,5 +132,11 @@ class PublicProjectViewSet(BaseRSRViewSet):
                         permitted_obj_pks.append(obj.pk)
 
                 queryset = public_objects | queryset.filter(pk__in=permitted_obj_pks).distinct()
+
+            return queryset
+
+        # filter projects if user is "non-privileged"
+        if user.is_anonymous() or not (user.is_superuser or user.is_admin):
+            queryset = projects_filter_for_non_privileged_users(user, queryset)
 
         return queryset


### PR DESCRIPTION
See rest/filters.py for documentation on how to use the filter. The existing filters based on DjangoFilterBackend are now also supported via some fun hackery :wink:

### Testing
The example queries in the doc string of filters.py are good examples of queries that should work and return objects (the domain part needs changing of course). I can help construct other more complex examples if needed. One possibility is to construct queries that return the same result as long as the objects in the result set aren't changed that could then be used in the integration/web tests (I'm not sure about the current status of our testing suite). This could be existing project updates for instance, they are pretty stable I'd say.

To test the select_realted and prefetch_realted functionality is harder. For that you really need to analyze the queries executed with and without them included on sufficiently complex queries, and I don't know if we have that functionality in place right now. Django-debug-toolbar can tell you how many queries a view generates, and I think you can get it to work with DRF.

Now that the DjangoFilterBackend-styled filtering has been removed, we also need to test that those kinds of filters still work. If we could find out the filters partners actually are using and test those that'd be the best and most relevant, as we should discourage additions of filters using the same syntax.