### PR TITLE
Update actual comment with update text

### DIFF
--- a/akvo/rsr/models/indicator.py
+++ b/akvo/rsr/models/indicator.py
@@ -511,6 +511,29 @@ class IndicatorPeriod(models.Model):
 
         return new_value
 
+    def update_actual_comment(self, save=True):
+        """
+        Set the actual comment to the text of the latest approved update.
+
+        :param save; Boolean, save period if True
+        :return Actual comment of period
+        """
+
+        approved_updates = self.data.filter(status=IndicatorPeriodData.STATUS_APPROVED_CODE)
+        update_texts = [
+            '{}: {}'.format(update.last_modified_at.strftime('%d-%m-%Y'), update.text)
+            for update in approved_updates.order_by('-created_at')
+        ]
+        actual_comment = ' | '.join(update_texts)
+        if len(actual_comment) >= 2000:  # max_size
+            actual_comment = '{} ...'.format(actual_comment[:1995])
+
+        self.actual_comment = actual_comment
+        if save:
+            self.save()
+
+        return self.actual_comment
+
     def is_calculated(self):
         """
         When a period has got indicator updates, we consider the actual value to be a
@@ -778,6 +801,7 @@ class IndicatorPeriodData(TimestampsMixin, models.Model):
         # In case the status is approved, recalculate the period
         if recalculate and self.status == self.STATUS_APPROVED_CODE:
             self.period.recalculate_period()
+            self.period.update_actual_comment()
 
     def delete(self, *args, **kwargs):
         old_status = self.status


### PR DESCRIPTION
Prepend the text of an update to the corresponding indicator period's
`actual_comment` field.  Older comments may get stripped off, if the
length of all comment exceeds 2k chars.

Fix #2342

# Test plan

1. For a project, add a result with an indicator and an indicator period. 
2. Adding indicator period updates from My Results section, should update the actual_comment field for that indicator. 

![sat sep 17 00 03 53 ist 2016](https://cloud.githubusercontent.com/assets/315678/18597282/e9a312a0-7c6a-11e6-9364-f7384ba8b6df.jpg)
