### PR TITLE
[Fixes #2371] Sort mappers_prefix choices

### DIFF
--- a/akvo/codelists/migrations/0004_auto_20160920_1045.py
+++ b/akvo/codelists/migrations/0004_auto_20160920_1045.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('codelists', '0003_auto_20160226_1131'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='country',
+            options={'ordering': ('-version', 'name', 'code'), 'verbose_name': 'country', 'verbose_name_plural': 'countries'},
+        ),
+    ]

--- a/akvo/rsr/migrations/0084_auto_20160920_1045.py
+++ b/akvo/rsr/migrations/0084_auto_20160920_1045.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rsr', '0083_auto_20160816_0950'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='projecteditorvalidation',
+            name='action',
+            field=models.PositiveSmallIntegerField(db_index=True, verbose_name='action', choices=[(1, 'Mandatory'), (2, 'Hidden')]),
+            preserve_default=True,
+        ),
+    ]

--- a/akvo/rsr/models/iati_import.py
+++ b/akvo/rsr/models/iati_import.py
@@ -30,7 +30,7 @@ def get_subpackages(module):
 def custom_mappers():
     "Create a list of available custom mapper, for use in the admin"
     from ...iati.imports import mappers
-    subs = get_subpackages(mappers)
+    subs = sorted(get_subpackages(mappers))
     return [(sub, sub) for sub in subs]
 
 import logging


### PR DESCRIPTION
The choices are obtained by listing subpackages of
`akvo.iati.imports.mappers`, and not sorting them can create unnecessary
migrations.

Also, add a couple of missing migration files from previous changes. 