### PR TITLE
#2375 results performance

### DIFF
--- a/akvo/rest/serializers/result.py
+++ b/akvo/rest/serializers/result.py
@@ -24,6 +24,16 @@ class ResultSerializer(ResultRawSerializer):
     parent_project = serializers.Field(source='parent_project')
     child_projects = serializers.Field(source='child_projects')
 
+    def to_native(self, obj):
+        """ Debugging method. Prints all queries made after calling super() """
+        ret = super(ResultSerializer, self).to_native(obj)
+
+        from django.db import connection, reset_queries
+        for c in connection.queries:
+            print c
+        reset_queries()
+        return ret
+
 
 class ResultsFrameworkSerializer(BaseRSRSerializer):
 

--- a/akvo/rest/serializers/result.py
+++ b/akvo/rest/serializers/result.py
@@ -24,16 +24,6 @@ class ResultSerializer(ResultRawSerializer):
     parent_project = serializers.Field(source='parent_project')
     child_projects = serializers.Field(source='child_projects')
 
-    def to_native(self, obj):
-        """ Debugging method. Prints all queries made after calling super() """
-        ret = super(ResultSerializer, self).to_native(obj)
-
-        from django.db import connection, reset_queries
-        for c in connection.queries:
-            print c
-        reset_queries()
-        return ret
-
 
 class ResultsFrameworkSerializer(BaseRSRSerializer):
 

--- a/akvo/rest/views/result.py
+++ b/akvo/rest/views/result.py
@@ -13,7 +13,7 @@ from ..viewsets import PublicProjectViewSet
 class ResultsViewSet(PublicProjectViewSet):
     """Results resource."""
 
-    queryset = Result.objects.all().select_related('project__title')
+    queryset = Result.objects.all().select_related('project')
     serializer_class = ResultSerializer
 
 

--- a/akvo/rest/views/result.py
+++ b/akvo/rest/views/result.py
@@ -13,7 +13,7 @@ from ..viewsets import PublicProjectViewSet
 class ResultsViewSet(PublicProjectViewSet):
     """Results resource."""
 
-    queryset = Result.objects.all()
+    queryset = Result.objects.all().select_related('project__title')
     serializer_class = ResultSerializer
 
 

--- a/akvo/rsr/models/result.py
+++ b/akvo/rsr/models/result.py
@@ -146,7 +146,7 @@ class Result(models.Model):
         Return a dictionary of this result's child projects.
         """
         projects = {}
-        for result in Result.objects.filter(parent_result=self).select_related('project__title'):
+        for result in Result.objects.filter(parent_result=self).select_related('project'):
             projects[result.project.id] = result.project.title
         return projects
 

--- a/akvo/rsr/models/result.py
+++ b/akvo/rsr/models/result.py
@@ -146,7 +146,7 @@ class Result(models.Model):
         Return a dictionary of this result's child projects.
         """
         projects = {}
-        for result in Result.objects.filter(parent_result=self):
+        for result in Result.objects.filter(parent_result=self).select_related('project__title'):
             projects[result.project.id] = result.project.title
         return projects
 


### PR DESCRIPTION
Fixes the main issue with the **result** endpoint. There's still going to be lots of queries for results in complex parent-child project hierarchies, but at least they'll be fast. I think what happens is that the first Result queryset is cached and then used in all other queries.