### PR TITLE
Fix broken transaction import from IATI xml

### DIFF
--- a/akvo/rest/views/user.py
+++ b/akvo/rest/views/user.py
@@ -16,6 +16,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from akvo.rest.models import TastyTokenAuthentication
+from akvo.utils import get_codelist_value_name
 from ...rsr.models import Country, Employment, Organisation
 from ..viewsets import BaseRSRViewSet
 from ..serializers import EmploymentSerializer, OrganisationSerializer, CountrySerializer
@@ -140,7 +141,7 @@ def request_organisation(request, pk=None):
                             status=status.HTTP_409_CONFLICT)
 
         if serializer.data['country']:
-            serializer.data['country_full'] = employment.iati_country().name
+            serializer.data['country_full'] = get_codelist_value_name(employment.iati_country())
         else:
             serializer.data['country_full'] = ''
         serializer.data['organisation_full'] = OrganisationSerializer(organisation).data

--- a/akvo/rsr/models/budget_item.py
+++ b/akvo/rsr/models/budget_item.py
@@ -15,7 +15,7 @@ from ..fields import ValidXMLCharField
 from akvo.codelists.models import BudgetIdentifier, BudgetStatus, BudgetType, Currency
 from akvo.codelists.store.codelists_v202 import (BUDGET_IDENTIFIER, BUDGET_TYPE, BUDGET_STATUS,
                                                  CURRENCY)
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 
 class BudgetItemLabel(models.Model):
@@ -123,19 +123,13 @@ class BudgetItem(models.Model):
             return self.__unicode__()
 
     def get_currency(self):
-        if self.currency:
-            return self.currency
-        else:
-            return self.project.currency
+        return self.currency if self.currency else self.project.currency
 
     def iati_type(self):
         return codelist_value(BudgetType, self, 'type')
 
     def iati_currency(self):
-        if self.currency:
-            return codelist_value(Currency, self, 'currency')
-        else:
-            return codelist_value(Currency, self.project, 'currency')
+        return codelist_value(Currency, self if self.currency else self.project, 'currency')
 
     def iati_status(self):
         return codelist_value(BudgetStatus, self, 'status')
@@ -168,7 +162,7 @@ class CountryBudgetItem(models.Model):
     )
 
     def __unicode__(self):
-        return self.iati_code().name if self.code else u'%s' % _(u'No code specified')
+        return get_codelist_value_name(self.iati_code()) if self.code else u'%s' % _(u'No code specified')
 
     def iati_code(self):
         return codelist_value(BudgetIdentifier, self, 'code')

--- a/akvo/rsr/models/country.py
+++ b/akvo/rsr/models/country.py
@@ -14,7 +14,7 @@ from ..iso3166 import ISO_3166_COUNTRIES, CONTINENTS, COUNTRY_CONTINENTS
 
 from akvo.codelists import models as codelist_models
 from akvo.codelists.store.codelists_v202 import COUNTRY
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 
 class Country(models.Model):
@@ -69,10 +69,7 @@ class RecipientCountry(models.Model):
 
     def __unicode__(self):
         if self.country:
-            try:
-                country_unicode = self.iati_country().name
-            except (AttributeError, codelist_models.Country.DoesNotExist):
-                country_unicode = self.country
+            country_unicode = get_codelist_value_name(self.iati_country())
         else:
             country_unicode = u'%s' % _(u'No country specified')
 

--- a/akvo/rsr/models/crs_add.py
+++ b/akvo/rsr/models/crs_add.py
@@ -16,7 +16,7 @@ from akvo.codelists.models import (CRSAddOtherFlags, LoanRepaymentType, LoanRepa
 from akvo.codelists.store.codelists_v202 import (C_R_S_ADD_OTHER_FLAGS, LOAN_REPAYMENT_TYPE,
                                                  LOAN_REPAYMENT_PERIOD, CURRENCY,
                                                  C_R_S_CHANNEL_CODE)
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 
 class CrsAdd(models.Model):
@@ -138,10 +138,7 @@ class CrsAddOtherFlag(models.Model):
 
     def __unicode__(self):
         if self.code:
-            try:
-                return self.iati_code().name
-            except AttributeError:
-                return self.iati_code()
+            return get_codelist_value_name(self.iati_code())
         else:
             return u'%s' % _(u'No other flag code specified')
 

--- a/akvo/rsr/models/employment.py
+++ b/akvo/rsr/models/employment.py
@@ -6,7 +6,7 @@
 
 from akvo.codelists import models as codelist_models
 from akvo.codelists.store.codelists_v202 import COUNTRY
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 from django.contrib.admin.models import LogEntry, CHANGE
 from django.contrib.auth import get_user_model
@@ -114,7 +114,7 @@ class Employment(models.Model):
             user_full=model_to_dict(self.user, fields=['id', 'first_name', 'last_name', 'email',]),
             is_approved=self.is_approved,
             job_title=self.job_title,
-            country_full=self.iati_country().name if self.country else '',
+            country_full=get_codelist_value_name(self.iati_country()),
             group=user_group,
             other_groups=other_groups,
             actions=True if self.organisation in org_list else False,

--- a/akvo/rsr/models/fss.py
+++ b/akvo/rsr/models/fss.py
@@ -12,7 +12,7 @@ from ..fields import ValidXMLCharField
 
 from akvo.codelists.models import Currency
 from akvo.codelists.store.codelists_v202 import CURRENCY
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 
 class Fss(models.Model):
@@ -67,10 +67,7 @@ class FssForecast(models.Model):
 
     def __unicode__(self):
         if self.value and self.currency:
-            try:
-                return u'{0} {1}'.format(self.iati_currency().name, self.value)
-            except AttributeError:
-                return u'{0} {1}'.format(self.iati_currency(), self.value)
+            return u'{0} {1}'.format(get_codelist_value_name(self.iati_currency()), self.value)
         else:
             return u'%s' % _(u'No currency or interest received specified')
 

--- a/akvo/rsr/models/organisation.py
+++ b/akvo/rsr/models/organisation.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from sorl.thumbnail.fields import ImageField
 
-from akvo.utils import codelist_choices, codelist_name, rsr_image_path
+from akvo.utils import codelist_choices, codelist_name, get_codelist_value_name, rsr_image_path
 
 from ..mixins import TimestampsMixin
 from ..fields import ValidXMLCharField, ValidXMLTextField
@@ -211,7 +211,7 @@ class Organisation(TimestampsMixin, models.Model):
         elif not name:
             # This prevents organisation names with only spaces
             validation_errors['name'] = _(u'Organisation name may not be blank')
-        
+
         if long_name and long_names.exists():
             validation_errors['long_name'] = u'{}: {}'.format(
                 _('An Organisation with this long name already exists'), long_name)
@@ -441,7 +441,7 @@ class Organisation(TimestampsMixin, models.Model):
         countries = []
         for location in self.locations.all():
             if location.iati_country:
-                countries.append(location.iati_country_value().name)
+                countries.append(get_codelist_value_name(location.iati_country_value()))
         return countries
 
     def iati_file(self):

--- a/akvo/rsr/models/organisation_document.py
+++ b/akvo/rsr/models/organisation_document.py
@@ -13,7 +13,7 @@ from ..fields import ValidXMLCharField
 
 from akvo.codelists.models import Country, DocumentCategory, Language
 from akvo.codelists.store.codelists_v202 import COUNTRY, DOCUMENT_CATEGORY, FILE_FORMAT, LANGUAGE
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 
 def document_path(self, filename):
@@ -108,10 +108,7 @@ class OrganisationDocumentCategory(models.Model):
 
     def __unicode__(self):
         if self.category:
-            try:
-                return self.iati_category().name
-            except AttributeError:
-                return self.iati_category()
+            return get_codelist_value_name(self.iati_category())
         else:
             return '%s' % _(u'No category specified')
 
@@ -139,10 +136,7 @@ class OrganisationDocumentCountry(models.Model):
 
     def __unicode__(self):
         if self.country:
-            try:
-                return self.iati_country().name
-            except AttributeError:
-                return self.iati_country()
+            return get_codelist_value_name(self.iati_country())
         else:
             return '%s' % _(u'No country specified')
 

--- a/akvo/rsr/models/planned_disbursement.py
+++ b/akvo/rsr/models/planned_disbursement.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 from ..fields import ValidXMLCharField
 from akvo.codelists.models import BudgetType, Currency
 from akvo.codelists.store.codelists_v202 import BUDGET_TYPE, CURRENCY
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 
 class PlannedDisbursement(models.Model):
@@ -56,12 +56,7 @@ class PlannedDisbursement(models.Model):
 
     def __unicode__(self):
         if self.value:
-            if self.currency:
-                return u'%s %s' % (self.iati_currency().name,
-                                   '{:,}'.format(int(self.value)))
-            else:
-                return u'%s %s' % (self.project.currency,
-                                   '{:,}'.format(int(self.value)))
+            return u'%s %s' % (get_codelist_value_name(self.iati_currency()), '{:,}'.format(int(self.value)))
         else:
             return u'%s' % _(u'No value specified')
 
@@ -80,10 +75,7 @@ class PlannedDisbursement(models.Model):
         return ''
 
     def iati_currency(self):
-        if self.currency:
-            return codelist_value(Currency, self, 'currency')
-        else:
-            return codelist_value(Currency, self.project, 'currency')
+        return codelist_value(Currency, self if self.currency else self.project, 'currency')
 
     def iati_type(self):
         return codelist_value(BudgetType, self, 'type')

--- a/akvo/rsr/models/policy_marker.py
+++ b/akvo/rsr/models/policy_marker.py
@@ -15,7 +15,7 @@ from ..fields import ValidXMLCharField
 from akvo.codelists import models as codelist_models
 from akvo.codelists.store.codelists_v202 import (POLICY_MARKER, POLICY_SIGNIFICANCE,
                                                  POLICY_MARKER_VOCABULARY)
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 
 class PolicyMarker(models.Model):
@@ -53,13 +53,12 @@ class PolicyMarker(models.Model):
     description = ValidXMLCharField(_(u'policy marker description'), max_length=255, blank=True)
 
     def __unicode__(self):
-        try:
-            return self.iati_policy_marker().name
-        except AttributeError:
-            if self.description:
-                return unicode(self.description)
-            else:
-                return u'%s' % _(u'Policy marker not specified')
+        name = get_codelist_value_name(self.iati_policy_marker())
+        if not name and self.description:
+            name = unicode(self.description)
+
+        else:
+            return u'%s' % _(u'Policy marker not specified')
 
     def iati_policy_marker(self):
         return codelist_value(codelist_models.PolicyMarker, self, 'policy_marker')

--- a/akvo/rsr/models/project_document.py
+++ b/akvo/rsr/models/project_document.py
@@ -13,7 +13,7 @@ from ..fields import ValidXMLCharField
 
 from akvo.codelists.models import DocumentCategory, FileFormat, Language
 from akvo.codelists.store.codelists_v202 import DOCUMENT_CATEGORY, FILE_FORMAT, LANGUAGE
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 
 def document_path(self, filename):
@@ -123,10 +123,7 @@ class ProjectDocumentCategory(models.Model):
 
     def __unicode__(self):
         if self.category:
-            try:
-                return self.iati_category().name
-            except AttributeError:
-                return self.iati_category()
+            return get_codelist_value_name(self.iati_category())
         else:
             return '%s' % _(u'No category specified')
 

--- a/akvo/rsr/models/region.py
+++ b/akvo/rsr/models/region.py
@@ -13,7 +13,7 @@ from ..fields import ValidXMLCharField
 
 from akvo.codelists.models import Region, RegionVocabulary
 from akvo.codelists.store.codelists_v202 import REGION, REGION_VOCABULARY
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 
 class RecipientRegion(models.Model):
@@ -57,10 +57,7 @@ class RecipientRegion(models.Model):
 
     def __unicode__(self):
         if self.region:
-            try:
-                region_unicode = self.iati_region().name
-            except AttributeError:
-                region_unicode = self.iati_region()
+            region_unicode = get_codelist_value_name(self.iati_region())
         else:
             region_unicode = u'%s' % _(u'No region specified')
 

--- a/akvo/rsr/models/result.py
+++ b/akvo/rsr/models/result.py
@@ -12,7 +12,7 @@ from ..fields import ValidXMLCharField
 
 from akvo.codelists.models import ResultType
 from akvo.codelists.store.codelists_v202 import RESULT_TYPE
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 
 class Result(models.Model):
@@ -53,7 +53,7 @@ class Result(models.Model):
         result_unicode = self.title if self.title else u'%s' % _(u'No result title')
 
         if self.type:
-            result_unicode += u' (' + self.iati_type().name + u')'
+            result_unicode += u' ({})'.format(get_codelist_value_name(self.iati_type()))
 
         if self.indicators.all():
             result_unicode += _(u' - %s indicators') % (unicode(self.indicators.count()))

--- a/akvo/rsr/models/sector.py
+++ b/akvo/rsr/models/sector.py
@@ -13,7 +13,7 @@ from ..fields import ValidXMLCharField
 
 from akvo.codelists import models as codelist_models
 from akvo.codelists.store.codelists_v202 import SECTOR_VOCABULARY
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 
 class Sector(models.Model):
@@ -53,15 +53,8 @@ class Sector(models.Model):
     def __unicode__(self):
         if self.sector_code:
             # Check if the code is specified
-            try:
-                sector_text = u'%s' % self.iati_sector().name.capitalize()
-            except AttributeError:
-                sector_text = self.text
-
-            try:
-                vocabulary = self.iati_vocabulary().name
-            except AttributeError:
-                vocabulary = ''
+            sector_text = u'%s' % get_codelist_value_name(self.iati_vocabulary()).capitalize()
+            vocabulary = get_codelist_value_name(self.iati_vocabulary())
 
             return u'{0}{1}{2}{3}'.format(
                 u'{0}: '.format(vocabulary) if vocabulary else u'',

--- a/akvo/rsr/models/transaction.py
+++ b/akvo/rsr/models/transaction.py
@@ -17,7 +17,7 @@ from akvo.codelists.store.codelists_v202 import (AID_TYPE, CURRENCY, DISBURSEMEN
                                                  FINANCE_TYPE, FLOW_TYPE, TIED_STATUS,
                                                  TRANSACTION_TYPE, COUNTRY, REGION,
                                                  REGION_VOCABULARY, SECTOR_VOCABULARY)
-from akvo.utils import codelist_choices, codelist_value
+from akvo.utils import codelist_choices, codelist_value, get_codelist_value_name
 
 
 class Transaction(models.Model):
@@ -139,12 +139,7 @@ class Transaction(models.Model):
 
     def __unicode__(self):
         if self.value:
-            if self.currency:
-                return u'%s %s' % (self.iati_currency().name,
-                                   '{:,}'.format(int(self.value)))
-            else:
-                return u'%s %s' % (self.project.currency,
-                                   '{:,}'.format(int(self.value)))
+            return u'%s %s' % (get_codelist_value_name(self.iati_currency()), '{:,}'.format(int(self.value)))
         else:
             return u'%s' % _(u'No value specified')
 

--- a/akvo/rsr/tests/iati_import/test_iati_import.py
+++ b/akvo/rsr/tests/iati_import/test_iati_import.py
@@ -102,6 +102,14 @@ class IatiImportTestCase(TestCase):
         self.assertEqual(project_v2.transactions.count(), 1)
         self.assertEqual(project_v2.budget_items.count(), 1)
         self.assertEqual(project_v2.planned_disbursements.count(), 2)
+        self.assertEqual(project_v2.recipient_regions.count(), 3)
+        self.assertEqual(project_v2.recipient_countries.count(), 2)
+        self.assertEqual(project_v2.locations.count(), 2)
+        self.assertEqual(project_v2.sectors.count(), 3)
+        self.assertEqual(project_v2.results.count(), 1)
+        self.assertEqual(project_v2.contacts.count(), 1)
+        self.assertEqual(project_v2.conditions.count(), 1)
+        self.assertEqual(project_v2.documents.count(), 1)
         self.assertEqual(project_v2.reporting_org.iati_org_id, "NL-KVK-0987654321")
 
     def test_iati_incorrect_import(self):

--- a/akvo/rsr/tests/iati_import/test_iati_import.py
+++ b/akvo/rsr/tests/iati_import/test_iati_import.py
@@ -77,6 +77,7 @@ class IatiImportTestCase(TestCase):
         self.assertEqual(project_v1.currency, "USD")
         self.assertEqual(project_v1.title, "Test project for IATI import v1")
         self.assertEqual(project_v1.partners.count(), 4)
+        self.assertEqual(project_v1.transactions.count(), 2)
         self.assertEqual(project_v1.reporting_org.iati_org_id, "NL-KVK-0987654321")
 
     def test_iati_v2_import(self):
@@ -98,6 +99,7 @@ class IatiImportTestCase(TestCase):
         self.assertEqual(project_v2.hierarchy, 1)
         self.assertEqual(project_v2.title, "Test project for IATI import v2")
         self.assertEqual(project_v2.partners.count(), 4)
+        self.assertEqual(project_v2.transactions.count(), 1)
         self.assertEqual(project_v2.reporting_org.iati_org_id, "NL-KVK-0987654321")
 
     def test_iati_incorrect_import(self):
@@ -120,6 +122,7 @@ class IatiImportTestCase(TestCase):
         self.assertEqual(project_inc.hierarchy, None)
         self.assertEqual(project_inc.title, "Test project for IATI import (incorrect)")
         self.assertEqual(project_inc.partners.count(), 1)
+        self.assertEqual(project_inc.transactions.count(), 1)
         self.assertEqual(project_inc.reporting_org.iati_org_id, "NL-KVK-0987654321")
 
     def test_iati_icco_import(self):
@@ -184,4 +187,5 @@ class IatiImportTestCase(TestCase):
         self.assertEqual(project_cordaid.hierarchy, 1)
         self.assertEqual(project_cordaid.title, "Test project for IATI Cordaid import")
         self.assertEqual(project_cordaid.partners.count(), 4)
+        self.assertEqual(project_cordaid.transactions.count(), 2)
         self.assertEqual(project_cordaid.reporting_org.iati_org_id, "NL-KVK-0987654321")

--- a/akvo/rsr/tests/iati_import/test_iati_import.py
+++ b/akvo/rsr/tests/iati_import/test_iati_import.py
@@ -100,6 +100,8 @@ class IatiImportTestCase(TestCase):
         self.assertEqual(project_v2.title, "Test project for IATI import v2")
         self.assertEqual(project_v2.partners.count(), 4)
         self.assertEqual(project_v2.transactions.count(), 1)
+        self.assertEqual(project_v2.budget_items.count(), 1)
+        self.assertEqual(project_v2.planned_disbursements.count(), 2)
         self.assertEqual(project_v2.reporting_org.iati_org_id, "NL-KVK-0987654321")
 
     def test_iati_incorrect_import(self):

--- a/akvo/utils.py
+++ b/akvo/utils.py
@@ -336,6 +336,19 @@ def codelist_value(model, instance, field, version=settings.IATI_VERSION):
     return ''
 
 
+def get_codelist_value_name(value):
+    """
+    Return name for a codelist value object.
+    :param value: Codelist instance
+    :return: Name of the codelist instance or value itself
+    """
+
+    try:
+        return value.name
+    except AttributeError:
+        return value
+
+
 def codelist_name(model, instance, field, version=settings.IATI_VERSION):
     """
     Looks up the name of a codelist


### PR DESCRIPTION
If the DB doesn't have a row for the currency of a transaction already, the transaction can fail to be imported. 