### PR TITLE
[#2366] Make arrows smaller and move them around

### DIFF
--- a/akvo/rsr/static/scripts-src/project-hierarchy.js
+++ b/akvo/rsr/static/scripts-src/project-hierarchy.js
@@ -2,22 +2,28 @@ jsPlumb.ready(function() {
     var instance = jsPlumb.getInstance({
         Connector : [ "Bezier", { curviness:20 } ],
         DragOptions : { cursor: "pointer", zIndex:200 },
-        PaintStyle : { strokeStyle:"grey", lineWidth:2 },
-        EndpointStyle : { radius:3, fillStyle:"grey" },
+        PaintStyle : { strokeStyle:"grey", lineWidth:1 },
+        EndpointStyle : { radius:2, fillStyle:"grey" },
         HoverPaintStyle : {strokeStyle:"orange" },
         EndpointHoverStyle : {fillStyle:"orange" },
         Container:"project-hierarchy"
     });
 
     instance.doWhileSuspended(function() {
-        var arrowCommon = { foldback:0.7, fillStyle:"grey", width:7 },
+        var arrowCommon = { foldback:0.7, fillStyle:"grey", width:7, length:7 },
             arrow = [
                 [ "Arrow", { location:0.5 }, arrowCommon ]
-            ],
-            two_arrows = [
-                [ "Arrow", { location:0.7 }, arrowCommon ],
-                [ "Arrow", { location:0.3, direction:-1 }, arrowCommon ]
             ];
+
+        // Function to off-set arrows based on the index of connector on the
+        // element for which we are using the arrows
+        var get_two_arrows = function (index) {
+            var two_arrows = [
+                [ "Arrow", { location:Math.max(0.9 - index*0.1, 0.55) }, arrowCommon ],
+                [ "Arrow", { location:Math.min(0.1 + index*0.1, 0.45), direction:-1 }, arrowCommon ]
+            ];
+            return two_arrows;
+        }
 
         var project_window = $("#project-hierarchy-project");
         var parent_windows = $(".project-hierarchy .project-hierarchy-parent");
@@ -42,22 +48,38 @@ jsPlumb.ready(function() {
         for (i = 0; i < parent_windows.length; i++) {
             var parent_uuid = parent_windows[i].getAttribute("id") + "-right";
             instance.addEndpoint(parent_windows[i], {uuid:parent_uuid, anchor:"Right"});
-            instance.connect({uuids:[parent_uuid, "project-left"], overlays:arrow});
+            instance.connect({
+                uuids:[parent_uuid, "project-left"],
+                overlays:arrow,
+                connector:["Bezier", {curviness:(i+1) * 20}]
+            });
         }
         for (i = 0; i < top_sibling_windows.length; i++) {
             var top_sibling_uuid = top_sibling_windows[i].getAttribute("id") + "-bottom";
             instance.addEndpoint(top_sibling_windows[i], {uuid:top_sibling_uuid, anchor:"Bottom"});
-            instance.connect({uuids:[top_sibling_uuid, "project-top"], overlays:two_arrows});
+            instance.connect({
+                uuids:[top_sibling_uuid, "project-top"],
+                overlays:get_two_arrows(i),
+                connector:["Bezier", {curviness:(i+1) * 20}]
+            });
         }
         for (i = 0; i < bottom_sibling_windows.length; i++) {
             var bottom_sibling_uuid = bottom_sibling_windows[i].getAttribute("id") + "-top";
             instance.addEndpoint(bottom_sibling_windows[i], {uuid:bottom_sibling_uuid, anchor:"Top"});
-            instance.connect({uuids:[bottom_sibling_uuid, "project-bottom"], overlays:two_arrows});
+            instance.connect({
+                uuids:[bottom_sibling_uuid, "project-bottom"],
+                overlays:get_two_arrows(i),
+                connector:["Bezier", {curviness:(i+1) * 20}]
+            });
         }
         for (i = 0; i < child_windows.length; i++) {
             var child_uuid = child_windows[i].getAttribute("id") + "-left";
             instance.addEndpoint(child_windows[i], {uuid:child_uuid, anchor:"Left"});
-            instance.connect({uuids:["project-right", child_uuid], overlays:arrow});
+            instance.connect({
+                uuids:["project-right", child_uuid],
+                overlays:arrow,
+                connector:["Bezier", {curviness:(i+1) * 20}]
+            });
         }
     });
 });

--- a/akvo/rsr/static/scripts-src/project-hierarchy.js
+++ b/akvo/rsr/static/scripts-src/project-hierarchy.js
@@ -33,6 +33,8 @@ jsPlumb.ready(function() {
         var i;
 
         if (top_sibling_windows.length) {
+            // Iterate over top siblings in reverse for symmetry with bottom
+            top_sibling_windows = top_sibling_windows.get().reverse();
             instance.addEndpoint(project_window, {uuid: "project-top", anchor: "Top", maxConnections: -1});
         }
         if (bottom_sibling_windows.length) {
@@ -51,7 +53,7 @@ jsPlumb.ready(function() {
             instance.connect({
                 uuids:[parent_uuid, "project-left"],
                 overlays:arrow,
-                connector:["Bezier", {curviness:(i+1) * 20}]
+                connector:["Bezier", {curviness:20}]
             });
         }
         for (i = 0; i < top_sibling_windows.length; i++) {
@@ -60,7 +62,7 @@ jsPlumb.ready(function() {
             instance.connect({
                 uuids:[top_sibling_uuid, "project-top"],
                 overlays:get_two_arrows(i),
-                connector:["Bezier", {curviness:(i+1) * 20}]
+                connector:["Bezier", {curviness:((i+1) * 20) % 100}]
             });
         }
         for (i = 0; i < bottom_sibling_windows.length; i++) {
@@ -69,7 +71,7 @@ jsPlumb.ready(function() {
             instance.connect({
                 uuids:[bottom_sibling_uuid, "project-bottom"],
                 overlays:get_two_arrows(i),
-                connector:["Bezier", {curviness:(i+1) * 20}]
+                connector:["Bezier", {curviness:((i+1) * 10) % 100}]
             });
         }
         for (i = 0; i < child_windows.length; i++) {
@@ -78,7 +80,7 @@ jsPlumb.ready(function() {
             instance.connect({
                 uuids:["project-right", child_uuid],
                 overlays:arrow,
-                connector:["Bezier", {curviness:(i+1) * 20}]
+                connector:["Bezier", {curviness:20}]
             });
         }
     });

--- a/akvo/templates/project_hierarchy.html
+++ b/akvo/templates/project_hierarchy.html
@@ -13,6 +13,8 @@
             <div class="col-sm-12 hidden-xs project-hierarchy small" id="project-hierarchy">
                 {% for row in hierarchy_grid %}
                 <div class="row">
+                    {# parent node #}
+
                     {% if row.0.0 %}
                     <a href="{% url 'project-hierarchy' row.0.0.pk %}">
                         <div class="project-hierarchy-window project-hierarchy-{{row.0.1}}" id="project-hierarchy-{{row.0.1}}{{forloop.counter}}">{{row.0.0.title}}</div>
@@ -20,6 +22,9 @@
                     {% else %}
                     <div class="project-hierarchy-empty-window"></div>
                     {% endif %}
+
+                    {# project node/sibling nodes #}
+
                     {% if row.1.0 and not row.1.1 == 'project' %}
                     <a href="{% url 'project-hierarchy' row.1.0.pk %}">
                         <div class="project-hierarchy-window project-hierarchy-{{row.1.1}}" id="project-hierarchy-{{row.1.1}}{{forloop.counter}}">{{row.1.0.title}}</div>
@@ -29,6 +34,9 @@
                     {% else %}
                     <div class="project-hierarchy-empty-window"></div>
                     {% endif %}
+
+                    {# child nodes #}
+
                     {% if row.2.0 %}
                     <a href="{% url 'project-hierarchy' row.2.0.pk %}">
                         <div class="project-hierarchy-window project-hierarchy-{{row.2.1}}" id="project-hierarchy-{{row.2.1}}{{forloop.counter}}">{{row.2.0.title}}</div>
@@ -36,6 +44,7 @@
                     {% else %}
                     <div class="project-hierarchy-empty-window"></div>
                     {% endif %}
+
                 </div>
                 {% endfor %}
             </div>


### PR DESCRIPTION
To avoid overlaps, the arrows are placed at slightly different positions
based on the index of the connector for which we are using an arrow, and
the curviness of the connectors is also changed.

| Before        | After         |
| ------------- |---------------|
| ![mon oct 3 16 58 30 ist 2016](https://cloud.githubusercontent.com/assets/315678/19036071/269c2804-898b-11e6-85ba-6bad606227bc.jpg)      | ![mon oct 3 16 57 39 ist 2016](https://cloud.githubusercontent.com/assets/315678/19036057/1e267508-898b-11e6-9f90-d1a012da6498.jpg)  |


