### PR TITLE
[#1577] Check project update photo file extension

### DIFF
--- a/akvo/rest/fields.py
+++ b/akvo/rest/fields.py
@@ -60,14 +60,14 @@ class Base64ImageField(ImageField):
             file_name = str(uuid.uuid4())[:12] # 12 characters are more than enough.
             # Get the file name extension:
             file_extension = self.get_file_extension(file_name, decoded_file)
-            if file_extension not in self.ALLOWED_IMAGE_TYPES:
-                raise serializers.ValidationError(
-                    _(u"The type of the image couldn't been determined.")
-                )
+            self.check_file_extension(file_extension)
             complete_file_name = file_name + "." + file_extension
             data = ContentFile(decoded_file, name=complete_file_name)
         else:
             data = base64_data
+            file_extension = self.get_file_extension(data.name, data.read())
+            self.check_file_extension(file_extension)
+            data.seek(0)
 
         return super(Base64ImageField, self).from_native(data)
 
@@ -154,3 +154,10 @@ class Base64ImageField(ImageField):
         extension = imghdr.what(filename, decoded_file)
         extension = "jpg" if extension == "jpeg" else extension
         return extension
+
+    def check_file_extension(self, file_extension):
+        if file_extension not in self.ALLOWED_IMAGE_TYPES:
+            formats = {'format': ', '.join(self.ALLOWED_IMAGE_TYPES)}
+            raise serializers.ValidationError(
+                _(u"Unknown image type. Only the following types are accepted: %(format)s") % formats
+            )


### PR DESCRIPTION
When the POST has a multipart-encoded file, the file extension checks
don't happen, and unknown file types don't give a proper error.  This
commit adds a check on the file type even for these cases.