### PR TITLE
Add a donations field to Projects

### DIFF
--- a/akvo/rsr/admin.py
+++ b/akvo/rsr/admin.py
@@ -901,7 +901,7 @@ class ProjectAdmin(TimestampsAdminDisplayMixin, ObjectPermissionsModelAdmin, Nes
                 u'You can define the budget information as a total for the whole project or within sections and '
                 u'periods to provide more granular information about where the project funds are being spent.'
             ),
-            'fields': ('capital_spend_percentage', ),
+            'fields': ('capital_spend_percentage', 'donations', ),
         }),
         (_(u'Project Financials - Transactions'), {
             'description': u'<p style="margin-left:0; padding-left:0; margin-top:1em; width:75%%;">%s</p>' % _(

--- a/akvo/rsr/migrations/0085_auto_20160920_1448.py
+++ b/akvo/rsr/migrations/0085_auto_20160920_1448.py
@@ -4,6 +4,22 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 
 
+def aggregate_donations(apps, schema_editor):
+    # We can't import the models directly as they may be a newer version than
+    # this migration expects. We use the historical versions.
+    Project = apps.get_model("rsr", "Project")
+    Invoice = apps.get_model("rsr", "Invoice")
+
+    for project in Project.objects.all():
+        STATUS_COMPLETE = 3
+        project_invoices = Invoice.objects.filter(project__exact=project.id)
+        completed_invoices = project_invoices.filter(status__exact=STATUS_COMPLETE).exclude(test=True)
+        donations = completed_invoices.aggregate(models.Sum('amount_received'))['amount_received__sum']
+        if donations is not None:
+            project.donations = donations
+            project.save()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -21,4 +37,12 @@ class Migration(migrations.Migration):
             field=models.URLField(help_text='Add a donation url for this project. If no URL is added, it is not possible to donate to this project through RSR.', null=True, verbose_name='donate url', blank=True),
             preserve_default=True,
         ),
+        migrations.AddField(
+            model_name='project',
+            name='donations',
+            field=models.DecimalField(decimal_places=2, default=0, max_digits=14, blank=True, help_text='The total sum of donations the project has already recieved.', null=True, db_index=True),
+            preserve_default=True,
+        ),
+        # Reverse migrations don't work by default if there's no reverse_code
+        migrations.RunPython(aggregate_donations, reverse_code=lambda x, y: None)
     ]

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -443,6 +443,12 @@ class Project(TimestampsMixin, models.Model):
         if self.pk:
             orig = Project.objects.get(pk=self.pk)
 
+            # Update funds and funds_needed if donations change.  Any other
+            # changes (budget, pledged amounts, ...) are handled by signals.
+            if self.donations != orig.donations:
+                self.funds = self.get_funds()
+                self.funds_needed = self.get_funds_needed()
+
             # Update legacy status field
             if self.iati_status != orig.iati_status:
                 self.status = self.CODE_TO_STATUS[self.iati_status]

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -296,10 +296,15 @@ class Project(TimestampsMixin, models.Model):
 
     # donate url
     donate_url = models.URLField(
-        # FIXME: _(u'donate url') may need fixes?
         _(u'donate url'), null=True, blank=True, max_length=200,
         help_text=_(u'Add a donation url for this project. If no URL is added, it is not possible '
                     u'to donate to this project through RSR.')
+    )
+
+    # donations
+    donations = models.DecimalField(
+        max_digits=14, decimal_places=2, blank=True, null=True, db_index=True, default=0,
+        help_text=_(u'The total sum of donations the project has already recieved.')
     )
 
     # extra IATI fields
@@ -551,7 +556,7 @@ class Project(TimestampsMixin, models.Model):
 
     def get_funds(self):
         """ All money given to a project"""
-        return self.get_pledged()
+        return self.donations + self.get_pledged()
 
     def update_funds(self):
         "Update de-normalized field"

--- a/akvo/rsr/tests/models/test_project.py
+++ b/akvo/rsr/tests/models/test_project.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 
 from django.contrib.auth import get_user_model
 
-from akvo.rsr.models import Partnership, Project, ProjectUpdate
+from akvo.rsr.models import BudgetItem, Partnership, Project, ProjectUpdate
 
 
 class ProjectModelTestCase(TestCase):
@@ -48,19 +48,23 @@ class ProjectModelTestCase(TestCase):
 
         # setup needed model instances
         project_1 = Project.objects.create(title="Test project 1")
+        budget_item = BudgetItem.objects.create(project=project_1, amount=200)
 
         # Change donations
         project_1.donations = 100
         project_1.save()
 
         # assert that funds for the project are correct
+        self.assertEqual(project_1.budget, budget_item.amount)
         self.assertEqual(project_1.donations, project_1.funds)
+        self.assertEqual(project_1.funds_needed, project_1.budget - project_1.funds)
 
     def test_project_funds_update_on_pledges_change(self):
         """Test that Project.funds is correct when pledged amounts change."""
 
         # setup needed model instances
         project_1 = Project.objects.create(title="Test project 1")
+        budget_item = BudgetItem.objects.create(project=project_1, amount=200)
         partnership = Partnership.objects.create(
             iati_organisation_role=Partnership.IATI_FUNDING_PARTNER,
             project=project_1, funding_amount=100
@@ -73,4 +77,6 @@ class ProjectModelTestCase(TestCase):
         project_1.save()
 
         # assert that funds for the project are correct
+        self.assertEqual(project_1.budget, budget_item.amount)
         self.assertEqual(project_1.funds, partnership.funding_amount + project_1.donations)
+        self.assertEqual(project_1.funds_needed, project_1.budget - project_1.funds)

--- a/akvo/templates/project_main_tabs/finance.html
+++ b/akvo/templates/project_main_tabs/finance.html
@@ -55,6 +55,12 @@
                           <dt class="totalFinance">{% trans "Total" %}:</dt><dd class="totalFinance currencyAmount">{{pledged|floatformat:0|intcomma}}<span class="currency"> {{project.currency}}</span></dd>
                       {% endif %}
                   </dl>
+                  {% if project.donations or project.donate_url %}
+                    <h4>{% trans "Donations" %}:</h4>
+                    <dl class="dl-horizontal">
+                      <dt>{% trans "Total" %}:</dt><dd class="currencyAmount">{{project.donations|floatformat:0|intcomma}}<span class="currency"> {{project.currency}}</span></dd>
+                    </dl>
+                  {% endif %}
                   {% if project.accepts_donations %}
                     <dl class="dl-horizontal">
                       <div class="donateButton">
@@ -67,6 +73,9 @@
                   <h4 class="">{% trans "Project funding" %}:</h4>
                   <dl class="dl-horizontal">
                       <dt>{% trans "Current funders" %}:</dt><dd class="currencyAmount">{% if pledged %}{{pledged|floatformat:0|intcomma}}{% else %}0{% endif %}<span class="currency"> {{project.currency}}</span></dd>
+                      {% if project.donations or project.donate_url %}
+                      <dt>{% trans "Donations" %}:</dt><dd class="currencyAmount">{{project.donations|floatformat:0|intcomma}}<span class="currency"> {{project.currency}}</span></dd>
+                      {% endif %}
                       <hr>
                       <dt>{% trans "Total funded" %}:</dt><dd class="currencyAmount">{{project.funds|floatformat:0|intcomma}}<span class="currency"> {{project.currency}}</span></dd>
                       <dt>{% trans "Project budget" %}:</dt>


### PR DESCRIPTION
- [x] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry

This is a follow-up pull-request to #2376. 

This PR adds a `donations` field on the `Project` model is used to keep track of any old donations that projects on the platform have already received.  In future, it can be used to keep track of donations received outside of RSR by manually updating it.

It also modifies an already merged migration (but not yet deployed), to populate the `donations` field correctly, for projects with donations.