### PR TITLE
[#2417] project_update API POST fails when photo is None

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,10 @@
 
 ## Bug fixes
 
+[#2417] (https://github.com/akvo/akvo-rsr/issues/2417) Fix bug in API calls
+which accept an image, which can be None, for example deleting project photo
+from the project editor.
+
 [#2421] (https://github.com/akvo/akvo-rsr/issues/2421) RSR User management page
 in the French site will now correctly show the user list.
 

--- a/akvo/rest/fields.py
+++ b/akvo/rest/fields.py
@@ -48,8 +48,10 @@ class Base64ImageField(ImageField):
         'png',
     )
     def from_native(self, base64_data):
+        if base64_data is None:
+            data = base64_data
         # Check if this is a base64 string
-        if isinstance(base64_data, basestring):
+        elif isinstance(base64_data, basestring):
             # Try to decode the file. Return validation error if it fails.
             try:
                 decoded_file = base64.b64decode(base64_data)

--- a/akvo/rsr/tests/rest/test_project_update.py
+++ b/akvo/rsr/tests/rest/test_project_update.py
@@ -119,6 +119,22 @@ class RestProjectUpdateTestCase(TestCase):
                                })
         self.assertEqual(response.status_code, 201)
 
+    def test_rest_post_project_update_photo_none(self):
+        """
+        Checks posting a project update with photo being None
+        """
+
+        self.c.login(username=self.user.username, password='password')
+        response = self.c.post('/rest/v1/project_update/?format=json',
+                               json.dumps({
+                                   'project': self.project.pk,
+                                   'user': self.user.pk,
+                                   'title': 'Allowed',
+                                   'photo': None,
+                               }),
+                               content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+
     def test_rest_post_project_update_wmf_string(self):
         """
         Checks posting a project update with a WMF photo base64 encoded.


### PR DESCRIPTION
- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

This bug was introduced in 1aa60508350d4477c1f0964db7f3c124d9d1bc01

Any API POST where 'photo' field is None would fail, but I don't yet know what exact user action triggered this report: http://sentry.support.akvo-ops.org/rsr/live/group/1017/

Closes #2417 