### PR TITLE
[#2398] Fix users not showing when a user has no groups

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,10 @@
 number of projects in data quality reports if an organisation has multiple
 partnership roles for a project.
 
+[#2398] (https://github.com/akvo/akvo-rsr/issues/2398) Fix empty user
+management page when a user in a page has an employment that does not have a
+group defined.
+
 [#2424] (https://github.com/akvo/akvo-rsr/issues/2424) Optimize how queryset filtering based on permissions is made. This is necessary since some filtering is taking so long that the request times out before completing.  The fix is based around parsing the django-rules predicates and turning them into Django Q object queryset filters. This results in speedup of at least an order of magnitude for complex filters.
 
 [#2417] (https://github.com/akvo/akvo-rsr/issues/2417) Fix bug in API calls

--- a/akvo/rsr/migrations/0087_auto_20161110_0920.py
+++ b/akvo/rsr/migrations/0087_auto_20161110_0920.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def fix_employment_groups(apps, schema_editor):
+    # We can't import the Employment or Group model directly as it may be a
+    # newer version than this migration expects. We use the historical version.
+    Group = apps.get_model("auth", "Group")
+    Employment = apps.get_model("rsr", "Employment")
+    for employment in Employment.objects.filter(group=None):
+        employment.group = Group.objects.get(name='Users')
+        employment.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rsr', '0086_auto_20160921_0947'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_employment_groups),
+    ]

--- a/akvo/rsr/static/scripts-src/my-user-management.js
+++ b/akvo/rsr/static/scripts-src/my-user-management.js
@@ -380,8 +380,8 @@ function initReact() {
                     React.createElement(Button, {onClick: this.deleteEmployment, bsStyle: "danger"}, i18n.remove_button_text)
                 )
             );
-
-            if (this.props.employment.group.name === 'Admins' && !orgAdmin) {
+            var group = this.props.employment.group;
+            if (group && group.name === 'Admins' && !orgAdmin) {
                 return (
                     React.DOM.span(null )
                 );
@@ -475,7 +475,8 @@ function initReact() {
                 )
             );
 
-            if (this.props.employment.group.name === 'Admins' && !orgAdmin) {
+            var group = this.props.employment.group;
+            if (group && group.name === 'Admins' && !orgAdmin) {
                 return (
                     React.DOM.span(null )
                 );
@@ -554,7 +555,8 @@ function initReact() {
         },
 
         disableButton: function() {
-            return (this.state.loading || (this.props.employment.group.name === 'Admins' && !orgAdmin));
+            var group = this.props.employment.group;
+            return (this.state.loading || (group && group.name === 'Admins' && !orgAdmin));
         },
 
         render: function() {

--- a/akvo/rsr/static/scripts-src/my-user-management.jsx
+++ b/akvo/rsr/static/scripts-src/my-user-management.jsx
@@ -380,8 +380,8 @@ function initReact() {
                     React.createElement(Button, {onClick: this.deleteEmployment, bsStyle: "danger"}, i18n.remove_button_text)
                 )
             );
-
-            if (this.props.employment.group.name === 'Admins' && !orgAdmin) {
+            var group = this.props.employment.group;
+            if (group && group.name === 'Admins' && !orgAdmin) {
                 return (
                     <span />
                 );
@@ -475,7 +475,8 @@ function initReact() {
                 )
             );
 
-            if (this.props.employment.group.name === 'Admins' && !orgAdmin) {
+            var group = this.props.employment.group;
+            if (group && group.name === 'Admins' && !orgAdmin) {
                 return (
                     <span />
                 );
@@ -554,7 +555,8 @@ function initReact() {
         },
 
         disableButton: function() {
-            return (this.state.loading || (this.props.employment.group.name === 'Admins' && !orgAdmin));
+            var group = this.props.employment.group;
+            return (this.state.loading || (group && group.name === 'Admins' && !orgAdmin));
         },
 
         render: function() {


### PR DESCRIPTION
- [ ] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

The user management page doesn't show any users when a single employment
shown on a page doesn't have a group assigned.  The post_save signal on
Employments actually tries to ensure that all Employments actually have
a Group and uses the 'Users' group as default.  But, the current DB
seems to have at least one Employment without a Group.

Fixes #2398 

Ideally, this should come with a data migration to fix any employments that don't have a group assigned. But, I'm not sure if we can should get that in, before a release.  I'll try working on that, now. This bug seemed like something that's an edge case that won't happen in the live DB, but it is currently happening. Hence, a "quick-fix".  