### PR TITLE
[#2450] Don't runserver when running tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,6 @@ before_install:
 install:
   - pip install -r scripts/deployment/pip/requirements/2_rsr.txt
 
-before_script:
-  - psql -c 'CREATE DATABASE travis_test;' -U postgres
-  - python manage.py migrate --noinput
-  - python manage.py runserver &
-
 script:
   - python manage.py collectstatic --noinput
   - coverage run manage.py test akvo


### PR DESCRIPTION
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry

This allows us to skip migrations on Travis, saving a lot of time when
running the tests.