### PR TITLE
#2374 Prevent duplicate employments

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+# Currently on `develop`
+
+## Bug fixes
+
+[#2374] (https://github.com/akvo/akvo-rsr/issues/2374) Prevent duplicate
+employments to the same organisation & group.
+
 # Akvo RSR version 3.18 Vilnius
 
 ## Bug fixes

--- a/akvo/rest/views/user.py
+++ b/akvo/rest/views/user.py
@@ -100,7 +100,7 @@ def request_organisation(request, pk=None):
     # request.user is the user identified by the auth token
     user = request.user
     # Users themselves are only allowed to request to join an organisation
-    if not user_by_pk == request.user:
+    if not user_by_pk == user:
         raise PermissionDenied()
     request.DATA['user'] = pk
 
@@ -109,14 +109,13 @@ def request_organisation(request, pk=None):
     if serializer.is_valid():
         try:
             organisation = Organisation.objects.get(pk=serializer.data['organisation'])
-            employment = Employment(
+            employment = Employment.objects.create(
                 user=user,
                 organisation=organisation,
                 country=serializer.data['country'],
                 job_title=serializer.data['job_title'],
                 is_approved=False,
             )
-            employment.save()
         except IntegrityError:
             return Response({'detail': _(u'User already linked to this organisation')},
                             status=status.HTTP_409_CONFLICT)

--- a/akvo/rsr/signals.py
+++ b/akvo/rsr/signals.py
@@ -169,6 +169,9 @@ def act_on_log_entry(sender, **kwargs):
 def employment_pre_save(sender, **kwargs):
     """
     This signal intends to send a mail to the user when his/her account has been approved.
+
+    This signal also sets 'Users' Group for the employment if no group has been set
+
     A mail will be sent when:
 
     - A new employment is created with is_approved = True.
@@ -176,7 +179,12 @@ def employment_pre_save(sender, **kwargs):
     - An existing employment is updated from is_approved = False changed to True.
       * We assume this happens when an existing user has requested to join an organisation himself.
     """
+    # FIXME: The actual save may fail. Why are emails being sent pre_save?!
     employment = kwargs.get("instance", None)
+
+    # Set the group to 'Users' when no group has been specified
+    if not employment.group:
+        employment.group = Group.objects.get(name='Users')
 
     try:
         obj = sender.objects.get(pk=employment.pk)
@@ -218,13 +226,11 @@ def employment_post_save(sender, **kwargs):
     - Set User to is_staff (for admin access) when the employment is approved and the Group is set
       to 'Project Editors', 'User managers' or 'Admins', or when the user is a superuser or general
       admin.
-    - Set 'Users' Group for the employment if no group has been set
 
     If a new employment is created for an active user of which the employment is not approved yet:
     - Inform RSR support users, organisation admins and organisation user managers of the request
     """
     # Retrieve all user groups and the employment
-    users_group = Group.objects.get(name='Users')
     project_editors_group = Group.objects.get(name='Project Editors')
     user_managers_group = Group.objects.get(name='User Managers')
     admins_group = Group.objects.get(name='Admins')
@@ -238,11 +244,6 @@ def employment_post_save(sender, **kwargs):
                 employment.is_approved) or user.is_superuser or user.is_admin:
             user.is_staff = True
             user.save()
-
-        # Set the group to 'Users' when no group has been specified
-        if not employment.group:
-            employment.group = users_group
-            employment.save()
 
         # Send an 'Organisation request' mail when an employment has been newly created, the
         # user is active and the employment has not been approved yet.

--- a/akvo/rsr/tests/rest/test_user.py
+++ b/akvo/rsr/tests/rest/test_user.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+"""
+Akvo RSR is covered by the GNU Affero General Public License.
+
+See more details in the license.txt file located at the root folder of the Akvo RSR module.
+For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+"""
+
+from __future__ import print_function
+
+from django.conf import settings
+from django.test import TransactionTestCase, Client
+
+from akvo.rsr.models import Employment, Organisation, User
+from akvo.utils import check_auth_groups
+
+
+# NOTE: Since these tests actually trigger some integrity errors and we want to
+# see if they are handled correctly, we use a TransactionTestCase instead of
+# TestCase, since wrapping the tests in a transaction isn't desirable.
+
+class UserTestCase(TransactionTestCase):
+    """Tests REST endpoints in views/user.py."""
+
+    def setUp(self):
+        check_auth_groups(settings.REQUIRED_AUTH_GROUPS)
+        self.c = Client(HTTP_HOST=settings.RSR_DOMAIN)
+        self.org = Organisation.objects.create(name='akvo', long_name='akvo foundation')
+        self.user_password = 'password'
+        self.user = self._create_user('abc@example.com', self.user_password)
+        self.c.login(username=self.user.username, password=self.user_password)
+
+    def test_request_organisation_once(self):
+        # Given
+        data = {'organisation': self.org.id}
+        pk = self.user.id
+
+        # When
+        response = self.c.post(
+            '/rest/v1/user/{}/request_organisation/?format=json'.format(pk), data
+        )
+
+        # Then
+        self.assertEqual(response.status_code, 200)
+        employment = Employment.objects.get(user=self.user, organisation_id=self.org.id)
+        self.assertEqual(employment.group.name, 'Users')
+
+    def test_request_organisation_twice(self):
+        # Given
+        data = {'organisation': self.org.id}
+        pk = self.user.id
+        self.c.post('/rest/v1/user/{}/request_organisation/?format=json'.format(pk), data)
+
+        # When
+        response = self.c.post(
+            '/rest/v1/user/{}/request_organisation/?format=json'.format(pk), data
+        )
+
+        # Then
+        self.assertEqual(response.status_code, 409)
+        employment = Employment.objects.get(user=self.user, organisation_id=self.org.id)
+        self.assertEqual(employment.group.name, 'Users')
+
+    def _create_user(self, email, password, is_active=True):
+        """Create a user with the given email and password."""
+
+        user = User.objects.create(email=email, username=email, is_active=is_active)
+        user.set_password(password)
+        user.save()
+
+        return user


### PR DESCRIPTION
- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

Employments are forced to have a non-null group, though the model does
allow null values, by trying to set a default group in the post_save.
But, this can fail if such an employment already exists, thus creating
an employment with a null group.  Multiple such employments with a null
group can get created, too.

This commit moves the setting of the group to the pre_save signal, thus
preventing an invalid employment from getting created.

Closes #2374, Closes #2122