### PR TITLE
[#2473] Test environment password dialog loses focus

### DIFF
--- a/akvo/rsr/static/scripts-src/cookie.js
+++ b/akvo/rsr/static/scripts-src/cookie.js
@@ -125,8 +125,7 @@ function createModal(){
                                     value: this.state.passwordField,
                                     onChange: this.handleChange,
                                     className: 'form-control'
-                                },
-                                this.state.passwordField
+                                }
                             )
                         ),
                         errorNode,

--- a/akvo/rsr/static/scripts-src/cookie.jsx
+++ b/akvo/rsr/static/scripts-src/cookie.jsx
@@ -125,8 +125,7 @@ function createModal(){
                                     value: this.state.passwordField,
                                     onChange: this.handleChange,
                                     className: 'form-control'
-                                },
-                                this.state.passwordField
+                                }
                             )
                         ),
                         errorNode,


### PR DESCRIPTION
- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

React.createElement is incorrectly passed a text field as the `children`
argument.  This causes invalid HTML (`<input>user-input</input>`) to be
generated and causes the input element to lose focus while typing.

Thanks to @gabemart for the fix!

Closes #2473