### PR TITLE
[#2479] Prompt using a different browser if geolocation disabled

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,10 @@ GitHub issue: [#2430](https://github.com/akvo/akvo-rsr/issues/2430)
 
 ## Bug fixes
 
+[#2479](https://github.com/akvo/akvo-rsr/issues/2479) Prompt user to use a
+different browser if GeoLocation API is only allowed on secure origins by the
+browser.
+
 [#2374](https://github.com/akvo/akvo-rsr/issues/2374) Prevent duplicate
 employments to the same organisation & group.
 

--- a/akvo/templates/update_add.html
+++ b/akvo/templates/update_add.html
@@ -77,11 +77,19 @@
   $( "#id_latitude").val(0);
   $( "#id_longitude").val(0);
   if (navigator.geolocation) {
-    navigator.geolocation.getCurrentPosition(storePosition);
+    navigator.geolocation.getCurrentPosition(storePosition, geolocationDisabled);
   }
   function storePosition(position) {
     $( "#id_latitude").val(position.coords.latitude);
     $( "#id_longitude").val(position.coords.longitude);
+  }
+  function geolocationDisabled(failure) {
+      if(failure.message.indexOf("Only secure origins are allowed") == 0) {
+          // Secure Origin issue.
+          alert("Your browser doesn't support getting location on non-https"
+                + " sites. If you want your location to be shared, please use"
+                + " another browser");
+      }
   }
 
 $('#id_photo').bind('change', function() {


### PR DESCRIPTION
- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

This fixes the problem of some `ProjectUpdate`s not having a location, since
Chrome >= v50 has disabled GeoLocation API on insecure origins.

Closes #2479 

## Test Plan

Click on the "Add an update" button in the top bar, in Chrome >= v50.  You should be shown an alert message asking you to use another browser.  Doing this in another browser should not show the message. 