### PR TITLE
[#2298] Fix requesting organization from UP app

### DIFF
--- a/akvo/rest/views/user.py
+++ b/akvo/rest/views/user.py
@@ -89,8 +89,11 @@ def update_details(request, pk=None):
 @authentication_classes([SessionAuthentication, TastyTokenAuthentication])
 def request_organisation(request, pk=None):
 
-    if 'group' not in request.data:
-        request.data['group'] = ''
+    # Add missing keys to request.data to simplify code and getting working
+    # with DRF-3 Serializer
+    for key in ('group', 'country', 'job_title'):
+        if key not in request.data:
+            request.data[key] = ''
 
     # Get the user, or return an error if the user does not exist
     try:

--- a/akvo/rsr/tests/rest/test_user.py
+++ b/akvo/rsr/tests/rest/test_user.py
@@ -31,6 +31,21 @@ class UserTestCase(TransactionTestCase):
         self.user = self._create_user('abc@example.com', self.user_password)
         self.c.login(username=self.user.username, password=self.user_password)
 
+    def test_request_organisation_simple(self):
+        # Given
+        data = {'organisation': self.org.id}
+        pk = self.user.id
+
+        # When
+        response = self.c.post(
+            '/rest/v1/user/{}/request_organisation/?format=json'.format(pk), data
+        )
+
+        # Then
+        self.assertEqual(response.status_code, 200)
+        employment = Employment.objects.get(user=self.user, organisation_id=self.org.id)
+        self.assertEqual(employment.group.name, 'Users')
+
     def test_request_organisation_once(self):
         # Given
         data = {'organisation': self.org.id, 'country': '', 'job_title': ''}


### PR DESCRIPTION
With the DRF 3 update, the serializers behave slightly differently -- Default
values are not returned for data not passed explicitly to the serializer as
initial data.  This commit explicitly adds required values to the initial data.


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
