### PR TITLE
[#2298] Allow updates to be posted with no photo_{caption,credit}

### DIFF
--- a/akvo/rest/serializers/project_update.py
+++ b/akvo/rest/serializers/project_update.py
@@ -21,15 +21,30 @@ class ProjectUpdateSerializer(BaseRSRSerializer):
 
     locations = ProjectUpdateLocationNestedSerializer(many=True, required=False)
     photo = Base64ImageField(required=False, allow_empty_file=True, allow_null=True)
+    video = serializers.URLField(required=False, allow_null=True)
+
+    # Allow null values for {photo,video}_{caption,credit} for UP app
+    photo_caption = serializers.CharField(required=False, allow_null=True)
+    photo_credit = serializers.CharField(required=False, allow_null=True)
+    video_caption = serializers.CharField(required=False, allow_null=True)
+    video_credit = serializers.CharField(required=False, allow_null=True)
 
     class Meta:
         model = ProjectUpdate
 
     def create(self, validated_data):
         locations_data = validated_data.pop('locations', [])
+
+        # Remove {photo,video}_{caption,credit} if they are None (happens, for
+        # instance, when these values are not filled in the UP app)
+        for key in ('photo_credit', 'photo_caption', 'video_credit', 'video_caption'):
+            if key in validated_data and validated_data[key] is None:
+                validated_data.pop(key)
         update = ProjectUpdate.objects.create(**validated_data)
+
         for location_data in locations_data:
             ProjectUpdateLocation.objects.create(location_target=update, **location_data)
+
         return update
 
 class ProjectUpdateDeepSerializer(ProjectUpdateSerializer):


### PR DESCRIPTION
- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

Updates fail with a 400 when the photo caption/credit fields are not filled up, in the RSR UP app.  This commit restores backward compatibility in this aspect. 