### PR TITLE
[#2559] Fix broken org logos in the partners tab

### DIFF
--- a/akvo/rsr/static/scripts-src/project-main/project-main-partners.js
+++ b/akvo/rsr/static/scripts-src/project-main/project-main-partners.js
@@ -73,7 +73,7 @@ function renderPartnersTab() {
 
             if (logoUrl !== '') {
                 return (
-                    React.DOM.img( {src:'/media/' + logoUrl, style:logoStyle} )
+                    React.DOM.img( {src:logoUrl, style:logoStyle} )
                 );
             } else {
                 return (

--- a/akvo/rsr/static/scripts-src/project-main/project-main-partners.jsx
+++ b/akvo/rsr/static/scripts-src/project-main/project-main-partners.jsx
@@ -73,7 +73,7 @@ function renderPartnersTab() {
 
             if (logoUrl !== '') {
                 return (
-                    <img src={'/media/' + logoUrl} style={logoStyle} />
+                    <img src={logoUrl} style={logoStyle} />
                 );
             } else {
                 return (


### PR DESCRIPTION
The url is now an absolute url and this breaks loading of partner logos.

Closes #2559


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
