### PR TITLE
[#2561] Fix deletion of files in period updates

### DIFF
--- a/akvo/rest/views/indicator_period_data.py
+++ b/akvo/rest/views/indicator_period_data.py
@@ -47,8 +47,7 @@ class IndicatorPeriodDataCommentViewSet(PublicProjectViewSet):
     serializer_class = IndicatorPeriodDataCommentSerializer
     project_relation = 'data__period__indicator__result__project__'
 
-
-@api_view(['POST'])
+@api_view(['POST', 'DELETE'])
 def indicator_upload_file(request, pk=None):
     """
     Special API call for directly uploading a file.
@@ -56,28 +55,41 @@ def indicator_upload_file(request, pk=None):
     :param request; A Django request object.
     :param pk; The primary key of an IndicatorPeriodData instance.
     """
-    update = IndicatorPeriodData.objects.get(pk=pk)
-    upload_file = request.data['file']
-
     # Permissions
     user = getattr(request, 'user', None)
     if not user:
         return Response({'error': 'User is not logged in'}, status=status.HTTP_403_FORBIDDEN)
-
     # TODO: Check if user is allowed to upload a file
     # if not user.has_perm('rsr.change_project', update.period.indicator.result.project):
     #     return Response({'error': 'User has no permission to place an update'},
     #                     status=status.HTTP_403_FORBIDDEN)
 
-    try:
-        file_type = request.POST.copy()['type']
-        if file_type == 'photo':
-            update.photo = upload_file
-            update.save(update_fields=['photo'])
-            return Response({'file': update.photo.url})
-        elif file_type == 'file':
-            update.file = upload_file
-            update.save(update_fields=['file'])
-            return Response({'file': update.file.url})
-    except Exception as e:
-        return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+    update = IndicatorPeriodData.objects.get(pk=pk)
+    if request.method == 'DELETE':
+        try:
+            if request.data['type'] == 'photo':
+                update.photo = ''
+                update.save(update_fields=['photo'])
+                return Response({}, status=status.HTTP_204_NO_CONTENT)
+            elif request.data['type'] == 'file':
+                update.file = ''
+                update.save(update_fields=['file'])
+                return Response({}, status=status.HTTP_204_NO_CONTENT)
+        except Exception as e:
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+    else: # POST
+        upload_file = request.data['file']
+        try:
+            file_type = request.POST.copy()['type']
+            if file_type == 'photo':
+                update.photo = upload_file
+                update.save(update_fields=['photo'])
+                # Add photo member to be able to distinguish from file URL in new results version
+                # while keeping the old API
+                return Response({'file': update.photo.url, 'photo': update.photo.url})
+            elif file_type == 'file':
+                update.file = upload_file
+                update.save(update_fields=['file'])
+                return Response({'file': update.file.url})
+        except Exception as e:
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)

--- a/akvo/rest/views/indicator_period_data.py
+++ b/akvo/rest/views/indicator_period_data.py
@@ -47,6 +47,7 @@ class IndicatorPeriodDataCommentViewSet(PublicProjectViewSet):
     serializer_class = IndicatorPeriodDataCommentSerializer
     project_relation = 'data__period__indicator__result__project__'
 
+
 @api_view(['POST', 'DELETE'])
 def indicator_upload_file(request, pk=None):
     """
@@ -77,7 +78,7 @@ def indicator_upload_file(request, pk=None):
                 return Response({}, status=status.HTTP_204_NO_CONTENT)
         except Exception as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-    else: # POST
+    else:  # POST
         upload_file = request.data['file']
         try:
             file_type = request.POST.copy()['type']

--- a/akvo/rsr/static/scripts-src/my-iati.jsx
+++ b/akvo/rsr/static/scripts-src/my-iati.jsx
@@ -43,9 +43,8 @@ function apiCall(method, url, data, followPages, successCallback, retries) {
             var response;
             try {
                 response = xmlHttp.responseText !== '' ? JSON.parse(xmlHttp.responseText) : '';
-            }
-            catch (e) {
-                response = {"error": xmlHttp.statusText}
+            } catch (e) {
+                response = {"error": xmlHttp.statusText || e};
             }
             if (xmlHttp.status >= 200 && xmlHttp.status < 400) {
                 if (method === 'GET' && response.next !== undefined) {

--- a/akvo/rsr/static/scripts-src/my-results.js
+++ b/akvo/rsr/static/scripts-src/my-results.js
@@ -13,7 +13,7 @@ var csrftoken,
     isPublic,
     months,
     projectIds,
-    user;
+    user = {};
 
 /* CSRF TOKEN (this should really be added in base.html, we use it everywhere) */
 function getCookie(name) {

--- a/akvo/rsr/static/scripts-src/my-results.js
+++ b/akvo/rsr/static/scripts-src/my-results.js
@@ -317,18 +317,42 @@ function initReact() {
             }, false, false);
         },
 
+        deleteFile: function(type) {
+            // Delete an indicator update and reload the period
+            // var update = this.findUpdate(updateId);
+            // var periodId = update.period;
+            // var url = endpoints.base_url + endpoints.update_and_comments.replace('{update}', updateId);
+
+            var updateId = this.props.update.id;
+            var url = endpoints.file_upload.replace('{update}', updateId);
+            // Reload the period
+            var thisApp = this;
+            var success = function(periodId) {
+                thisApp.props.reloadPeriod(periodId);
+                thisApp.setState({loading: false});
+            };
+            this.setState({loading: true});
+            apiCall('DELETE', url, JSON.stringify({type: type}), success.bind(null, this.props.update.period));
+        },
+
+
         removePhoto: function() {
             // Remove the photo, but keep editing the indicator update.
-            this.baseSave({'photo': ''}, true, false);
+            this.deleteFile('photo');
         },
 
         removeFile: function() {
             // Remove the file, but keep editing the indicator update.
-            this.baseSave({'file': ''}, true, false);
+            this.deleteFile('file');
         },
 
         baseUpload: function(file, type) {
             // Base function for uploading a photo or file to the indicator update.
+            if (file) {
+
+            } else {
+
+            }
             var thisApp = this;
             var updateId = this.props.update.id;
             var url = endpoints.file_upload.replace('{update}', updateId);

--- a/akvo/rsr/static/scripts-src/my-results.js
+++ b/akvo/rsr/static/scripts-src/my-results.js
@@ -318,41 +318,32 @@ function initReact() {
         },
 
         deleteFile: function(type) {
-            // Delete an indicator update and reload the period
-            // var update = this.findUpdate(updateId);
-            // var periodId = update.period;
-            // var url = endpoints.base_url + endpoints.update_and_comments.replace('{update}', updateId);
-
             var updateId = this.props.update.id;
             var url = endpoints.file_upload.replace('{update}', updateId);
-            // Reload the period
             var thisApp = this;
             var success = function(periodId) {
                 thisApp.props.reloadPeriod(periodId);
                 thisApp.setState({loading: false});
             };
             this.setState({loading: true});
-            apiCall('DELETE', url, JSON.stringify({type: type}), success.bind(null, this.props.update.period));
+            apiCall(
+                'DELETE', url,
+                JSON.stringify({type: type}),
+                success.bind(null, this.props.update.period)
+            );
         },
 
 
         removePhoto: function() {
-            // Remove the photo, but keep editing the indicator update.
             this.deleteFile('photo');
         },
 
         removeFile: function() {
-            // Remove the file, but keep editing the indicator update.
             this.deleteFile('file');
         },
 
         baseUpload: function(file, type) {
             // Base function for uploading a photo or file to the indicator update.
-            if (file) {
-
-            } else {
-
-            }
             var thisApp = this;
             var updateId = this.props.update.id;
             var url = endpoints.file_upload.replace('{update}', updateId);

--- a/akvo/rsr/static/scripts-src/my-results.jsx
+++ b/akvo/rsr/static/scripts-src/my-results.jsx
@@ -13,7 +13,7 @@ var csrftoken,
     isPublic,
     months,
     projectIds,
-    user;
+    user = {};
 
 /* CSRF TOKEN (this should really be added in base.html, we use it everywhere) */
 function getCookie(name) {

--- a/akvo/rsr/static/scripts-src/my-results.jsx
+++ b/akvo/rsr/static/scripts-src/my-results.jsx
@@ -317,14 +317,29 @@ function initReact() {
             }, false, false);
         },
 
+        deleteFile: function(type) {
+            var updateId = this.props.update.id;
+            var url = endpoints.file_upload.replace('{update}', updateId);
+            var thisApp = this;
+            var success = function(periodId) {
+                thisApp.props.reloadPeriod(periodId);
+                thisApp.setState({loading: false});
+            };
+            this.setState({loading: true});
+            apiCall(
+                'DELETE', url,
+                JSON.stringify({type: type}),
+                success.bind(null, this.props.update.period)
+            );
+        },
+
+
         removePhoto: function() {
-            // Remove the photo, but keep editing the indicator update.
-            this.baseSave({'photo': ''}, true, false);
+            this.deleteFile('photo');
         },
 
         removeFile: function() {
-            // Remove the file, but keep editing the indicator update.
-            this.baseSave({'file': ''}, true, false);
+            this.deleteFile('file');
         },
 
         baseUpload: function(file, type) {


### PR DESCRIPTION
The attachments in indicator period updates can't be deleted because of changes in how DRF3 handles uploaded files.

Fix by adding DELETE method handling in indicator_upload_file() and corresponding method deleteFile in my-results.jsx


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
