### PR TITLE
[#2454] Honeypot form field in registration

### DIFF
--- a/akvo/rsr/static/styles-src/main.css
+++ b/akvo/rsr/static/styles-src/main.css
@@ -4390,3 +4390,8 @@ div.iatiFilters {
 
 .fa-paperclip, .fa-camera {
   margin-right: 0.3em; }
+
+#id_title {
+  display: none;
+  position: absolute;
+  top: -9999px; }

--- a/akvo/rsr/static/styles-src/main.scss
+++ b/akvo/rsr/static/styles-src/main.scss
@@ -4896,3 +4896,11 @@ div.iatiFilters {
 .fa-paperclip, .fa-camera {
     margin-right: 0.3em;
 }
+
+// Registration honeypot field
+
+#id_title {
+    display: none;
+    position: absolute;
+    top: -9999px;
+}

--- a/akvo/rsr/tests/views/test_account.py
+++ b/akvo/rsr/tests/views/test_account.py
@@ -14,6 +14,7 @@ import json
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.test import TestCase, Client
+from urlparse import urlparse
 
 from akvo.rsr.models import Employment, Organisation, Partnership, Project, User
 from akvo.utils import check_auth_groups
@@ -28,6 +29,9 @@ class AccountTestCase(TestCase):
         self.user_group = Group.objects.get(name='Users')
         self.username = 'user@example.com'
         self.password = 'password'
+        self.title = 'Admiral'
+        self.first_name = 'John'
+        self.last_name = 'Doe'
         self.org1 = Organisation.objects.create(name='akvo', long_name='akvo foundation')
         self.org2 = Organisation.objects.create(name='icco', long_name='icco foundation')
         for org in (self.org1, self.org2):
@@ -126,6 +130,40 @@ class AccountTestCase(TestCase):
             set(Project.objects.filter(publishingstatus__status='published').values_list('id', flat=True)),
             set(edit_projects)
         )
+
+    def test_registration_without_honeypot_filled_in(self):
+        # Given
+        data = dict(
+            first_name=self.first_name,
+            last_name=self.last_name,
+            email=self.username,
+            password1=self.password,
+            password2=self.password,
+        )
+
+        # When
+        response = self.c.post('/en/register/', data=data)
+
+        # Then
+        self.assertEqual(response.status_code, 200)
+
+    def test_registration_with_honeypot_filled_in(self):
+        # Given
+        data = dict(
+            title=self.title,
+            first_name=self.first_name,
+            last_name=self.last_name,
+            email=self.username,
+            password1=self.password,
+            password2=self.password,
+        )
+
+        # When
+        response = self.c.post('/en/register/', data=data)
+
+        # Then
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(urlparse(response._headers['location'][1]).path, '/en/')
 
     def _create_user(self, email, password, is_active=True, is_admin=False):
         """Create a user with the given email and password."""

--- a/akvo/rsr/views/account.py
+++ b/akvo/rsr/views/account.py
@@ -39,6 +39,9 @@ def register(request):
     if request.method == 'POST':
         form = RegisterForm(data=request.POST, files=request.FILES)
         if form.is_valid():
+            #  Honeypot field filled in? If so don't register and redirect to home page
+            if request.POST.get('title'):
+                return redirect('index')
             user = form.save(request)
             return render_to_response('registration/register_complete.html',
                                       {'new_user': user},

--- a/akvo/templates/registration/register.html
+++ b/akvo/templates/registration/register.html
@@ -12,6 +12,8 @@
             <form method="post" action="" name="registrationForm">
                 {% csrf_token %}
                 {% bootstrap_form_errors form type='non_fields' %}
+                {# Experimental honeypot field for registration bots #}
+                <input maxlength="30" name="title" id="id_title" type="text"/>
                 {% for field in form %}
                     {% bootstrap_field field %}
                 {% endfor %}


### PR DESCRIPTION
Add a hidden from field in the registration form. If this field contains data when a POST is made to the register view, discard the form and redirect to the RSR homepage.

The assumption is that if the honeypot field has data a bot has filled it in and we should discard the registration.


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
