### PR TITLE
[#2454] Change id of honeypot field to not match the search bar id

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+## In development
+
+[#2454](https://github.com/akvo/akvo-rsr/issues/2454) Add hidden field to registration form as
+honeypot for bots
+
 # Akvo RSR version 3.22.1 Chisinau hotfix
 
 ## Bug fixes

--- a/akvo/rsr/static/styles-src/main.css
+++ b/akvo/rsr/static/styles-src/main.css
@@ -4391,7 +4391,7 @@ div.iatiFilters {
 .fa-paperclip, .fa-camera {
   margin-right: 0.3em; }
 
-#id_title {
+#id_hp_title {
   display: none;
   position: absolute;
   top: -9999px; }

--- a/akvo/rsr/static/styles-src/main.scss
+++ b/akvo/rsr/static/styles-src/main.scss
@@ -4899,7 +4899,7 @@ div.iatiFilters {
 
 // Registration honeypot field
 
-#id_title {
+#id_hp_title {
     display: none;
     position: absolute;
     top: -9999px;

--- a/akvo/rsr/tests/views/test_account.py
+++ b/akvo/rsr/tests/views/test_account.py
@@ -150,7 +150,7 @@ class AccountTestCase(TestCase):
     def test_registration_with_honeypot_filled_in(self):
         # Given
         data = dict(
-            title=self.title,
+            hp_title=self.title,
             first_name=self.first_name,
             last_name=self.last_name,
             email=self.username,

--- a/akvo/rsr/views/account.py
+++ b/akvo/rsr/views/account.py
@@ -40,7 +40,7 @@ def register(request):
         form = RegisterForm(data=request.POST, files=request.FILES)
         if form.is_valid():
             #  Honeypot field filled in? If so don't register and redirect to home page
-            if request.POST.get('title'):
+            if request.POST.get('hp_title'):
                 return redirect('index')
             user = form.save(request)
             return render_to_response('registration/register_complete.html',

--- a/akvo/templates/registration/register.html
+++ b/akvo/templates/registration/register.html
@@ -13,7 +13,7 @@
                 {% csrf_token %}
                 {% bootstrap_form_errors form type='non_fields' %}
                 {# Experimental honeypot field for registration bots #}
-                <input maxlength="30" name="title" id="id_title" type="text"/>
+                <input maxlength="30" name="hp_title" id="id_hp_title" type="text"/>
                 {% for field in form %}
                     {% bootstrap_field field %}
                 {% endfor %}


### PR DESCRIPTION
The CSS for the honeypot field is getting applied to the search bar in the
project directory since they both have the same id.


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
