### PR TITLE
[#29] Hardcode all urls in emails to use https protocol

### DIFF
--- a/akvo/templates/registration/activation_email.txt
+++ b/akvo/templates/registration/activation_email.txt
@@ -6,7 +6,7 @@
 {% blocktrans %}
 Someone, hopefully you, signed up for a new account at {{site}} using this email address. If it was you, and you'd like to activate and use your account, click the link below or copy and paste it into your web browser's address bar:
 
-{{request.scheme}}://{{site}}{{registration_activate_url}}
+https://{{site}}{{registration_activate_url}}
 
 Note: After you have activated your account, we will review your application and possibly contact you to ensure that the account was created correctly, before the account is enabled. When you are ready to connect with your organisation, you can do so via Akvo RSR website or Akvo RSR mobile application, which you can download from Google Play Store.
 

--- a/akvo/templates/registration/approved_added_email_message.txt
+++ b/akvo/templates/registration/approved_added_email_message.txt
@@ -6,7 +6,7 @@ Dear {{user_name}},
 You have been added to the following organisation on Akvo RSR: {{org_name}}.
 
 Please visit the MyRSR section to view your projects and add updates to the projects here:
-{{request.scheme}}://{{ site }}/myrsr/
+https://{{ site }}/myrsr/
 
 Thank you,
 Akvo.org

--- a/akvo/templates/registration/approved_request_email_message.txt
+++ b/akvo/templates/registration/approved_request_email_message.txt
@@ -6,7 +6,7 @@ Dear {{user_name}},
 Your request to join {{org_name}} on Akvo RSR has been approved.
 
 Please visit the MyRSR section to view your projects and add updates to the projects here:
-{{request.scheme}}://{{ site }}/myrsr/
+https://{{ site }}/myrsr/
 
 Thank you,
 Akvo.org

--- a/akvo/templates/registration/invited_user_message.html
+++ b/akvo/templates/registration/invited_user_message.html
@@ -30,7 +30,7 @@
     <p>Dear Sir or Madam,</p>
     <p>You have been invited to use Akvo RSR by {{ user_name }} linked to the following organisation: {{ org_name }}.</p>
     <p>Please click the following link to activate your account and start using Akvo RSR:</p>
-    <h3><a href="{{request.scheme}}://{{ site }}/activate_invite/{{ user_pk }}/{{ invite_user_pk }}/{{ employment_pk }}/{{ token_date }}/{{ token }}/">Click here to activate your account</a></h3>
+    <h3><a href="https://{{ site }}/activate_invite/{{ user_pk }}/{{ invite_user_pk }}/{{ employment_pk }}/{{ token_date }}/{{ token }}/">Click here to activate your account</a></h3>
     <p>If you believe this mail was not intended for you, you don't need to do anything and you won't receive any more email from us.</p>
     <p>
         Thank you,<br/>

--- a/akvo/templates/registration/invited_user_message.txt
+++ b/akvo/templates/registration/invited_user_message.txt
@@ -6,7 +6,7 @@ Dear Sir or Madam,
 You have been invited to use Akvo RSR by {{ user_name }} linked to the following organisation: {{ org_name }}.
 
 Please click the following link to activate your account and start using Akvo RSR:
-{{request.scheme}}://{{ site }}/activate_invite/{{ user_pk }}/{{ invite_user_pk }}/{{ employment_pk }}/{{ token_date }}/{{ token }}/
+https://{{ site }}/activate_invite/{{ user_pk }}/{{ invite_user_pk }}/{{ employment_pk }}/{{ token_date }}/{{ token }}/
 
 If you believe this mail was not intended for you, you don't need to do anything and you won't receive any more email from us.
 

--- a/akvo/templates/registration/user_organisation_request_message.txt
+++ b/akvo/templates/registration/user_organisation_request_message.txt
@@ -16,7 +16,7 @@ Linked support partners of {{ organisation_name }}:
 
 {% blocktrans %}
 Please check the credentials of this user and then activate here:
-{{request.scheme}}://{{ site }}/myrsr/user_management/
+https://{{ site }}/myrsr/user_management/
 
 Thank you,
 Akvo.org

--- a/akvo/templates/results_framework/approve_update_message.html
+++ b/akvo/templates/results_framework/approve_update_message.html
@@ -39,7 +39,7 @@
         {% endif %}
         <p>{% trans 'Please click the following link to view and approve the update' %}:</p>
         <h3>
-            <a href="{{request.scheme}}://{{ site }}/{{ LANGUAGE_CODE }}/myrsr/results/{{ update.period.indicator.result.project.pk }}/#results,{{ update.period.indicator.result.pk }},{{ update.period.indicator.pk }},{{ update.period.pk }}">
+            <a href="https://{{ site }}/{{ LANGUAGE_CODE }}/myrsr/results/{{ update.period.indicator.result.project.pk }}/#results,{{ update.period.indicator.result.pk }},{{ update.period.indicator.pk }},{{ update.period.pk }}">
                 {% trans 'View and approve the update' %}
             </a>
         </h3>

--- a/akvo/templates/results_framework/approve_update_message.txt
+++ b/akvo/templates/results_framework/approve_update_message.txt
@@ -20,7 +20,7 @@ Comments
 {% endif %}
 
 {% trans 'Please click the following link to view and approve the update' %}:
-{{request.scheme}}://{{ site }}/{{ LANGUAGE_CODE }}/myrsr/results/{{ update.period.indicator.result.project.pk }}/#results,{{ update.period.indicator.result.pk }},{{ update.period.indicator.pk }},{{ update.period.pk }}
+https://{{ site }}/{{ LANGUAGE_CODE }}/myrsr/results/{{ update.period.indicator.result.project.pk }}/#results,{{ update.period.indicator.result.pk }},{{ update.period.indicator.pk }},{{ update.period.pk }}
 
 {% trans 'Thank you' %},
 Akvo.org

--- a/akvo/templates/results_framework/approved_message.html
+++ b/akvo/templates/results_framework/approved_message.html
@@ -39,7 +39,7 @@
         {% endif %}
         <p>{% trans 'Click the following link to view the update' %}:</p>
         <h3>
-            <a href="{{request.scheme}}://{{ site }}/{{ LANGUAGE_CODE }}/myrsr/results/{{ update.period.indicator.result.project.pk }}/#results,{{ update.period.indicator.result.pk }},{{ update.period.indicator.pk }},{{ update.period.pk }}">
+            <a href="https://{{ site }}/{{ LANGUAGE_CODE }}/myrsr/results/{{ update.period.indicator.result.project.pk }}/#results,{{ update.period.indicator.result.pk }},{{ update.period.indicator.pk }},{{ update.period.pk }}">
                 {% trans 'View the update' %}
             </a>
         </h3>

--- a/akvo/templates/results_framework/approved_message.txt
+++ b/akvo/templates/results_framework/approved_message.txt
@@ -20,7 +20,7 @@ Comments
 {% endif %}
 
 {% trans 'Click the following link to view the update' %}:
-{{request.scheme}}://{{ site }}/{{ LANGUAGE_CODE }}/myrsr/results/{{ update.period.indicator.result.project.pk }}/#results,{{ update.period.indicator.result.pk }},{{ update.period.indicator.pk }},{{ update.period.pk }}
+https://{{ site }}/{{ LANGUAGE_CODE }}/myrsr/results/{{ update.period.indicator.result.project.pk }}/#results,{{ update.period.indicator.result.pk }},{{ update.period.indicator.pk }},{{ update.period.pk }}
 
 {% trans 'Thank you' %},
 Akvo.org

--- a/akvo/templates/results_framework/revise_update_message.html
+++ b/akvo/templates/results_framework/revise_update_message.html
@@ -39,7 +39,7 @@
         {% endif %}
         <p>{% trans 'Please click the following link to edit the update' %}:</p>
         <h3>
-            <a href="{{request.scheme}}://{{ site }}/{{ LANGUAGE_CODE }}/myrsr/results/{{ update.period.indicator.result.project.pk }}/#results,{{ update.period.indicator.result.pk }},{{ update.period.indicator.pk }},{{ update.period.pk }}">
+            <a href="https://{{ site }}/{{ LANGUAGE_CODE }}/myrsr/results/{{ update.period.indicator.result.project.pk }}/#results,{{ update.period.indicator.result.pk }},{{ update.period.indicator.pk }},{{ update.period.pk }}">
                 {% trans 'Edit the update' %}
             </a>
         </h3>

--- a/akvo/templates/results_framework/revise_update_message.txt
+++ b/akvo/templates/results_framework/revise_update_message.txt
@@ -20,7 +20,7 @@ Comments
 {% endif %}
 
 {% trans 'Please click the following link to edit the update' %}:
-{{request.scheme}}://{{ site }}/{{ LANGUAGE_CODE }}/myrsr/results/{{ update.period.indicator.result.project.pk }}/#results,{{ update.period.indicator.result.pk }},{{ update.period.indicator.pk }},{{ update.period.pk }}
+https://{{ site }}/{{ LANGUAGE_CODE }}/myrsr/results/{{ update.period.indicator.result.project.pk }}/#results,{{ update.period.indicator.result.pk }},{{ update.period.indicator.pk }},{{ update.period.pk }}
 
 {% trans 'Thank you' %},
 Akvo.org


### PR DESCRIPTION
Email context doesn't have a request and hence request.scheme doesn't work.
Since, we are making https the default, the URLs are hard-coded to use https.


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
