### PR TITLE
Fix problems with Location advanced filter in project directory

### DIFF
--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -953,6 +953,18 @@ class Project(TimestampsMixin, models.Model):
         return False
     is_published.boolean = True
 
+    def publish(self):
+        """Set the publishing status to published."""
+
+        self.publishingstatus.status = PublishingStatus.STATUS_PUBLISHED
+        self.publishingstatus.save()
+
+    def unpublish(self):
+        """Set the publishing status to unpublished."""
+
+        self.publishingstatus.status = PublishingStatus.STATUS_UNPUBLISHED
+        self.publishingstatus.save()
+
     def is_empty(self):
         exclude_fields = ['benchmarks', 'categories', 'created_at', 'crsadd', 'currency',
                           'custom_fields', 'fss', 'iati_checks', 'iati_project_exports',

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -652,7 +652,7 @@ class Project(TimestampsMixin, models.Model):
             [country for country in self.recipient_countries.all()] +
             [
                 location.country for location in self.locations.all()
-                if location.country.iso_code not in country_codes
+                if location.country and location.country.iso_code not in country_codes
             ]
         )
 

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -644,6 +644,18 @@ class Project(TimestampsMixin, models.Model):
                 iati_organisation_role=Partnership.IATI_REPORTING_ORGANISATION
             )
 
+    def countries(self):
+        """Return a list of countries for the project."""
+
+        country_codes = set([c.country.lower() for c in self.recipient_countries.all()])
+        return (
+            [country for country in self.recipient_countries.all()] +
+            [
+                location.country for location in self.locations.all()
+                if location.country.iso_code not in country_codes
+            ]
+        )
+
     class QuerySet(DjangoQuerySet):
         def of_partner(self, organisation):
             "return projects that have organisation as partner"

--- a/akvo/rsr/tests/models/test_partner_site.py
+++ b/akvo/rsr/tests/models/test_partner_site.py
@@ -23,11 +23,9 @@ class PartnerSiteModelTestCase(TestCase):
 
         # Setup a project with results framework and a user
         self.project_1 = Project.objects.create(title="Test project 1")
-        self.project_1.publishingstatus.status = PublishingStatus.STATUS_PUBLISHED
-        self.project_1.publishingstatus.save()
+        self.project_1.publish()
         self.project_2 = Project.objects.create(title="Test project 2")
-        self.project_2.publishingstatus.status = PublishingStatus.STATUS_PUBLISHED
-        self.project_2.publishingstatus.save()
+        self.project_2.publish()
         self.org_1 = Organisation.objects.create(name='Org 1', long_name='Organisation 1')
         self.org_2 = Organisation.objects.create(name='Org 2', long_name='Organisation 2')
         self.user = User.objects.create(username='user1@com.com', email='user1@com.com')

--- a/akvo/rsr/tests/models/test_partner_site.py
+++ b/akvo/rsr/tests/models/test_partner_site.py
@@ -8,7 +8,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from akvo.rsr.models import (
-    Organisation, Partnership, PartnerSite, Project, ProjectUpdate, PublishingStatus
+    Organisation, Partnership, PartnerSite, Project, ProjectUpdate
 )
 
 User = get_user_model()

--- a/akvo/rsr/tests/views/test_account.py
+++ b/akvo/rsr/tests/views/test_account.py
@@ -36,8 +36,7 @@ class AccountTestCase(TestCase):
         self.org2 = Organisation.objects.create(name='icco', long_name='icco foundation')
         for org in (self.org1, self.org2):
             project = Project.objects.create()
-            project.publishingstatus.status = 'published'
-            project.publishingstatus.save()
+            project.publish()
             Partnership.objects.create(project=project, organisation=org)
         self.c = Client(HTTP_HOST=settings.RSR_DOMAIN)
 

--- a/akvo/rsr/tests/views/test_project.py
+++ b/akvo/rsr/tests/views/test_project.py
@@ -101,8 +101,7 @@ class ProjectViewsTestCase(TestCase):
         project_title = '{} awesome project'.format(hostname)
         project = Project.objects.create(title=project_title)
         project.keywords.add(keyword)
-        project.publishingstatus.status = 'published'
-        project.publishingstatus.save()
+        project.publish()
         url = '/en/projects/'
         self.c = Client(HTTP_HOST='{}.{}'.format(hostname, settings.AKVOAPP_DOMAIN))
 
@@ -125,13 +124,11 @@ class ProjectViewsTestCase(TestCase):
         )
         project_title1 = '{} awesome project {}'.format(hostname, 1)
         project1 = Project.objects.create(title=project_title1)
-        project1.publishingstatus.status = 'published'
-        project1.publishingstatus.save()
+        project1.publish()
         Partnership.objects.create(organisation=org, project=project1)
         project_title2 = '{} awesome project {}'.format(hostname, 2)
         project2 = Project.objects.create(title=project_title2)
-        project2.publishingstatus.status = 'published'
-        project2.publishingstatus.save()
+        project2.publish()
         Partnership.objects.create(organisation=org, project=project2)
         url = '/en/projects/'
         self.c = Client(HTTP_HOST='{}.{}'.format(hostname, settings.AKVOAPP_DOMAIN))
@@ -159,13 +156,11 @@ class ProjectViewsTestCase(TestCase):
         project_title1 = '{} awesome project {}'.format(hostname, 1)
         project1 = Project.objects.create(title=project_title1)
         project1.keywords.add(keyword)
-        project1.publishingstatus.status = 'published'
-        project1.publishingstatus.save()
+        project1.publish()
         Partnership.objects.create(organisation=org, project=project1)
         project_title2 = '{} awesome project {}'.format(hostname, 2)
         project2 = Project.objects.create(title=project_title2)
-        project2.publishingstatus.status = 'published'
-        project2.publishingstatus.save()
+        project2.publish()
         Partnership.objects.create(organisation=org, project=project2)
         url = '/en/projects/'
         self.c = Client(HTTP_HOST='{}.{}'.format(hostname, settings.AKVOAPP_DOMAIN))

--- a/akvo/rsr/tests/views/test_project.py
+++ b/akvo/rsr/tests/views/test_project.py
@@ -175,7 +175,7 @@ class ProjectViewsTestCase(TestCase):
         self.assertIn(project_title1, response.content)
         self.assertNotIn(project_title2, response.content)
 
-    def test_should_show_only_recipient_country_projects(self):
+    def test_should_show_all_country_projects(self):
         # Given
         project_title1 = 'Project 1'
         project_title2 = 'Project 2'
@@ -205,7 +205,7 @@ class ProjectViewsTestCase(TestCase):
         self.assertNotIn(project_title1, response.content)
         self.assertIn(project_title2, response.content)
         self.assertEqual(project_location.country.iso_code, country_code.lower())
-        self.assertNotIn(project_title3, response.content)
+        self.assertIn(project_title3, response.content)
 
     def setup_country_objects(self):
         for iso_code, name in ISO_3166_COUNTRIES:

--- a/akvo/rsr/tests/views/test_project.py
+++ b/akvo/rsr/tests/views/test_project.py
@@ -197,6 +197,10 @@ class ProjectViewsTestCase(TestCase):
         project_location = ProjectLocation.objects.create(location_target=project3,
                                                           latitude=latitude,
                                                           longitude=longitude)
+        # ProjectLocation with no country
+        ProjectLocation.objects.create(location_target=project3,
+                                       latitude=None,
+                                       longitude=None)
 
         # When
         response = self.c.get(url, follow=True)

--- a/akvo/rsr/views/project.py
+++ b/akvo/rsr/views/project.py
@@ -90,6 +90,8 @@ def directory(request):
     page.object_list = page.object_list.prefetch_related(
         'publishingstatus',
         'recipient_countries',
+        'locations',
+        'locations__country',
         'sectors',
         'budget_items',
         'partnerships__organisation',

--- a/akvo/rsr/views/project.py
+++ b/akvo/rsr/views/project.py
@@ -7,7 +7,6 @@ Akvo RSR module. For additional details on the GNU license please see
 < http://www.gnu.org/licenses/agpl.html >.
 """
 
-import django_filters
 import json
 from datetime import datetime
 from sorl.thumbnail import get_thumbnail

--- a/akvo/templates/project_directory.html
+++ b/akvo/templates/project_directory.html
@@ -107,10 +107,10 @@
             <h1><a href="{% url 'project-main' project.id %}"><i class="fa fa-folder-o"></i> {{project.title}}</a></h1>
             <p class="projectSubT">{{project.subtitle}}</p>
             <p class="projectLocation"><i class="fa fa-map-marker"></i>
-                {% for recipient_country in project.recipient_countries.all %}
-                    {{ recipient_country }}{% if not forloop.last %}, {% endif %}
+                {% for country in project.countries %}
+                    {{ country }}{% if not forloop.last %}, {% endif %}
                 {% empty %}
-                    {% trans 'No recipient countries specified' %}
+                    {% trans 'No project locations or recipient countries specified' %}
                 {% endfor %}
             </p>
             {% if project.primary_organisation %}


### PR DESCRIPTION
`ProjectLocation`s associated with projects were being used to populate the list of options in the advanced filter for locations, while `RecipientCountry` locations are shown in the project directory, when showing information about each project.  This made the search buggy, and also hard to understand.  To make it easier for the user to understand how search is working, this code ignores the `ProjectLocation` countries completely, and simply uses the `RecipientCountry` values.

- [ ] Test plan | Unit test | Integration test 
- [ ] Copyright header 
- [ ] Code formatting 
- [ ] Documentation 
- [ ] Change log entry

Closes #2623 