### PR TITLE
[#2624] Show all orgs in project editor typeahead

### DIFF
--- a/akvo/rest/views/typeahead.py
+++ b/akvo/rest/views/typeahead.py
@@ -42,7 +42,12 @@ def typeahead_country(request):
 @api_view(['GET'])
 def typeahead_organisation(request):
     page = request.rsr_page
-    organisations = page.organisation.partners() if page else Organisation.objects.all()
+    if request.GET.get('partners', '0') == '1' and page:
+        organisations = page.partners()
+    else:
+        # Project editor - all organizations
+        organisations = Organisation.objects.all()
+
     return Response(
         rejig(organisations, TypeaheadOrganisationSerializer(organisations,
                                                              many=True))

--- a/akvo/rsr/static/scripts-src/project-directory-typeahead.js
+++ b/akvo/rsr/static/scripts-src/project-directory-typeahead.js
@@ -160,7 +160,7 @@ function initReact() {
     // Load globals
     Typeahead = ReactTypeahead.Typeahead;
 
-    loadAsync('/rest/v1/typeaheads/organisations?format=json', 0, 3);
+    loadAsync('/rest/v1/typeaheads/organisations?format=json&partners=1', 0, 3);
 }
 
 var loadJS = function(url, implementationCode, location){


### PR DESCRIPTION
- [x] Test plan | Unit test | Integration test 
- [x] Copyright header 
- [x] Code formatting 
- [x] Documentation 
- [x] Change log entry

Show all organisations in the typeahead for organisations in the project editor on partner sites.  Any organisation could be added as a partner to a project, making it a partner for the site's organisation.  Showing only existing partners in this typeahead definitely doesn't make sense.

Closes #2624