### PR TITLE
Do not list/count private projects anywhere outside of MyRSR

### DIFF
--- a/akvo/rest/views/typeahead.py
+++ b/akvo/rest/views/typeahead.py
@@ -96,7 +96,7 @@ def typeahead_project(request):
     if request.GET.get('published', '0') == '0':
         # Project editor - organization projects, all
         page = request.rsr_page
-        projects = page.organisation.all_projects() if page else Project.objects.all()
+        projects = page.all_projects() if page else Project.objects.all()
     else:
         # Search bar - organization projects, published
         projects = _project_directory_coll(request)

--- a/akvo/rsr/models/organisation.py
+++ b/akvo/rsr/models/organisation.py
@@ -497,35 +497,9 @@ class Organisation(TimestampsMixin, models.Model):
             amount_pledged=Sum('partnerships__funding_amount')
         )['amount_pledged'] or 0
 
-    def euros_pledged(self):
-        "How much € the organisation has pledged to projects it is a partner to"
-        return self.active_projects().euros().filter(
-            partnerships__organisation__exact=self,
-            partnerships__iati_organisation_role__exact=Partnership.IATI_FUNDING_PARTNER
-        ).aggregate(
-            euros_pledged=Sum('partnerships__funding_amount')
-        )['euros_pledged'] or 0
-
-    def dollars_pledged(self):
-        "How much $ the organisation has pledged to projects"
-        return self.active_projects().dollars().filter(
-            partnerships__organisation__exact=self,
-            partnerships__iati_organisation_role__exact=Partnership.IATI_FUNDING_PARTNER
-        ).aggregate(
-            dollars_pledged=Sum('partnerships__funding_amount')
-        )['dollars_pledged'] or 0
-
     def org_currency_projects_count(self):
         "How many projects with budget in default currency the organisation is a partner to"
         return self.published_projects().filter(currency=self.currency).distinct().count()
-
-    def euro_projects_count(self):
-        "How many projects with budget in € the organisation is a partner to"
-        return self.published_projects().euros().distinct().count()
-
-    def dollar_projects_count(self):
-        "How many projects with budget in $ the organisation is a partner to"
-        return self.published_projects().dollars().distinct().count()
 
     def _aggregate_funds_needed(self, projects):
         return sum(projects.values_list('funds_needed', flat=True))
@@ -537,22 +511,6 @@ class Organisation(TimestampsMixin, models.Model):
         The ORM aggregate() doesn't work here since we may have multiple partnership relations
         to the same project."""
         return self._aggregate_funds_needed(self.published_projects().filter(currency=self.currency).distinct())
-
-    def euro_funds_needed(self):
-        """How much is still needed to fully fund all projects with € budget that the
-        organisation is a partner to.
-
-        The ORM aggregate() doesn't work here since we may have multiple partnership relations
-        to the same project."""
-        return self._aggregate_funds_needed(self.published_projects().euros().distinct())
-
-    def dollar_funds_needed(self):
-        """How much is still needed to fully fund all projects with $ budget that the
-        organisation is a partner to.
-
-        The ORM aggregate() doesn't work here since we may have multiple partnership relations
-        to the same project."""
-        return self._aggregate_funds_needed(self.published_projects().dollars().distinct())
 
     class Meta:
         app_label = 'rsr'

--- a/akvo/rsr/models/organisation.py
+++ b/akvo/rsr/models/organisation.py
@@ -280,12 +280,6 @@ class Organisation(TimestampsMixin, models.Model):
             from .project import Project
             return Project.objects.of_partner(self).distinct()
 
-        def public_projects(self):
-            """
-            Returns a queryset with all public projects that has self as any kind of partner.
-            """
-            return self.all_projects().public()
-
         def users(self):
             "returns a queryset of all users belonging to the organisation(s)"
             from .user import User

--- a/akvo/rsr/models/organisation.py
+++ b/akvo/rsr/models/organisation.py
@@ -21,7 +21,6 @@ from akvo.codelists.store.codelists_v202 import CURRENCY, ORGANISATION_TYPE
 from akvo.codelists.models import Currency
 
 from .country import Country
-from .keyword import Keyword
 from .partner_site import PartnerSite
 from .partnership import Partnership
 from .publishing_status import PublishingStatus

--- a/akvo/rsr/models/organisation.py
+++ b/akvo/rsr/models/organisation.py
@@ -343,9 +343,10 @@ class Organisation(TimestampsMixin, models.Model):
         "returns a queryset of all users belonging to the organisation"
         return self.users.all()
 
-    def published_projects(self):
+    def published_projects(self, only_public=True):
         "returns a queryset with published projects that has self as any kind of partner"
-        return self.projects.published().distinct()
+        projects = self.projects.published().distinct()
+        return projects.public() if only_public else projects
 
     def all_projects(self):
         """returns a queryset with all projects that has self as any kind of partner."""

--- a/akvo/rsr/models/organisation.py
+++ b/akvo/rsr/models/organisation.py
@@ -278,7 +278,7 @@ class Organisation(TimestampsMixin, models.Model):
         def all_projects(self):
             "returns a queryset with all projects that has self as any kind of partner"
             from .project import Project
-            return Project.objects.filter(partnerships__organisation__in=self).distinct()
+            return Project.objects.of_partner(self).distinct()
 
         def public_projects(self):
             """

--- a/akvo/rsr/models/partner_site.py
+++ b/akvo/rsr/models/partner_site.py
@@ -181,16 +181,20 @@ class PartnerSite(TimestampsMixin, models.Model):
         """All partner organisations of all projects of the Page"""
         return self.projects().all_partners()
 
-    def projects(self):
+    def all_projects(self):
         """All projects of the Page"""
         from .project import Project
         # Get all projects associated via the Page's organisation
         if self.partner_projects:
-            fk_projects = self.organisation.published_projects().public()
+            fk_projects = self.organisation.all_projects()
         else:
-            fk_projects = Project.objects.public().published()
+            fk_projects = Project.objects.all()
         # Add (or remove) projects via keywords
         return self.apply_keywords(fk_projects)
+
+    def projects(self):
+        """Publicly published projects of the page."""
+        return self.all_projects().published().public()
 
     def apply_keywords(self, projects):
         """Apply keywords to the Page's projects."""

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -714,16 +714,6 @@ class Project(TimestampsMixin, models.Model):
         def status_not_archived(self):
             return self.exclude(iati_status__exact='6')
 
-        def active(self):
-            """Return projects that are published and not cancelled or archived"""
-            return self.published().status_not_cancelled().status_not_archived()
-
-        def euros(self):
-            return self.filter(currency='EUR')
-
-        def dollars(self):
-            return self.filter(currency='USD')
-
         # aggregates
         def budget_sum(self):
             ''' aggregates the budgets of all the projects in the QS

--- a/akvo/rsr/models/user.py
+++ b/akvo/rsr/models/user.py
@@ -464,7 +464,7 @@ class User(AbstractBaseUser, PermissionsMixin):
             user=self, is_approved=True, group__name='M&E Managers'
         )
         orgs = employments.organisations()
-        return project in Project.objects.filter(partnerships__organisation__in=orgs).distinct()
+        return project in Project.objects.of_partners(orgs).distinct()
 
     def project_editor_of(self, org):
         """
@@ -494,19 +494,19 @@ class User(AbstractBaseUser, PermissionsMixin):
         """Return all projects of orgs where user is an admin."""
 
         orgs = self.get_admin_employment_orgs()
-        return Project.objects.filter(partnerships__organisation__in=orgs).distinct()
+        return Project.objects.of_partners(orgs).distinct()
 
     def project_editor_me_manager_projects(self):
         """Return all projects of orgs where user is project editor or m&e manager."""
 
         orgs = self.get_project_editor_me_manager_employment_orgs()
-        return Project.objects.filter(partnerships__organisation__in=orgs).distinct()
+        return Project.objects.of_partners(orgs).distinct()
 
     def user_manager_projects(self):
         """Return all projects where user is a user manager."""
 
         orgs = self.get_user_manager_employment_orgs()
-        return Project.objects.filter(partnerships__organisation__in=orgs).distinct()
+        return Project.objects.of_partners(orgs).distinct()
 
     def get_permission_filter(self, permission, project_relation):
         """Convert a rules permission predicate into a queryset filter using Q objects.

--- a/akvo/rsr/views/organisation.py
+++ b/akvo/rsr/views/organisation.py
@@ -25,7 +25,7 @@ from lxml import etree
 
 def _public_projects():
     """Return all public projects."""
-    return Project.objects.public().published().select_related('partners').order_by('-id')
+    return Project.objects.public().published().select_related('partners')
 
 
 def _page_organisations(page):

--- a/akvo/rsr/views/project_update.py
+++ b/akvo/rsr/views/project_update.py
@@ -35,7 +35,7 @@ def _all_updates():
 
 def _all_projects():
     """Return all active projects."""
-    return Project.objects.public().published().select_related('project_updates').order_by('-id')
+    return Project.objects.public().published().select_related('project_updates')
 
 
 def _page_updates(page):

--- a/akvo/rsr/views/utils.py
+++ b/akvo/rsr/views/utils.py
@@ -24,7 +24,7 @@ def apply_keywords(page, project_qs):
 
 def org_projects(organisation):
     """."""
-    return organisation.published_projects().public().select_related(
+    return organisation.published_projects().select_related(
         'partners',
         'categories',
         'primary_location',

--- a/akvo/rsr/views/widgets.py
+++ b/akvo/rsr/views/widgets.py
@@ -94,10 +94,7 @@ class ProjectListView(BaseWidgetView):
             'primary_location__country'
         ).prefetch_related(
             'last_update'
-        ).filter(
-            partnerships__organisation__id=org_id,
-            publishingstatus__status__exact='published'
-        ).order_by('-id').distinct()
+        ).of_partner(org_id).published().public().distinct()
 
         if order_by == 'status':
             projects = projects.order_by('status', 'title')

--- a/akvo/rsr/views/widgets.py
+++ b/akvo/rsr/views/widgets.py
@@ -88,13 +88,16 @@ class ProjectListView(BaseWidgetView):
         order_by = self.request.GET.get('order_by', 'title')
         org_id = self.request.GET.get('organisation_id')
         organisation = get_object_or_404(Organisation, pk=org_id)
-        projects = Project.objects.select_related(
+        projects = organisation.active_projects().select_related(
             'publishingstatus__status',
             'primary_location',
-            'primary_location__country'
+            'primary_location__country',
+            'last_update',
         ).prefetch_related(
-            'last_update'
-        ).of_partner(org_id).published().public().distinct()
+            'recipient_countries',
+            'partnerships',
+            'partnerships__organisation',
+        )
 
         if order_by == 'status':
             projects = projects.order_by('status', 'title')
@@ -123,6 +126,6 @@ class ProjectMapView(BaseWidgetView):
         context['style'] = self.request.GET.get('style', 'dark')
         context['state'] = self.request.GET.get('state', 'dynamic')
         org_id = self.request.GET.get('organisation_id')
-        org = get_object_or_404(Organisation, pk=org_id)
-        context['projects'] = org.published_projects()
+        organisation = get_object_or_404(Organisation, pk=org_id)
+        context['projects'] = organisation.active_projects()
         return context

--- a/akvo/utils.py
+++ b/akvo/utils.py
@@ -201,7 +201,7 @@ def right_now_in_akvo():
     """
     Calculate the numbers used in the "Right now in Akvo" box on the home page.
     """
-    projects = get_model('rsr', 'Project').objects.published()
+    projects = get_model('rsr', 'Project').objects.public().published()
     organisations = get_model('rsr', 'Organisation').objects.all()
     updates = get_model('rsr', 'ProjectUpdate').objects.all()
     people_served = projects.get_largest_value_sum(


### PR DESCRIPTION
- Private projects are meant to be viewed only by members of the organisations which are partners of the projects. Members of these organisations could be shown private projects in the project listings, etc., but to keep these pages simple, it was decided to exclude private projects from all the pages outside of MyRSR.

- The existence of private projects shouldn't be known to anyone outside of the organisations to which they "belong".  So, all public counts of projects must exclude private projects.

- [x] Test plan | Unit test | Integration test

- [x] Copyright header

- [x] Code formatting

- [x] Documentation

- [x] Change log entry