### PR TITLE
Optimize the permissions code and user_management view code

### DIFF
--- a/akvo/rsr/models/user.py
+++ b/akvo/rsr/models/user.py
@@ -373,7 +373,8 @@ class User(AbstractBaseUser, PermissionsMixin):
         """
         Return all approved employments.
         """
-        return self.employers.all().exclude(is_approved=False)
+        employments = self.employers.all().exclude(is_approved=False)
+        return employments.select_related('organisation', 'group', 'user')
 
     def can_create_project(self):
         """Check to see if the user can create a project."""

--- a/akvo/rsr/views/my_rsr.py
+++ b/akvo/rsr/views/my_rsr.py
@@ -458,7 +458,12 @@ def user_management(request):
     # Order employments in reverse chronological order, but also group
     # employments by the user.
     employments = employments.annotate(max_id=Max('user__employers__id'))
-    employments = employments.order_by('-max_id', '-id')
+    employments = employments.order_by('-max_id', '-id').select_related(
+        'user',
+        'organisation',
+        'group',
+        'country',
+    )
 
     qs = remove_empty_querydict_items(request.GET)
     page = request.GET.get('page')

--- a/akvo/rsr/views/my_rsr.py
+++ b/akvo/rsr/views/my_rsr.py
@@ -500,10 +500,7 @@ def user_management(request):
             employment_dict["user"] = user_dict
         employments_array.append(employment_dict)
 
-    organisations_list = []
-    for organisation in organisations:
-        organisation_dict = {'id': organisation.id, 'name': organisation.name}
-        organisations_list.append(organisation_dict)
+    organisations_list = list(organisations.values('id', 'name'))
 
     roles_list = []
     for role in roles:


### PR DESCRIPTION
To prevent timeouts, especially when a user has multiple employments, the code in the `user_management` view and the permissions code has been optimized mostly using a bunch of selects/prefetches.

- [x] Test plan | Unit test | Integration test 
- [x] Copyright header 
- [x] Code formatting 
- [x] Documentation 
- [x] Change log entry
```markdown
Fixed user management page timeouts for users with too many employments - [#2651](https://github.com/akvo/akvo-rsr/issues/2651)
```