### PR TITLE
[#2658] Document category input partial is included using wrong id

### DIFF
--- a/akvo/templates/myrsr/project_editor/related_objects/document_input.html
+++ b/akvo/templates/myrsr/project_editor/related_objects/document_input.html
@@ -46,8 +46,8 @@
                 {% for category in document.categories.all %}
                     {% include "myrsr/project_editor/related_objects/document_category_input.html" %}
                 {% empty %}
-                    {% with category_id_string=category.pk|default:"new-0"|stringformat:"s" %}
-                        {% include "myrsr/project_editor/related_objects/document_category_input.html" with category='ProjectDocumentCategory.'|add:project_id_string|add:'_'|add:category_id_string %}
+                    {% with document_id_string=document.pk|default:"new-0"|stringformat:"s" %}
+                        {% include "myrsr/project_editor/related_objects/document_category_input.html" with category='ProjectDocumentCategory.'|add:project_id_string|add:'_'|add:document_id_string %}
                     {% endwith %}
                 {% endfor %}
                 <div class="row form-group">


### PR DESCRIPTION
The `document_category_input.html` template is included using wrong category id
when being inserted, and causes the document category to not be saved when a new
document category is added.  This commit fixes the bug and closes #2658.


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
```markdown
Fixed problem with saving document category in some cases - [#2658](https://github.com/akvo/akvo-rsr/issues/2658)
```
