### PR TITLE
[#2686] Fix missing indicator description in IATI exports

### DIFF
--- a/akvo/iati/exports/elements/result.py
+++ b/akvo/iati/exports/elements/result.py
@@ -58,7 +58,7 @@ def result(project):
                     if indicator.description:
                         description_element = etree.SubElement(indicator_element, "description")
                         narrative_element = etree.SubElement(description_element, "narrative")
-                        narrative_element.text = res.description
+                        narrative_element.text = indicator.description
 
                     for reference in indicator.references.all():
                         if reference.vocabulary or reference.reference or reference.vocabulary_uri:

--- a/akvo/rsr/tests/iati_export/test_iati_export.py
+++ b/akvo/rsr/tests/iati_export/test_iati_export.py
@@ -405,7 +405,7 @@ class IatiExportTestCase(TestCase, XmlTestMixin):
             measure="1",
             ascending=True,
             title="Title",
-            description="Description",
+            description="Indicator Description",
             baseline_year=2016,
             baseline_value="1",
             baseline_comment="Comment"
@@ -488,6 +488,12 @@ class IatiExportTestCase(TestCase, XmlTestMixin):
         )
         self.assertEqual(1, len(related_activities))
         self.assertEqual(attributes, related_activities[0].attrib)
+
+        # Test indicator has description
+        indicator_description_xpath = './iati-activity/result/indicator/description/narrative'
+        self.assertXpathsExist(root_test, (indicator_description_xpath,))
+        indicators = root_test.xpath(indicator_description_xpath)
+        self.assertEqual(indicators[0].text, 'Indicator Description')
 
     def test_different_complete_project_export(self):
         """


### PR DESCRIPTION
Looks like a copy-pasta error -- result description was being used instead of
the indicator description.

Closes #2686


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

```markdown
Bugfix

Indicator descriptions missing in IATI file [#2686](https://github.com/akvo/akvo-rsr/issues/2686)