### PR TITLE
[#2552] Scroll to the search field when advanced filters are active

### DIFF
--- a/akvo/rsr/static/scripts-src/rsr.js
+++ b/akvo/rsr/static/scripts-src/rsr.js
@@ -35,7 +35,6 @@ $(document).ready(function() {
 
   // Advanced filtering & search
   $(".menu-toggle").click(function(e) {
-    e.preventDefault();
     $("#wrapper, #search").toggleClass("toggled");
     $("a.showFilters > i").toggleClass("fa-toggle-off fa-toggle-on");
   });
@@ -48,7 +47,7 @@ $(document).ready(function() {
       "hide": 1000
     }
   });
-  
+
 
   function getCookie(name) {
     var cookieValue = null;

--- a/akvo/rsr/static/styles-src/main.css
+++ b/akvo/rsr/static/styles-src/main.css
@@ -1068,6 +1068,9 @@ h4.detailedInfo {
 
 .searchContainer {
   position: relative; }
+  .searchContainer #search-view {
+    position: absolute;
+    top: -65px; }
   .searchContainer #search .showFilters {
     /*background-color: rgba(white,0.2);
             border: 1px solid rgba($rsrGreen, 0);

--- a/akvo/rsr/static/styles-src/main.scss
+++ b/akvo/rsr/static/styles-src/main.scss
@@ -1208,6 +1208,10 @@ h4.detailedInfo {
 
 .searchContainer {
     position: relative;
+    #search-view {
+        position: absolute;
+        top: -65px;
+    }
     #search {
         .showFilters {
             /*background-color: rgba(white,0.2);

--- a/akvo/templates/project_directory.html
+++ b/akvo/templates/project_directory.html
@@ -11,6 +11,9 @@
   <form id="filterForm" action="" method="get" accept-charset="uft-8" class="searchContainer">
     <section id="search-filter">
       <div class="container-fluid">
+          <div id="search-view">
+              <!-- This is a hack to bring the search field into view properly, and not go under the top nav bar -->
+          </div>
         <div id="search" class="verticalPadding">
           <p>{% trans "Refine the project list below by searching by name, organisation or sector" %}</p>
           <div class="form-inline" role="form">
@@ -23,7 +26,7 @@
                     </button>
                 </span>
               </div>
-              <a class="btn showFilters menu-toggle"><i class="fa fa-toggle-off"></i> {% trans 'Advanced filters' %}</a>
+              <a href="#search-view" class="btn showFilters menu-toggle"><i class="fa fa-toggle-off"></i> {% trans 'Advanced filters' %}</a>
             </div>
             {% if q %}
             <div><a href="{% url 'project-directory' %}" class="btn"><i class="fa fa-times"></i>  {% trans 'Reset all filters' %}</a></div>


### PR DESCRIPTION
This commit tries to keep the search bar at the top of the page, when the
advanced filters pane is open, even on reloads.


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
