### PR TITLE
[#2666] Remove actual value and comment fields from project editor

### DIFF
--- a/akvo/templates/myrsr/project_editor/related_objects/indicator_period_input.html
+++ b/akvo/templates/myrsr/project_editor/related_objects/indicator_period_input.html
@@ -24,23 +24,7 @@
                 {% include text_input with obj=period field='target_value' %}
             </div>
             <div class="col-md-6">
-                {% if not period.data.exists %}
-                    {% include text_input with obj=period field='actual_value' %}
-                {% else %}
-                    {% include text_input with obj=period field='actual_value' disabled=True %}
-                    <p class="help-block">
-                        {% trans 'It is not possible to edit the actual value when indicator data has been filled in through the My results section. ' %}
-                        {% trans 'Go to the' %} <a href="{% url 'my_results' project.pk %}" target="_blank">{% trans 'My results' %}</a> {% trans 'section to update this value.' %}
-                    </p>
-                {% endif %}
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-6">
                 {% include textarea_input with obj=period field='target_comment' %}
-            </div>
-            <div class="col-md-6">
-                {% include textarea_input with obj=period field='actual_comment' %}
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
We could've set some hidden fields in the validation sets, but since we are
changing the template to prevent the page from looking weird, we are going to
need to change back the template if we are going to add those fields back. The
change cannot be made without a deploy, and we might as well change the template
in that case.

Closes #2666


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
```markdown
Remove the actual value and actual value comments from the project editor [#2666](https://github.com/akvo/akvo-rsr/issues/2666)
```
