### PR TITLE
Some minor UI and UX changes for Dynamic filters

### DIFF
--- a/akvo/rsr/static/scripts-src/project-directory-filters.js
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.js
@@ -70,19 +70,16 @@ var FilterForm = React.createClass({displayName: "FilterForm",
                 )
             );
         };
-        var project_count = this.state.disabled?(React.createElement("span", null, this.props.i18n.loading_text)):(
-            React.createElement("span", null, this.props.i18n.search_text + ' ' + this.state.project_count + ' ' + this.props.i18n.projects_text
+        var project_count = this.state.disabled?(React.createElement("a", null, this.props.i18n.loading_text)):(
+            React.createElement("p", null, this.props.i18n.search_text + ' ' + this.state.project_count + ' ' + this.props.i18n.projects_text
             )
         );
         return (
             React.createElement("aside", {id: "sidebar-wrapper"}, 
                 React.createElement("div", {id: "filter"}, 
-                    React.createElement("div", {id: "advanced-filter-status"}, 
-                        project_count
-                    ), 
                     this.props.filters.map(create_filter, this), 
                     React.createElement("div", null, 
-                        React.createElement("nav", null, 
+                        React.createElement("nav", {id: "advanced-filter-nav"}, 
                             React.createElement("ul", {className: "nav nav-pills nav-stacked"}, 
                                 React.createElement("li", null, 
                                     React.createElement("a", {className: "showFilters text-center", 
@@ -96,6 +93,9 @@ var FilterForm = React.createClass({displayName: "FilterForm",
                                         React.createElement("i", {className: "fa fa-toggle-off"}), 
                                         React.createElement("span", null, " ", this.props.i18n.close_this_text)
                                     )
+                                ), 
+                                React.createElement("li", {id: "advanced-filter-status"}, 
+                                    project_count
                                 )
                             )
                         )

--- a/akvo/rsr/static/scripts-src/project-directory-filters.js
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.js
@@ -8,6 +8,12 @@
 var filtersWrapper = document.getElementById('wrapper'),
     options_cache = {};
 
+var trim_label = function(obj) {
+    if (obj.hasOwnProperty('label')) {
+        obj.label = obj.label.trim();
+    }
+    return obj;
+};
 var Filter = React.createClass({displayName: "Filter",
     render: function(){
         var Typeahead = ReactBootstrapTypeahead.Typeahead;
@@ -30,6 +36,7 @@ var Filter = React.createClass({displayName: "Filter",
     },
     onChange: function(values){
         this.props.onChange(this.props.name, values);
+        if (values.length > 0) { trim_label(values[0]); }
     }
 });
 
@@ -228,9 +235,11 @@ var FilterForm = React.createClass({displayName: "FilterForm",
         // since it needs the processed options
         var initial_selection = {};
         var set_initial_selection = function (key){
-            var id = this.state.selected[key];
-            var find_function = function(option){return option.id == id;};
-            initial_selection[key] = [options[key].find(find_function)];
+            var id = this.state.selected[key],
+                find_function = function(option){return option.id == id;},
+                selection = options[key].find(find_function),
+                selection_clone = Object.assign({}, selection);
+            initial_selection[key] = [trim_label(selection_clone)];
         };
         Object.keys(this.state.selected).map(set_initial_selection, this);
         this.setState({"initial_selection": initial_selection});

--- a/akvo/rsr/static/scripts-src/project-directory-filters.js
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.js
@@ -64,6 +64,7 @@ var FilterForm = React.createClass({displayName: "FilterForm",
         window.advanced_filter_form = this;
         if (Object.keys(this.state.selected).length > 0) {
             this.toggleForm();
+            document.querySelector('#search-view').scrollIntoView();
         }
 
     },

--- a/akvo/rsr/static/scripts-src/project-directory-filters.js
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.js
@@ -14,6 +14,7 @@ var trim_label = function(obj) {
     }
     return obj;
 };
+
 var Filter = React.createClass({displayName: "Filter",
     render: function(){
         var Typeahead = ReactBootstrapTypeahead.Typeahead;
@@ -61,6 +62,10 @@ var FilterForm = React.createClass({displayName: "FilterForm",
     componentDidMount: function(){
         this.fetchFilterOptions(true);
         window.advanced_filter_form = this;
+        if (Object.keys(this.state.selected).length > 0) {
+            this.toggleForm();
+        }
+
     },
     render: function(){
         var create_filter = function(filter_name){
@@ -243,7 +248,6 @@ var FilterForm = React.createClass({displayName: "FilterForm",
         };
         Object.keys(this.state.selected).map(set_initial_selection, this);
         this.setState({"initial_selection": initial_selection});
-        if (Object.keys(initial_selection).length > 0) { this.toggleForm(); }
     },
     updateState: function(options, mountedNow){
         var project_count = options.project_count;

--- a/akvo/rsr/static/scripts-src/project-directory-filters.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.jsx
@@ -62,6 +62,9 @@ var FilterForm = React.createClass({
     componentDidMount: function(){
         this.fetchFilterOptions(true);
         window.advanced_filter_form = this;
+        if (Object.keys(this.state.selected).length > 0) {
+            this.toggleForm();
+        }
     },
     render: function(){
         var create_filter = function(filter_name){
@@ -244,7 +247,6 @@ var FilterForm = React.createClass({
         };
         Object.keys(this.state.selected).map(set_initial_selection, this);
         this.setState({"initial_selection": initial_selection});
-        if (Object.keys(initial_selection).length > 0) { this.toggleForm(); }
     },
     updateState: function(options, mountedNow){
         var project_count = options.project_count;

--- a/akvo/rsr/static/scripts-src/project-directory-filters.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.jsx
@@ -64,6 +64,7 @@ var FilterForm = React.createClass({
         window.advanced_filter_form = this;
         if (Object.keys(this.state.selected).length > 0) {
             this.toggleForm();
+            document.querySelector('#search-view').scrollIntoView();
         }
     },
     render: function(){

--- a/akvo/rsr/static/scripts-src/project-directory-filters.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.jsx
@@ -8,6 +8,13 @@
 var filtersWrapper = document.getElementById('wrapper'),
     options_cache = {};
 
+var trim_label = function(obj) {
+    if (obj.hasOwnProperty('label')) {
+        obj.label = obj.label.trim();
+    }
+    return obj;
+};
+
 var Filter = React.createClass({
     render: function(){
         var Typeahead = ReactBootstrapTypeahead.Typeahead;
@@ -30,6 +37,7 @@ var Filter = React.createClass({
     },
     onChange: function(values){
         this.props.onChange(this.props.name, values);
+        if (values.length > 0) { trim_label(values[0]); }
     }
 });
 
@@ -228,9 +236,11 @@ var FilterForm = React.createClass({
         // since it needs the processed options
         var initial_selection = {};
         var set_initial_selection = function (key){
-            var id = this.state.selected[key];
-            var find_function = function(option){return option.id == id;};
-            initial_selection[key] = [options[key].find(find_function)];
+            var id = this.state.selected[key],
+                find_function = function(option){return option.id == id;},
+                selection = options[key].find(find_function),
+                selection_clone = Object.assign({}, selection);
+            initial_selection[key] = [trim_label(selection_clone)];
         };
         Object.keys(this.state.selected).map(set_initial_selection, this);
         this.setState({"initial_selection": initial_selection});

--- a/akvo/rsr/static/scripts-src/project-directory-filters.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.jsx
@@ -70,19 +70,16 @@ var FilterForm = React.createClass({
                 />
             );
         };
-        var project_count = this.state.disabled?(<span>{this.props.i18n.loading_text}</span>):(
-            <span>{this.props.i18n.search_text + ' ' + this.state.project_count + ' ' + this.props.i18n.projects_text}
-            </span>
+        var project_count = this.state.disabled?(<a>{this.props.i18n.loading_text}</a>):(
+            <p>{this.props.i18n.search_text + ' ' + this.state.project_count + ' ' + this.props.i18n.projects_text}
+            </p>
         );
         return (
             <aside id="sidebar-wrapper">
                 <div id="filter">
-                    <div id="advanced-filter-status">
-                        {project_count}
-                    </div>
                     {this.props.filters.map(create_filter, this)}
                     <div>
-                        <nav>
+                        <nav id="advanced-filter-nav">
                             <ul className="nav nav-pills nav-stacked">
                                 <li>
                                     <a className="showFilters text-center"
@@ -96,6 +93,9 @@ var FilterForm = React.createClass({
                                         <i className="fa fa-toggle-off"></i>
                                         <span> {this.props.i18n.close_this_text}</span>
                                     </a>
+                                </li>
+                                <li id="advanced-filter-status">
+                                    {project_count}
                                 </li>
                             </ul>
                         </nav>

--- a/akvo/rsr/static/styles-src/main.css
+++ b/akvo/rsr/static/styles-src/main.css
@@ -1172,12 +1172,16 @@ h4.detailedInfo {
       padding-bottom: 20px; } }
   #sidebar-wrapper div#filter {
     padding: 5px 15px 15px 15px;
-    min-height: 700px;
     overflow-y: hidden; }
-    #sidebar-wrapper div#filter div#advanced-filter-status {
+    #sidebar-wrapper div#filter #advanced-filter-status {
       text-align: center;
       font-weight: bold;
-      display: block; }
+      display: block;
+      padding-top: 40px !important; }
+    #sidebar-wrapper div#filter #advanced-filter-nav {
+      padding-top: 25px; }
+      #sidebar-wrapper div#filter #advanced-filter-nav li {
+        padding: 5px 0; }
     #sidebar-wrapper div#filter div .btn-group {
       width: 100%;
       border-top: 1px solid rgba(32, 32, 36, 0.1);
@@ -1199,11 +1203,9 @@ h4.detailedInfo {
 #wrapper.toggled {
   padding-left: 200px; }
   #wrapper.toggled #sidebar-wrapper {
-    width: 300px; }
-    #wrapper.toggled #sidebar-wrapper .dropdown-menu {
-      max-width: 260px; }
-      #wrapper.toggled #sidebar-wrapper .dropdown-menu li > a {
-        white-space: normal !important; }
+    width: 350px; }
+    #wrapper.toggled #sidebar-wrapper .dropdown-menu li > a {
+      white-space: normal !important; }
 
 #search-filter {
   background-color: #241F20; }

--- a/akvo/rsr/static/styles-src/main.css
+++ b/akvo/rsr/static/styles-src/main.css
@@ -1076,6 +1076,9 @@ h4.detailedInfo {
 
 .searchContainer {
   position: relative; }
+  .searchContainer #search-view {
+    position: absolute;
+    top: -65px; }
   .searchContainer #search .showFilters {
     /*background-color: rgba(white,0.2);
             border: 1px solid rgba($rsrGreen, 0);

--- a/akvo/rsr/static/styles-src/main.scss
+++ b/akvo/rsr/static/styles-src/main.scss
@@ -1208,6 +1208,10 @@ h4.detailedInfo {
 
 .searchContainer {
     position: relative;
+    #search-view {
+        position: absolute;
+        top: -65px;
+    }
     #search {
         .showFilters {
             /*background-color: rgba(white,0.2);

--- a/akvo/rsr/static/styles-src/main.scss
+++ b/akvo/rsr/static/styles-src/main.scss
@@ -1326,12 +1326,18 @@ h4.detailedInfo {
     }
     div#filter {
         padding: 5px 15px 15px 15px;
-        min-height: 700px;
         overflow-y: hidden;
-        div#advanced-filter-status {
+        #advanced-filter-status {
             text-align: center;
             font-weight: bold;
             display: block;
+            padding-top: 40px !important;
+        }
+        #advanced-filter-nav {
+            padding-top: 25px;
+            li {
+                padding: 5px 0;
+            }
         }
         div {
             .btn-group {
@@ -1363,9 +1369,8 @@ h4.detailedInfo {
 #wrapper.toggled {
     padding-left: 200px;
     #sidebar-wrapper {
-        width: 300px;
+        width: 350px;
         .dropdown-menu {
-            max-width: 260px;
             li > a {
                 white-space: normal !important;
             }

--- a/akvo/templates/project_directory.html
+++ b/akvo/templates/project_directory.html
@@ -11,6 +11,9 @@
   <form id="filterForm" action="" method="get" accept-charset="uft-8" class="searchContainer">
     <section id="search-filter">
       <div class="container-fluid">
+          <div id="search-view">
+              <!-- A hack to bring the search bar into view without being covered by the top nav bar -->
+          </div>
         <div id="search" class="verticalPadding">
           <p>{% trans "Refine the project list below by searching by name, organisation or sector" %}</p>
           <div class="form-inline" role="form">


### PR DESCRIPTION
- Scroll so that the search bar is at the top of the page when filters are active
- Display the advanced filters sidebar ASAP, instead of waiting for response from server with options
- Trim white space in selected names
- Move down the total project count to use the empty whitespace at the bottom
- Increase side bar width slightly

This should make the experience of using the Dynamic filters much better, as suggested by @AkvoAnt.  Caching the options to make the whole experience more responsive also would help. That is coming in a separate PR. 

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry

