### PR TITLE
[#2697] Show organisation specific reports only to those org users

### DIFF
--- a/akvo/rest/views/report.py
+++ b/akvo/rest/views/report.py
@@ -4,6 +4,7 @@
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
+from django.db.models import Q
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
@@ -16,10 +17,20 @@ def reports(request):
     """
     A view for displaying all report information, sorted by title.
     """
+
+    user = request.user
+    is_admin = user.is_active and (user.is_superuser or user.is_admin)
+    reports = Report.objects.all()
+    if not is_admin:
+        # Show only those reports that the user is allowed to see
+        reports = reports.filter(
+            Q(organisations=None) | Q(organisations__in=user.approved_organisations())
+        ).distinct()
+
     # FIXME: Use a viewset instead?
     return Response({
-        'count': Report.objects.all().count(),
-        'results': [ReportSerializer(r).data for r in Report.objects.all().order_by('title')],
+        'count': reports.count(),
+        'results': [ReportSerializer(r).data for r in reports.order_by('title')],
     })
 
 

--- a/akvo/rsr/migrations/0099_report_organisations.py
+++ b/akvo/rsr/migrations/0099_report_organisations.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def create_organisation_results_report(apps, schema_editor):
+    Report = apps.get_model("rsr", "Report")
+    ReportFormat = apps.get_model("rsr", "ReportFormat")
+    excel = ReportFormat.objects.get(name='excel')
+    report, _ = Report.objects.get_or_create(
+        name='organisation-results-export',
+        defaults={
+            'title': 'Results export',
+            'description': "Results export for all projects within your organisation",
+            'url': '/en/reports/orgresults/{organisation}?format={format}&download=true',
+        }
+    )
+    report.formats.add(excel)
+
+    # Currently, the report is shown only to EUTF users
+    Organisation = apps.get_model("rsr", "Organisation")
+    try:
+        eutf = Organisation.objects.get(id=3394)
+    except Organisation.DoesNotExist:
+        print "EUTF organisation not in DB."
+    else:
+        report.organisations.add(eutf)
+
+
+def add_organisation_for_plan_finland_report(apps, schema_editor):
+    """Add organisation for the plan-finland report."""
+
+    Report = apps.get_model("rsr", "Report")
+    Organisation = apps.get_model("rsr", "Organisation")
+
+    try:
+        plan_finland = Organisation.objects.get(id=2555)
+        plan_finland_report = Report.objects.get(name='plan-finland')
+    except Organisation.DoesNotExist:
+        print "Plan Finland organisation not in DB."
+    except Report.DoesNotExist:
+        print "plan-finland report not in DB."
+    else:
+        plan_finland_report.organisations.add(plan_finland)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rsr', '0098_auto_20170529_1442'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='report',
+            name='organisations',
+            field=models.ManyToManyField(to='rsr.Organisation', blank=True),
+            preserve_default=True,
+        ),
+        migrations.RunPython(create_organisation_results_report, reverse_code=lambda x, y: None),
+        migrations.RunPython(add_organisation_for_plan_finland_report, reverse_code=lambda x, y: None),
+    ]

--- a/akvo/rsr/models/report.py
+++ b/akvo/rsr/models/report.py
@@ -39,6 +39,7 @@ class Report(models.Model):
         help_text=_(u'Enter the parametrized path for downloading the report'),
     )
     formats = models.ManyToManyField(ReportFormat)
+    organisations = models.ManyToManyField('Organisation', blank=True)
 
     @property
     def parameters(self):

--- a/akvo/rsr/static/scripts-src/my-reports.js
+++ b/akvo/rsr/static/scripts-src/my-reports.js
@@ -393,40 +393,19 @@ function initReact() {
             });
         },
 
-        canSeePlanFinlandReport: function() {
-            if (this.props.userOptions.is_admin || this.props.userOptions.is_superuser) {
-                return true;
-            } else {
-                var approved_employments = this.props.userOptions.approved_employments;
-                for (var i = 0; i < approved_employments.length; i++) {
-                    var orgLongName = approved_employments[i].organisation_name.toLowerCase();
-                    if (orgLongName.indexOf('plan') > -1 && orgLongName.indexOf('finland') > -1) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-        },
-
         render: function() {
             var reportsData,
                 thisReportsDropdown = this;
             if (this.props.reportOptions.length > 0 && this.props.userOptions !== null) {
                 reportsData = this.props.reportOptions.map(function (report) {
-                    if (report.name === 'plan-finland' && !thisReportsDropdown.canSeePlanFinlandReport()) {
-                        return (
-                            React.createElement("span", null)
-                        );
-                    } else {
-                        return (
-                            React.createElement("li", {key: report.name}, 
-                                React.createElement(ReportOption, {
-                                    report: report,
-                                    selectReport: thisReportsDropdown.selectReport
-                                })
-                            )
-                        );
-                    }
+                    return (
+                        React.createElement("li", {key: report.name}, 
+                            React.createElement(ReportOption, {
+                                 report: report,
+                                 selectReport: thisReportsDropdown.selectReport
+                            })
+                        )
+                    );
                 });
             } else {
                 reportsData = React.createElement("li", null, React.createElement("a", {href: "#"}, React.createElement("i", {className: "fa fa-spin fa-spinner"}), " Loading..."));

--- a/akvo/rsr/static/scripts-src/my-reports.jsx
+++ b/akvo/rsr/static/scripts-src/my-reports.jsx
@@ -393,40 +393,19 @@ function initReact() {
             });
         },
 
-        canSeePlanFinlandReport: function() {
-            if (this.props.userOptions.is_admin || this.props.userOptions.is_superuser) {
-                return true;
-            } else {
-                var approved_employments = this.props.userOptions.approved_employments;
-                for (var i = 0; i < approved_employments.length; i++) {
-                    var orgLongName = approved_employments[i].organisation_name.toLowerCase();
-                    if (orgLongName.indexOf('plan') > -1 && orgLongName.indexOf('finland') > -1) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-        },
-
         render: function() {
             var reportsData,
                 thisReportsDropdown = this;
             if (this.props.reportOptions.length > 0 && this.props.userOptions !== null) {
                 reportsData = this.props.reportOptions.map(function (report) {
-                    if (report.name === 'plan-finland' && !thisReportsDropdown.canSeePlanFinlandReport()) {
-                        return (
-                            <span />
-                        );
-                    } else {
-                        return (
-                            <li key={report.name}>
-                                {React.createElement(ReportOption, {
-                                    report: report,
-                                    selectReport: thisReportsDropdown.selectReport
-                                })}
-                            </li>
-                        );
-                    }
+                    return (
+                        <li key={report.name}>
+                            {React.createElement(ReportOption, {
+                                 report: report,
+                                 selectReport: thisReportsDropdown.selectReport
+                            })}
+                        </li>
+                    );
                 });
             } else {
                 reportsData = <li><a href="#"><i className="fa fa-spin fa-spinner" /> Loading...</a></li>;


### PR DESCRIPTION
This commit adds an organisation field to reports, to associate one or more
organisations with a report. The report option is displayed only to users of
those organisations or to admin users.

Closes #2697


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
