### PR TITLE
[#2710] Reinstate link to custom stylesheet for Akvo pages

### DIFF
--- a/akvo/rsr/context_processors.py
+++ b/akvo/rsr/context_processors.py
@@ -58,7 +58,7 @@ def extra_pages_context(request):
             'organisation': page.organisation,
             'return_url': page.return_url,
             'return_url_text': page.custom_return_url_text,
-            'stylesheet': page.stylesheet,
+            'page_stylesheet': page.stylesheet,
             'akvoapp_root_url': '//{}'.format(settings.AKVOAPP_DOMAIN),
             'domain_url': '//{}'.format(settings.RSR_DOMAIN),
             'no_facebook': not page.facebook_button,

--- a/akvo/templates/base.html
+++ b/akvo/templates/base.html
@@ -53,6 +53,9 @@
 
     {# CSS #}
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap.min.css">
+    {% if page_stylesheet %}
+      <link rel="stylesheet" href="{{MEDIA_URL}}{{page_stylesheet}}">
+    {% endif %}
     {% if request.resolver_match.url_name == 'my_new_results' %}
       {% stylesheet 'new_results' %}
     {% else %}


### PR DESCRIPTION
Add back the code for generating the link to the custom CSS file that can be uploaded to an Akvo page

Also change the context variable name to `page_stylesheet` not to clash with Pipline's `stylesheet` template tag.

### Test plan

On rsr.test.akvo.org (I think this is the only test server where we can create a Page now that https is in force, but I don't recall the exact name to use) create a Page site and upload a cusom CSS file (can be "stolen" from an exising site). Check that the style is applied.

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry

This fixes #2710

```markdown
### Bugfix

Fix missing custom stylesheet for Akvo pages [#2710](https://github.com/akvo/akvo-rsr/issues/2710)
```