### PR TITLE
[#2719] Enable submitting the test env password modal using Return

### DIFF
--- a/akvo/rsr/static/scripts-src/cookie.js
+++ b/akvo/rsr/static/scripts-src/cookie.js
@@ -114,9 +114,10 @@ function createModal(){
                         React.createElement('br'),
                         React.createElement('br'),
                         React.createElement(
-                            'div',
+                            'form',
                             {
-                                className: formGroupClass
+                                className: formGroupClass,
+                                onSubmit: this.checkPassword
                             },
                             React.createElement(
                                 'input',
@@ -124,7 +125,8 @@ function createModal(){
                                     type: "password",
                                     value: this.state.passwordField,
                                     onChange: this.handleChange,
-                                    className: 'form-control'
+                                    className: 'form-control',
+                                    autoFocus: true
                                 }
                             )
                         ),

--- a/akvo/rsr/static/scripts-src/cookie.jsx
+++ b/akvo/rsr/static/scripts-src/cookie.jsx
@@ -114,9 +114,10 @@ function createModal(){
                         React.createElement('br'),
                         React.createElement('br'),
                         React.createElement(
-                            'div',
+                            'form',
                             {
-                                className: formGroupClass
+                                className: formGroupClass,
+                                onSubmit: this.checkPassword
                             },
                             React.createElement(
                                 'input',
@@ -124,7 +125,8 @@ function createModal(){
                                     type: "password",
                                     value: this.state.passwordField,
                                     onChange: this.handleChange,
-                                    className: 'form-control'
+                                    className: 'form-control',
+                                    autoFocus: true
                                 }
                             )
                         ),


### PR DESCRIPTION
Also, automatically focus the password input when the dialog is shown.

Closes #2719


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
```markdown
Make the password dialog on test environments more usable [#2719](https://github.com/akvo/akvo-rsr/issues/2719)
```
