### PR TITLE
[#2730] Improve UI interaction before all models are loaded

### DIFF
--- a/akvo/rsr/static/scripts-src/my-results/components/App.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/App.jsx
@@ -311,10 +311,10 @@ export default class App extends React.Component {
             <div className="col-xs-6">
             </div>;
 
-        const results = this.props.ui.allFetched ?
-            <Results parentId="results"/>
-        :
-            <p className="loading">Loading <i className="fa fa-spin fa-spinner" /></p>;
+        // const results = this.props.ui.allFetched ?
+        //     <Results parentId="results"/>
+        // :
+        //     <p className="loading">Loading <i className="fa fa-spin fa-spinner" /></p>;
 
         return (
             <div className={'periodMenuBar'}>
@@ -371,7 +371,7 @@ export default class App extends React.Component {
                         </div>
                     </div>
                 </div>
-                {results}
+                <Results parentId="results"/>
             </div>
         );
     }

--- a/akvo/rsr/static/scripts-src/my-results/components/Indicators.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/Indicators.jsx
@@ -144,9 +144,9 @@ export default class Indicators extends React.Component {
     render() {
         const indicatorIds = this.props.resultChildrenIds[this.props.parentId];
 
-        if (!indicatorIds) {
+        if (!this.props.indicators.fetched) {
             return (
-                <p>Loading...</p>
+                <p className="loading">Loading <i className="fa fa-spin fa-spinner" /></p>
             );
         } else if (indicatorIds.length > 0) {
             return (

--- a/akvo/rsr/static/scripts-src/my-results/components/Periods.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/Periods.jsx
@@ -198,7 +198,8 @@ const DeleteUpdateAlert = ({message, close}) => (
     return {
         periods: store.models.periods,
         keys: store.keys,
-        user: store.models.user.objects[store.models.user.ids[0]],
+        user: store.models.user.ids && store.models.user.ids.length > 0 ?
+            store.models.user.objects[store.models.user.ids[0]] : {},
         ui: store.ui,
         indicatorChildrenIds: getIndicatorsChildrenIds(store),
         actualValue: getPeriodsActualValue(store),
@@ -297,9 +298,9 @@ export default class Periods extends React.Component {
 
     render() {
         const periodIds = this.props.indicatorChildrenIds[this.props.parentId];
-        if (!periodIds) {
+        if (!this.props.periods.fetched) {
             return (
-                <p>Loading...</p>
+                <p className="loading">Loading <i className="fa fa-spin fa-spinner" /></p>
             );
         } else if (periodIds.length > 0) {
             return (

--- a/akvo/rsr/static/scripts-src/my-results/components/Results.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/Results.jsx
@@ -143,12 +143,13 @@ export default class Results extends React.Component {
 
     render() {
         // Special case, always get all Results
-        const resultIds = this.props.results.ids;
+        const results = this.props.results;
+        const resultIds = results.ids;
         const toggleKey = createToggleKey(resultIds, this.activeKey());
 
-        if (!resultIds) {
+        if (!results.fetched) {
             return (
-                <p>Loading...</p>
+                <p className="loading">Loading <i className="fa fa-spin fa-spinner" /></p>
             );
         } else if (resultIds.length > 0) {
             return (

--- a/akvo/rsr/static/scripts-src/my-results/components/updates/Updates.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/updates/Updates.jsx
@@ -336,9 +336,9 @@ export default class Updates extends React.Component {
     render() {
         const updateIds = this.props.periodChildrenIds[this.props.parentId] || [];
         // const toggleKey = createToggleKey(ids, this.activeKey());
-        if (!updateIds) {
+        if (!this.props.updates.fetched) {
             return (
-                <p>Loading...</p>
+                <p className="loading">Loading <i className="fa fa-spin fa-spinner" /></p>
             );
         } else if (updateIds.length > 0) {
             return (

--- a/akvo/rsr/static/scripts-src/my-results/utils.js
+++ b/akvo/rsr/static/scripts-src/my-results/utils.js
@@ -27,6 +27,34 @@ export function identicalArrays(array1, array2) {
 }
 
 
+// From https://stackoverflow.com/questions/4994201/is-object-empty
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+export function isEmpty(obj) {
+
+    // null and undefined are "empty"
+    if (obj == null) return true;
+
+    // Assume if it has a length property with a non-zero value
+    // that that property is correct.
+    if (obj.length > 0)    return false;
+    if (obj.length === 0)  return true;
+
+    // If it isn't an object at this point
+    // it is empty, but it can't be anything *but* empty
+    // Is it empty?  Depends on your application.
+    if (typeof obj !== "object") return true;
+
+    // Otherwise, does it have any properties of its own?
+    // Note that this doesn't handle
+    // toString and valueOf enumeration bugs in IE < 9
+    for (var key in obj) {
+        if (hasOwnProperty.call(obj, key)) return false;
+    }
+
+    return true;
+}
+
+
 // global holding the month's translation strings
 let months;
 export function displayDate(dateString) {


### PR DESCRIPTION
Add Loading... messages on all accordion levels and add more checks to selectors making sure they work when the params they rely on are not populated yet.

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry

### Testing

This is a little hard to test. I used the throttling in Chrome to load the page at a crawl and then I got a short time window when not all models were loaded. As far as I could tell I could still interact with the page, opening the Results accordion and see how the aggregate values in the indicators appeared when the periods and updates were fetched.

Proper unit tests would improve the situation here 😉.
