### PR TITLE
[#2684] Keep the set page size value even after filters applied

### DIFF
--- a/akvo/rsr/views/project.py
+++ b/akvo/rsr/views/project.py
@@ -128,6 +128,7 @@ def directory(request):
         'current_org': org_filter,
         'map_projects': map_projects,
         'sectors_dict': sectors_dict,
+        'limit': limit,
     }
     return render(request, 'project_directory.html', context)
 

--- a/akvo/templates/project_directory.html
+++ b/akvo/templates/project_directory.html
@@ -36,6 +36,8 @@
       </div>
     </section>
     <div id="wrapper"></div>
+    <!-- hidden input field to keep the page limit when using the filters -->
+    <input style="display: none;" name="limit" value="{{limit}}"/>
   </form>
 
   <div class="container">


### PR DESCRIPTION
Page size is set using a `limit` query parameter. When filters are applied, a
form submission happens, and only the form data is submitted to the server. The
`limit` query parameter gets lost.  This commit adds a hidden field for the
limit parameter to the form, so that this data is retained even when form
submissions happen.

Closes #2684


- [x] Test plan | Unit test | Integration test

  - Go to the project directory
  - Change the number of projects being view from 10 to 20/50/100. 
  - Select one or more advanced filters and apply them
  - Check that the results pages have the same number of projects per page, as chosen above

- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
```
Don't reset the page size to the default value of 10, when filters are applied [#2684](https://github.com/akvo/akvo-rsr/issues/2684)
```
