### PR TITLE
[#2740] Rename query parameter iati_status to status

### DIFF
--- a/akvo/rsr/static/scripts-src/project-directory-filters.js
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.js
@@ -66,7 +66,6 @@ var FilterForm = React.createClass({displayName: "FilterForm",
             this.toggleForm();
             document.querySelector('#search-view').scrollIntoView();
         }
-
     },
     render: function(){
         var create_filter = function(filter_name){
@@ -189,6 +188,8 @@ var FilterForm = React.createClass({displayName: "FilterForm",
     getStateFromUrl: function(){
         var selected = {};
         var query = location.search.substring(1);
+        // Treat iati_status query param as status param
+        query = query.replace('iati_status', 'status');
         if (query === '') { return selected; }
         query.split('&').map(function(query_term){
             var pair = query_term.split('='),

--- a/akvo/rsr/static/scripts-src/project-directory-filters.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.jsx
@@ -188,6 +188,8 @@ var FilterForm = React.createClass({
     getStateFromUrl: function(){
         var selected = {};
         var query = location.search.substring(1);
+        // Treat iati_status query param as status param
+        query = query.replace('iati_status', 'status');
         if (query === '') { return selected; }
         query.split('&').map(function(query_term){
             var pair = query_term.split('='),

--- a/akvo/rsr/views/project.py
+++ b/akvo/rsr/views/project.py
@@ -45,6 +45,10 @@ def directory(request):
     """The project list view."""
     qs = remove_empty_querydict_items(request.GET)
 
+    # iati_status was renamed to sector in fa8094647b
+    if 'status' not in qs:
+        qs['status'] = qs.pop('iati_status', [''])[0]
+
     # Set show_filters to "in" if any filter is selected
     show_filters = "in"  # To simplify template use bootstrap class
     available_filters = [

--- a/akvo/templates/organisation_main.html
+++ b/akvo/templates/organisation_main.html
@@ -126,7 +126,7 @@ For additional details on the GNU license please see http://www.gnu.org/licenses
             <dt class="iatiStatuses">{% trans 'Pipeline/identification' %}</dt>
             <dd>
               {% if organisation.published_projects.status_onhold.count %}
-                <a href="{% url 'project-directory' %}?organisation={{ organisation.pk }}&amp;iati_status=1">
+                <a href="{% url 'project-directory' %}?organisation={{ organisation.pk }}&amp;status=1">
                   {{ organisation.published_projects.status_onhold.count }}
                 </a>
               {% else %}
@@ -136,7 +136,7 @@ For additional details on the GNU license please see http://www.gnu.org/licenses
             <dt class="iatiStatuses">{% trans 'Implementation' %}</dt>
             <dd>
               {% if organisation.published_projects.status_active.count %}
-                <a href="{% url 'project-directory' %}?organisation={{ organisation.pk }}&amp;iati_status=2">
+                <a href="{% url 'project-directory' %}?organisation={{ organisation.pk }}&amp;status=2">
                   {{ organisation.published_projects.status_active.count }}
                 </a>
               {% else %}
@@ -146,7 +146,7 @@ For additional details on the GNU license please see http://www.gnu.org/licenses
             <dt class="iatiStatuses">{% trans 'Completion' %}</dt>
             <dd>
               {% if organisation.published_projects.status_complete.count %}
-                <a href="{% url 'project-directory' %}?organisation={{ organisation.pk }}&amp;iati_status=3">
+                <a href="{% url 'project-directory' %}?organisation={{ organisation.pk }}&amp;status=3">
                   {{ organisation.published_projects.status_complete.count }}
                 </a>
               {% else %}
@@ -156,7 +156,7 @@ For additional details on the GNU license please see http://www.gnu.org/licenses
             <dt class="iatiStatuses">{% trans 'Post-completion' %}</dt>
             <dd>
               {% if organisation.published_projects.status_post_complete.count %}
-                <a href="{% url 'project-directory' %}?organisation={{ organisation.pk }}&amp;iati_status=4">
+                <a href="{% url 'project-directory' %}?organisation={{ organisation.pk }}&amp;status=4">
                   {{ organisation.published_projects.status_post_complete.count }}
                 </a>
               {% else %}
@@ -166,7 +166,7 @@ For additional details on the GNU license please see http://www.gnu.org/licenses
             <dt class="iatiStatuses">{% trans 'Cancelled' %}</dt>
             <dd>
               {% if organisation.published_projects.status_cancelled.count %}
-                <a href="{% url 'project-directory' %}?organisation={{ organisation.pk }}&amp;iati_status=5">
+                <a href="{% url 'project-directory' %}?organisation={{ organisation.pk }}&amp;status=5">
                   {{ organisation.published_projects.status_cancelled.count }}
                 </a>
               {% else %}
@@ -176,7 +176,7 @@ For additional details on the GNU license please see http://www.gnu.org/licenses
             <dt class="iatiStatuses">{% trans 'Suspended' %}</dt>
             <dd>
               {% if organisation.published_projects.status_none.count %}
-                <a href="{% url 'project-directory' %}?organisation={{ organisation.pk }}&amp;iati_status=6">
+                <a href="{% url 'project-directory' %}?organisation={{ organisation.pk }}&amp;status=6">
                   {{ organisation.published_projects.status_none.count }}
                 </a>
               {% else %}


### PR DESCRIPTION
The filter name was changed in a previous
commit (fa8094647b1270ec5aa28f15c09b10f7f1b24693) when the dynamic filter was
implemented.  But, a lot of links actually use the old filter, and hence are
broken.  This commit renames the query parameter to fix the problem.

Closes #2740


- [ ] Test plan | Unit test | Integration test

  - The links to projects in different states (completed/post-completion, etc.) on the Organisation page should show the correct number of projects. 
    For example: https://rsr.akvo.org/en/organisation/42

- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
```
Fix broken links to projects in different states from the organisation page [#2740](fa8094647b1270ec5aa28f15c09b10f7f1b24693)
```