### PR TITLE
Use a cookie to detect if advanced filters pane should be open or not

### DIFF
--- a/akvo/rsr/static/scripts-src/cookie.js
+++ b/akvo/rsr/static/scripts-src/cookie.js
@@ -27,7 +27,7 @@ function createDiv() {
     div.innerHTML = '<p>' + cookie_text + '<a href="http://akvo.org/help/akvo-policies-and-terms-2/akvo-terms-of-use/cookie-policy/" rel="nofollow" title="Privacy &amp; Cookies Policy" target="_blank">' + policy_text + '</a>.    <a class="close-cookie-banner btn btn-primary" href="javascript:void(0);" onclick="window.removeMe();"><span>' + button_text + '</span></a></p>';
     bodytag.insertBefore(div,bodytag.firstChild); // Adds the Cookie Law Banner just after the opening <body> tag
     document.getElementsByTagName('body')[0].className+=' cookiebanner'; //Adds a class to the <body> tag when the banner is visible
-    createCookie(cookieName, cookieValue, cookieDuration); // Create the cookie
+    Cookies.set(cookieName, cookieValue, {expires: cookieDuration}); // Create the cookie
 }
 
 
@@ -51,7 +51,7 @@ function createModal(){
         },
 
         createProtectionCookie: function() {
-            createCookie(protectCookieName, cookieValue, protectCookieDuration);
+            Cookies.set(protectCookieName, cookieValue, {expires: protectCookieDuration});
         },
 
         checkPassword: function() {
@@ -157,32 +157,9 @@ function createModal(){
 }
 
 
-function createCookie(name,value,days) {
-    var date, expires = "";
-    if (days) {
-        date = new Date();
-        date.setTime(date.getTime()+(days*24*60*60*1000));
-        expires = "; expires="+date.toGMTString();
-    }
-    if(dropCookie) {
-        document.cookie = name+"="+value+expires+"; path=/";
-    }
-}
-
-function checkCookie(name) {
-    var nameEQ = name + "=";
-    var ca = document.cookie.split(';');
-    for(var i=0;i < ca.length;i++) {
-        var c = ca[i];
-        while (c.charAt(0)==' ') c = c.substring(1,c.length);
-        if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length,c.length);
-    }
-    return null;
-}
-
 function removeMe(){
-	var element = document.getElementById('cookie-law');
-	element.parentNode.removeChild(element);
+  var element = document.getElementById('cookie-law');
+  element.parentNode.removeChild(element);
 }
 window.removeMe = removeMe;
 
@@ -238,7 +215,7 @@ document.addEventListener('DOMContentLoaded', function() {
     testEnvironments = ['test', 'uat'];     // Set the test environments that need a password
 
     // Check for a protection cookie on Test or UAT
-    if (checkCookie(protectCookieName)!== cookieValue) {
+    if (Cookies.get(protectCookieName)!== cookieValue) {
         var hostnameArray = window.location.hostname.split(".");
         for (var i = 0; i < testEnvironments.length; i++) {
             if (hostnameArray.indexOf(testEnvironments[i]) > -1) {
@@ -249,7 +226,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     // Check for general cookie
-    if (checkCookie(cookieName) !== cookieValue) {
+    if (Cookies.get(cookieName) !== cookieValue) {
         createDiv();
     }
 });

--- a/akvo/rsr/static/scripts-src/cookie.jsx
+++ b/akvo/rsr/static/scripts-src/cookie.jsx
@@ -27,7 +27,7 @@ function createDiv() {
     div.innerHTML = '<p>' + cookie_text + '<a href="http://akvo.org/help/akvo-policies-and-terms-2/akvo-terms-of-use/cookie-policy/" rel="nofollow" title="Privacy &amp; Cookies Policy" target="_blank">' + policy_text + '</a>.    <a class="close-cookie-banner btn btn-primary" href="javascript:void(0);" onclick="window.removeMe();"><span>' + button_text + '</span></a></p>';
     bodytag.insertBefore(div,bodytag.firstChild); // Adds the Cookie Law Banner just after the opening <body> tag
     document.getElementsByTagName('body')[0].className+=' cookiebanner'; //Adds a class to the <body> tag when the banner is visible
-    createCookie(cookieName, cookieValue, cookieDuration); // Create the cookie
+    Cookies.set(cookieName, cookieValue, {expires: cookieDuration}); // Create the cookie
 }
 
 
@@ -51,7 +51,7 @@ function createModal(){
         },
 
         createProtectionCookie: function() {
-            createCookie(protectCookieName, cookieValue, protectCookieDuration);
+            Cookies.set(protectCookieName, cookieValue, {expires: protectCookieDuration});
         },
 
         checkPassword: function() {
@@ -157,32 +157,9 @@ function createModal(){
 }
 
 
-function createCookie(name,value,days) {
-    var date, expires = "";
-    if (days) {
-        date = new Date();
-        date.setTime(date.getTime()+(days*24*60*60*1000));
-        expires = "; expires="+date.toGMTString();
-    }
-    if(dropCookie) {
-        document.cookie = name+"="+value+expires+"; path=/";
-    }
-}
-
-function checkCookie(name) {
-    var nameEQ = name + "=";
-    var ca = document.cookie.split(';');
-    for(var i=0;i < ca.length;i++) {
-        var c = ca[i];
-        while (c.charAt(0)==' ') c = c.substring(1,c.length);
-        if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length,c.length);
-    }
-    return null;
-}
-
 function removeMe(){
-	var element = document.getElementById('cookie-law');
-	element.parentNode.removeChild(element);
+  var element = document.getElementById('cookie-law');
+  element.parentNode.removeChild(element);
 }
 window.removeMe = removeMe;
 
@@ -238,7 +215,7 @@ document.addEventListener('DOMContentLoaded', function() {
     testEnvironments = ['test', 'uat'];     // Set the test environments that need a password
 
     // Check for a protection cookie on Test or UAT
-    if (checkCookie(protectCookieName)!== cookieValue) {
+    if (Cookies.get(protectCookieName)!== cookieValue) {
         var hostnameArray = window.location.hostname.split(".");
         for (var i = 0; i < testEnvironments.length; i++) {
             if (hostnameArray.indexOf(testEnvironments[i]) > -1) {
@@ -249,7 +226,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     // Check for general cookie
-    if (checkCookie(cookieName) !== cookieValue) {
+    if (Cookies.get(cookieName) !== cookieValue) {
         createDiv();
     }
 });

--- a/akvo/rsr/static/scripts-src/project-directory-filters.js
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.js
@@ -62,11 +62,9 @@ var FilterForm = React.createClass({displayName: "FilterForm",
     componentDidMount: function(){
         this.fetchFilterOptions(true);
         window.advanced_filter_form = this;
-        if (Object.keys(this.state.selected).length > 0) {
-            this.toggleForm();
+        if (Cookies.get('showAdvancedFilters') === 'on') {
             document.querySelector('#search-view').scrollIntoView();
         }
-
     },
     render: function(){
         var create_filter = function(filter_name){

--- a/akvo/rsr/static/scripts-src/project-directory-filters.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.jsx
@@ -62,8 +62,7 @@ var FilterForm = React.createClass({
     componentDidMount: function(){
         this.fetchFilterOptions(true);
         window.advanced_filter_form = this;
-        if (Object.keys(this.state.selected).length > 0) {
-            this.toggleForm();
+        if (Cookies.get('showAdvancedFilters') === 'on') {
             document.querySelector('#search-view').scrollIntoView();
         }
     },

--- a/akvo/rsr/static/scripts-src/rsr.js
+++ b/akvo/rsr/static/scripts-src/rsr.js
@@ -33,12 +33,27 @@ window.AKVO_RSR.utils = {
 
 $(document).ready(function() {
 
+  function toggle_advanced_filters(show){
+    // Toggles the advanced filters pane if show is undefined
+    // Shows the pane if show is true.
+    // Hides the pane if show is false.
+    if (show != undefined && show == $("#wrapper, #search").hasClass('toggled')){
+      return;
+    }
+    $("#wrapper, #search").toggleClass("toggled");
+    $("a.showFilters > i").toggleClass("fa-toggle-off fa-toggle-on");
+    Cookies.set('showAdvancedFilters', $("#wrapper, #search").hasClass('toggled')?'on':'off');
+  }
+
   // Advanced filtering & search
   $(".menu-toggle").click(function(e) {
     e.preventDefault();
-    $("#wrapper, #search").toggleClass("toggled");
-    $("a.showFilters > i").toggleClass("fa-toggle-off fa-toggle-on");
+    toggle_advanced_filters();
   });
+
+  if ($("#wrapper, #search").length && Cookies.get('showAdvancedFilters') === 'on'){
+    toggle_advanced_filters(true);
+  }
 
   // partner + tooltip
   $('[data-toggle="tooltip"]').tooltip({
@@ -48,7 +63,7 @@ $(document).ready(function() {
       "hide": 1000
     }
   });
-  
+
 
   function getCookie(name) {
     var cookieValue = null;

--- a/akvo/templates/base.html
+++ b/akvo/templates/base.html
@@ -106,6 +106,7 @@
       {# Other third party libraries #}
       <script src="//cdnjs.cloudflare.com/ajax/libs/jsPlumb/1.7.2/dom.jsPlumb.js" integrity="sha256-0bM5Fc0I7ovRAgHPI8ECaoa5wqvyi6xYL+t272uvdbE=" crossorigin="anonymous"></script>
       <script src="//cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.js" integrity="sha256-/jZqCQrAZxcboc/rOOI54YFU6KVLAi/Zvs6IG0xVXyk=" crossorigin="anonymous"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.1.4/js.cookie.js" integrity="sha256-VbCkoqthqE7ves/+1VO4vW2so2L7zhb4uanLPLcrh4k=" crossorigin="anonymous"></script>
       {% else %}
       {# jQuery #}
       <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js" integrity="sha256-1OxYPHYEAB+HIz0f4AdsvZCfFaX4xrTD9d2BtGLXnTI=" crossorigin="anonymous"></script>
@@ -122,6 +123,7 @@
       {# Other third party libraries #}
       <script src="//cdnjs.cloudflare.com/ajax/libs/jsPlumb/1.7.2/dom.jsPlumb.min.js" integrity="sha256-F1cIPOY4SemH0aexB8v8gKVMOpAOa2tT+TSPjZbdoS8=" crossorigin="anonymous"></script>
       <script src="//cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js" integrity="sha256-aB35laj7IZhLTx58xw/Gm1EKOoJJKZt6RY+bH1ReHxs=" crossorigin="anonymous"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.1.4/js.cookie.min.js" integrity="sha256-NjbogQqosWgor0UBdCURR5dzcvAgHnfUZMcZ8RCwkk8=" crossorigin="anonymous"></script>
     {% endif %}
 
     {# bootstrap #}


### PR DESCRIPTION
- [x] Test plan | Unit test | Integration test
  1. Click on the advanced search button to open the advanced filters pane. 
  2. Reload the page to see that the advanced filters pane is open.
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
```
Open the advanced filters pane if it was previously opened, not otherwise [#2741](https://github.com/akvo/akvo-rsr/issues/2741)
```