### PR TITLE
[#2745] Reports are not visible to some users

### DIFF
--- a/akvo/rest/views/user.py
+++ b/akvo/rest/views/user.py
@@ -130,7 +130,7 @@ def request_organisation(request, pk=None):
         data = EmploymentSerializer(employment).data
         if data['country']:
             data['country_full'] = employment.iati_country().name
-            data['country_name'] = str(employment.iati_country())
+            data['country_name'] = unicode(employment.iati_country())
         else:
             data['country_full'] = ''
         data['organisation_full'] = OrganisationSerializer(organisation).data

--- a/akvo/rsr/models/employment.py
+++ b/akvo/rsr/models/employment.py
@@ -76,7 +76,7 @@ class Employment(models.Model):
         return codelist_value(codelist_models.Country, self, 'country')
 
     def iati_country_unicode(self):
-        return str(self.iati_country())
+        return unicode(self.iati_country())
 
     def approve(self, approved_by):
         """

--- a/akvo/rsr/tests/rest/test_user.py
+++ b/akvo/rsr/tests/rest/test_user.py
@@ -12,6 +12,7 @@ from __future__ import print_function
 from django.conf import settings
 from django.test import TransactionTestCase, Client
 
+from akvo.codelists.models import Country, Version
 from akvo.rsr.models import Employment, Organisation, User
 from akvo.utils import check_auth_groups
 
@@ -31,6 +32,13 @@ class UserTestCase(TransactionTestCase):
         self.user = self._create_user('abc@example.com', self.user_password)
         self.c.login(username=self.user.username, password=self.user_password)
 
+        version = Version.objects.create(code=settings.IATI_VERSION)
+        self.country = Country.objects.create(
+            code='CI',
+            name=u'CI - C\xc3\xb4te Divoire',
+            version=version
+        )
+
     def test_request_organisation_simple(self):
         # Given
         data = {'organisation': self.org.id}
@@ -48,7 +56,7 @@ class UserTestCase(TransactionTestCase):
 
     def test_request_organisation_once(self):
         # Given
-        data = {'organisation': self.org.id, 'country': '', 'job_title': ''}
+        data = {'organisation': self.org.id, 'country': 'CI', 'job_title': ''}
         pk = self.user.id
 
         # When


### PR DESCRIPTION
Closes #2745


- [ ] Test plan | Unit test | Integration test
  Verify that the end-point `http://rsr.localdev.akvo.org/rest/v1/user/30297/?format=json` doesn't 500. 
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
  ```
  Problem with displaying report types for some kinds of users resolved - [#2745](https://github.com/akvo/akvo-rsr/issues/2745)
  ```