### PR TITLE
[#2738] Use actual value of a period directly

### DIFF
--- a/akvo/rsr/static/scripts-src/my-results/selectors.js
+++ b/akvo/rsr/static/scripts-src/my-results/selectors.js
@@ -104,8 +104,8 @@ export const getPeriodsActualValue = createSelector(
         Return an object on the form:
         {periodId1: <actualValue1>, periodId2: <actualValue2>,...}
      */
-    [getPeriodIds, getUpdateObjects, getPeriodsChildrenIds],
-    (periodIds, updateObjects, childUpdateIds) => {
+    [getPeriodIds, getPeriodObjects, getUpdateObjects, getPeriodsChildrenIds],
+    (periodIds, periodObjects, updateObjects, childUpdateIds) => {
         return periodIds && updateObjects && !isEmpty(childUpdateIds) && periodIds.reduce((acc, periodId) => {
             const actualValue = childUpdateIds[periodId].filter(
                 (updateId) => updateObjects[updateId].status == c.UPDATE_STATUS_APPROVED
@@ -120,7 +120,13 @@ export const getPeriodsActualValue = createSelector(
                     return acc;
                 }, 0
             );
-            return {...acc, [periodId]: actualValue};
+          // We allow users to set an actual value on periods directly from the
+          // project editor. When there are no updates, over which we can
+          // aggregate, this value should be used as the actual value. Also, the
+          // UI only allows actual values to be numbers, so we try and convert
+          // it to a number.
+          const periodActualValue = (parseFloat(periodObjects[periodId].actual_value)||0);
+          return {...acc, [periodId]: (childUpdateIds[periodId].length > 0)?actualValue:periodActualValue};
         }, {});
     }
 );


### PR DESCRIPTION
Instead of aggregating the updates on the client side, we directly use the
actual value on the period, so that

1. we remove duplication of this aggregation computation on the client side
2. handle the case when a period has no updates, but the actual value has been
   set directly on the period.

Closes #2738


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

```markdown
Use the actual value for a period entered in project editor if there is one and no updates have been added to the period. [2738](https://github.com/akvo/akvo-rsr/issues/2738)
```