### PR TITLE
[#2742] Display an error message when uploading org logo fails

### DIFF
--- a/akvo/rest/views/project_editor.py
+++ b/akvo/rest/views/project_editor.py
@@ -327,10 +327,12 @@ def update_object(Model, obj_id, field, obj_data, field_name, orig_data, changes
         # Retrieve object and set new value of field
         obj = Model.objects.get(pk=int(obj_id))
         setattr(obj, field, obj_data)
+        print "*** 01 ***"
     except (Model.DoesNotExist, ValueError) as e:
         # If object does not exist or 'obj_id' is not an integer, add an error and do not process
         # the object
         errors = add_error(errors, str(e), field_name)
+        print "*** 02 ***"
         return changes, errors, rel_objects
 
     try:
@@ -338,6 +340,7 @@ def update_object(Model, obj_id, field, obj_data, field_name, orig_data, changes
         obj.full_clean(exclude=['primary_location',
                                 'primary_organisation',
                                 'last_update'])
+        print "*** 03 ***"
     except ValidationError as e:
         if field in dict(e).keys():
             # Since we save the object per field, display the (first) error of this field on the
@@ -347,10 +350,12 @@ def update_object(Model, obj_id, field, obj_data, field_name, orig_data, changes
             # Somewhere else in the model a validation error occurred (or a combination of fields).
             # We display this nonetheless and do not save the field.
             errors = add_error(errors, str(e), field_name)
+        print "*** 04 ***"
     except Exception as e:
         # Just in case any other error will occur, this will also be displayed underneath the field
         # in the project editor.
         errors = add_error(errors, str(e), field_name)
+        print "*** 05 ***"
     else:
         # No validation errors. Save the field and append the changes to the changes list.
         # In case of a non-Project object, add the object to the related objects list, so that the
@@ -359,7 +364,9 @@ def update_object(Model, obj_id, field, obj_data, field_name, orig_data, changes
         changes = add_changes(changes, obj, field, field_name, orig_data)
         if not (related_obj_id in rel_objects.keys() or isinstance(obj, Project)):
             rel_objects[related_obj_id] = obj.pk
+        print "*** 06 ***"
     finally:
+        print "*** 07 ***"
         return changes, errors, rel_objects
 
 
@@ -860,6 +867,7 @@ def project_editor_remove_keyword(request, project_pk=None, keyword_pk=None):
 @api_view(['POST'])
 @permission_classes((IsAuthenticated, ))
 def project_editor_organisation_logo(request, pk=None):
+
     org = Organisation.objects.get(pk=pk)
     user = request.user
 
@@ -869,11 +877,14 @@ def project_editor_organisation_logo(request, pk=None):
     data = request.data
     errors, changes, rel_objects = [], [], {}
 
+    print "foo"
     if 'logo' in data.keys():
+        print "bar"
         changes, errors, rel_objects = update_object(
             Organisation, pk, 'logo', data['logo'], '', '', changes, errors,
             rel_objects, 'rsr_organisation.' + str(pk)
         )
+    print "baz"
 
     return Response({'errors': errors})
 

--- a/akvo/rsr/models/organisation.py
+++ b/akvo/rsr/models/organisation.py
@@ -39,6 +39,7 @@ ORG_TYPES = (
 
 
 def image_path(instance, file_name):
+    print instance.id, file_name
     return rsr_image_path(instance, file_name, 'db/org/%(instance_pk)s/%(file_name)s')
 
 

--- a/akvo/rsr/static/scripts-src/project-editor.js
+++ b/akvo/rsr/static/scripts-src/project-editor.js
@@ -3508,6 +3508,7 @@ function addOrgModal() {
                     if (org_logo_files !== undefined) {
                         api_url = '/rest/v1/organisation/' + organisation_id + '/add_logo/?format=json';
                         logo_data = new FormData();
+                        console.log("org_logo_files[0]: " + org_logo_files[0]);
                         logo_data.append("logo", org_logo_files[0]);
                         logo_request = new XMLHttpRequest();
                         logo_request.onreadystatechange = function() {

--- a/akvo/rsr/static/scripts-src/project-editor.js
+++ b/akvo/rsr/static/scripts-src/project-editor.js
@@ -3502,7 +3502,7 @@ function addOrgModal() {
                         request_loc.send(form_data + '&location_target=' + organisation_id);
                     }
 
-                    // Add logo (fails silently)
+                    // Add logo
                     var logo_request, logo_data, org_logo_files;
                     org_logo_files = document.getElementById("org-logo").files;
                     if (org_logo_files !== undefined) {
@@ -3510,6 +3510,37 @@ function addOrgModal() {
                         logo_data = new FormData();
                         logo_data.append("logo", org_logo_files[0]);
                         logo_request = new XMLHttpRequest();
+                        logo_request.onreadystatechange = function() {
+                            if (logo_request.readyState !== XMLHttpRequest.DONE) { return; }
+                            if (logo_request.status === 200) { return; }
+                            var Modal = ReactBootstrap.Modal,
+                                Button = ReactBootstrap.Button;
+                            var ErrorModal = React.createClass({displayName: "ErrorModal",
+                                render: function(){
+                                    return (
+                                        React.createElement("div", {className: "modalContainer"},
+                                            React.createElement(Modal.Dialog, null,
+                                                React.createElement(Modal.Header, {closeButton: true, onHide: this.hideModal},
+                                                    React.createElement(Modal.Title, null, "Error: Failed to upload Organisation Logo")
+                                                ),
+                                                React.createElement(Modal.Body, null,
+                                                    "The logo for the organisation could not be successfully updated," + ' ' +
+                                                    "probably due to a network issue."
+                                                ),
+                                                React.createElement(Modal.Footer, null,
+                                                    React.createElement(Button, {onClick: this.hideModal}, "Close")
+                                                )
+                                            )
+                                        )
+                                    );
+                                },
+
+                                hideModal: function(){
+                                    ReactDOM.findDOMNode(this).remove();
+                                }
+                            });
+                            ReactDOM.render(React.createElement(ErrorModal, null), document.querySelector('footer'));
+                        };
                         logo_request.open("POST", api_url);
                         logo_request.setRequestHeader("X-CSRFToken", csrftoken);
                         logo_request.send(logo_data);

--- a/akvo/rsr/static/scripts-src/project-editor.jsx
+++ b/akvo/rsr/static/scripts-src/project-editor.jsx
@@ -3502,7 +3502,7 @@ function addOrgModal() {
                         request_loc.send(form_data + '&location_target=' + organisation_id);
                     }
 
-                    // Add logo (fails silently)
+                    // Add logo
                     var logo_request, logo_data, org_logo_files;
                     org_logo_files = document.getElementById("org-logo").files;
                     if (org_logo_files !== undefined) {
@@ -3510,6 +3510,37 @@ function addOrgModal() {
                         logo_data = new FormData();
                         logo_data.append("logo", org_logo_files[0]);
                         logo_request = new XMLHttpRequest();
+                        logo_request.onreadystatechange = function() {
+                            if (logo_request.readyState !== XMLHttpRequest.DONE) { return; }
+                            if (logo_request.status === 200) { return; }
+                            var Modal = ReactBootstrap.Modal,
+                                Button = ReactBootstrap.Button;
+                            var ErrorModal = React.createClass({
+                                render: function(){
+                                    return (
+                                        <div className="modalContainer">
+                                            <Modal.Dialog>
+                                                <Modal.Header closeButton={true} onHide={this.hideModal}>
+                                                    <Modal.Title>Error: Failed to upload Organisation Logo</Modal.Title>
+                                                </Modal.Header>
+                                                <Modal.Body>
+                                                    The logo for the organisation could not be successfully updated,
+                                                    probably due to a network issue.
+                                                </Modal.Body>
+                                                <Modal.Footer>
+                                                    <Button onClick={this.hideModal}>Close</Button>
+                                                </Modal.Footer>
+                                            </Modal.Dialog>
+                                        </div>
+                                    );
+                                },
+
+                                hideModal: function(){
+                                    ReactDOM.findDOMNode(this).remove();
+                                }
+                            });
+                            ReactDOM.render(<ErrorModal/>, document.querySelector('footer'));
+                        };
                         logo_request.open("POST", api_url);
                         logo_request.setRequestHeader("X-CSRFToken", csrftoken);
                         logo_request.send(logo_data);


### PR DESCRIPTION
Closes #2742


- [ ] Test plan | Unit test | Integration test

   - Modify the function `rest.views.project_editor.project_editor_organisation_logo` and raise an error in it, for all requests
   - Create a new organisation from section 3 - Project partners - by typing a non-existing name in the partner field, and clicking on `add new organization`.
   - Ensure that failing to upload the logo doesn't fail silently 

- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
```markdown
- Fixed the problem of organization logo failing to upload silently without notifying the user - [#2742](https://github.com/akvo/akvo-rsr/issues/2742)
```