### PR TITLE
[#2771] Display organization long names in the partners tab

### DIFF
--- a/akvo/iati/imports/__init__.py
+++ b/akvo/iati/imports/__init__.py
@@ -97,16 +97,16 @@ class ImportMapper(object):
 
         if name:
             try:
-                return Organisation.objects.get(name=name[:25])
+                return Organisation.objects.get(name=name[:40])
             except Organisation.DoesNotExist:
                 try:
-                    return Organisation.objects.get(long_name=name[:75])
+                    return Organisation.objects.get(long_name=name[:100])
                 except Organisation.DoesNotExist:
                     pass
 
         return Organisation.objects.create(
-            name=name[:25],
-            long_name=name[:75],
+            name=name[:40],
+            long_name=name[:100],
             iati_org_id=ref if ref else None,
             organisation_type=ORG_TYPE_NGO,
             content_owner=self.project.reporting_org

--- a/akvo/iati/imports/mappers/CordaidZip/organisations.py
+++ b/akvo/iati/imports/mappers/CordaidZip/organisations.py
@@ -116,7 +116,7 @@ class Organisations(ImportMapper):
         org_fields = {}
         org_fields['long_name'] = self.get_child_element_text(
             self.parent_elem, 'name', 'long_name').strip()
-        org_fields['name'] = org_fields['long_name'][:25]
+        org_fields['name'] = org_fields['long_name'][:40]
         org_fields['new_organisation_type'] = int(self.get_child_element_text(
             self.parent_elem, 'iati_organisation_type', 'new_organisation_type', 22))
         org_fields['iati_org_id'] = self.get_child_element_text(

--- a/akvo/rest/views/organisation.py
+++ b/akvo/rest/views/organisation.py
@@ -50,7 +50,7 @@ class AkvoOrganisationParser(XMLParser):
             return [dict(latitude=latitude, longitude=longitude, country=country, primary=primary)]
 
         long_name = find_text(tree, 'name')
-        name = long_name[:25]
+        name = long_name[:40]
         description = find_text(tree, 'description')
         url = find_text(tree, 'url')
         iati_type = find_text(tree, 'iati_organisation_type')

--- a/akvo/rsr/models/employment.py
+++ b/akvo/rsr/models/employment.py
@@ -70,7 +70,7 @@ class Employment(models.Model):
 
     def __unicode__(self):
         return u"{0} {1}: {2}".format(self.user.first_name, self.user.last_name,
-                                      self.organisation.name)
+                                      self.organisation.get_name)
 
     def iati_country(self):
         return codelist_value(codelist_models.Country, self, 'country')

--- a/akvo/rsr/models/iati_export.py
+++ b/akvo/rsr/models/iati_export.py
@@ -46,8 +46,8 @@ class IatiExport(TimestampsMixin, models.Model):
         verbose_name_plural = _(u'IATI exports')
 
     def __unicode__(self):
-        if self.reporting_organisation and self.reporting_organisation.name:
-            return u'%s %s' % (_(u'IATI export for'), self.reporting_organisation.name)
+        if self.reporting_organisation and self.reporting_organisation.get_name:
+            return u'%s %s' % (_(u'IATI export for'), self.reporting_organisation.get_name)
         else:
             return u'%s' % _(u'IATI export for unknown organisation')
 

--- a/akvo/rsr/models/internal_organisation_id.py
+++ b/akvo/rsr/models/internal_organisation_id.py
@@ -26,8 +26,8 @@ class InternalOrganisationID(models.Model):
 
     def __unicode__(self):
         return _(u"{rec_org_name}'s internal ID for {ref_org_name}: {identifier}").format(
-            rec_org_name=self.recording_org.name,
-            ref_org_name=self.referenced_org.name,
+            rec_org_name=self.recording_org.get_name,
+            ref_org_name=self.referenced_org.get_name,
             identifier=self.identifier,
         )
 

--- a/akvo/rsr/models/partner_site.py
+++ b/akvo/rsr/models/partner_site.py
@@ -165,7 +165,7 @@ class PartnerSite(TimestampsMixin, models.Model):
 
     def __unicode__(self):
         """Unicode representation."""
-        return _(u'Akvo page for {}').format(self.organisation.name)
+        return _(u'Akvo page for {}').format(self.organisation.get_name)
 
     def save(self, *args, **kwargs):
         if self.hostname:

--- a/akvo/rsr/models/partnership.py
+++ b/akvo/rsr/models/partnership.py
@@ -163,8 +163,7 @@ class Partnership(models.Model):
     def organisation_show_link(self):
         if self.organisation:
             return u'<a href="{0}">{1}</a>'.format(self.organisation.get_absolute_url(),
-                                                   self.organisation.long_name or
-                                                   self.organisation.name)
+                                                   self.organisation.get_name)
         return ''
 
     def funding_amount_with_currency(self):
@@ -181,10 +180,8 @@ class Partnership(models.Model):
 
     def __unicode__(self):
         if self.organisation:
-            if self.organisation.name:
-                organisation_unicode = self.organisation.name
-            elif self.organisation.long_name:
-                organisation_unicode = self.organisation.long_name
+            if self.organisation.get_name:
+                organisation_unicode = self.organisation.get_name
             else:
                 organisation_unicode = u'%s' % _(u'Organisation name not specified')
         else:

--- a/akvo/rsr/models/planned_disbursement.py
+++ b/akvo/rsr/models/planned_disbursement.py
@@ -68,15 +68,13 @@ class PlannedDisbursement(models.Model):
     def provider_organisation_show_link(self):
         if self.provider_organisation:
             return u'<a href="{0}">{1}</a>'.format(self.provider_organisation.get_absolute_url(),
-                                                   self.provider_organisation.long_name or
-                                                   self.provider_organisation.name)
+                                                   self.provider_organisation.get_name)
         return ''
 
     def receiver_organisation_show_link(self):
         if self.receiver_organisation:
             return u'<a href="{0}">{1}</a>'.format(self.receiver_organisation.get_absolute_url(),
-                                                   self.receiver_organisation.long_name or
-                                                   self.receiver_organisation.name)
+                                                   self.receiver_organisation.get_name)
         return ''
 
     def iati_currency(self):

--- a/akvo/rsr/models/transaction.py
+++ b/akvo/rsr/models/transaction.py
@@ -147,15 +147,13 @@ class Transaction(models.Model):
     def provider_organisation_show_link(self):
         if self.provider_organisation:
             return u'<a href="{0}">{1}</a>'.format(self.provider_organisation.get_absolute_url(),
-                                                   self.provider_organisation.long_name or
-                                                   self.provider_organisation.name)
+                                                   self.provider_organisation.get_name)
         return ''
 
     def receiver_organisation_show_link(self):
         if self.receiver_organisation:
             return u'<a href="{0}">{1}</a>'.format(self.receiver_organisation.get_absolute_url(),
-                                                   self.receiver_organisation.long_name or
-                                                   self.receiver_organisation.name)
+                                                   self.receiver_organisation.get_name)
         return ''
 
     def get_currency(self):

--- a/akvo/rsr/static/scripts-src/project-main/project-main-partners.js
+++ b/akvo/rsr/static/scripts-src/project-main/project-main-partners.js
@@ -82,9 +82,14 @@ function renderPartnersTab() {
             }
         },
 
+        partnerName: function(partner){
+            var org = partner[0].organisation;
+            return (org.long_name || org.name).trim();
+        },
+
         compare: function(o1, o2) {
-            var o1Name = o1[0].organisation.name;
-            var o2Name = o2[0].organisation.name;
+            var o1Name = this.partnerName(o1),
+                o2Name = this.partnerName(o2);
             if (o1Name < o2Name) {
                 return -1;
             } else if (o1Name > o2Name) {
@@ -102,8 +107,6 @@ function renderPartnersTab() {
                     )
                 );
             } else {
-
-
                 var partnershipsArray = [];
                 for (var orgId in this.state.partnerships) {
                     if(this.state.partnerships.hasOwnProperty(orgId)) {
@@ -121,16 +124,18 @@ function renderPartnersTab() {
                         }
                     }
 
+                    var id = partner[0].organisation.id;
+
                     return (
-                        React.createElement("div", {className: "row verticalPadding projectPartners"}, 
+                        React.createElement("div", {className: "row verticalPadding projectPartners", key: id}, 
                             React.createElement("div", {className: "col-sm-2 img"}, 
-                                React.createElement("a", {href: '/en/organisation/' + partner[0].organisation.id + '/'}, 
+                                React.createElement("a", {href: '/en/organisation/' + id + '/'}, 
                                     thisApp.orgLogo(partner[0].organisation.logo, 120, 120)
                                 )
                             ), 
                             React.createElement("div", {className: "col-sm-6"}, 
-                                React.createElement("a", {href: '/en/organisation/' + partner[0].organisation.id + '/', className: "org-link"}, 
-                                    React.createElement("i", {className: "fa fa-users"}), " ", React.createElement("h2", null, partner[0].organisation.name)
+                                React.createElement("a", {href: '/en/organisation/' + id + '/', className: "org-link"}, 
+                                    React.createElement("i", {className: "fa fa-users"}), " ", React.createElement("h2", null, thisApp.partnerName(partner))
                                 )
                             ), 
                             React.createElement("div", {className: "col-sm-4"}, 

--- a/akvo/rsr/static/scripts-src/project-main/project-main-partners.js
+++ b/akvo/rsr/static/scripts-src/project-main/project-main-partners.js
@@ -9,6 +9,13 @@ var endpointsPartners,
     i18nPartners,
     projectIdPartners;
 
+// Polyfill from MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function(searchString, position){
+      return this.substr(position || 0, searchString.length) === searchString;
+  };
+}
+
 /* CSRF TOKEN (this should really be added in base.html, we use it everywhere) */
 function getCookie(name) {
     var cookieValue = null;
@@ -83,8 +90,36 @@ function renderPartnersTab() {
         },
 
         partnerName: function(partner){
+            /*
+            Return org.long_name if org.name looks like a truncated version of org.long_name
+
+            When importing organisations from IATI, the name field may have been truncated to 25 or
+            (more seldom) 40 characters.
+            Therefore we check if the name is exactly 25 or 40 chars long AND is identical to the
+            substring of long_name to that length. If this is the case we use the long_name as there
+            is a very high probability that the name field has been truncated.
+
+            NOTE: this is also done in the Organisation.get_name method
+            */
             var org = partner[0].organisation;
-            return (org.long_name || org.name).trim();
+            var SHORT_TRUNCATED_NAME_LENGTH = 25;
+            var LONG_TRUNCATED_NAME_LENGTH = 40;
+            var name = org.name;
+            var long_name = org.long_name;
+            if (
+                    name.length === 0
+                    || (
+                            name.length == SHORT_TRUNCATED_NAME_LENGTH &&
+                            long_name.length > SHORT_TRUNCATED_NAME_LENGTH
+                        ||
+                            name.length == LONG_TRUNCATED_NAME_LENGTH &&
+                            long_name.length > LONG_TRUNCATED_NAME_LENGTH
+                    )
+                    && long_name.startsWith(name))
+            {
+                return long_name.trim()
+            }
+            return name.trim();
         },
 
         compare: function(o1, o2) {
@@ -129,12 +164,12 @@ function renderPartnersTab() {
                     return (
                         React.createElement("div", {className: "row verticalPadding projectPartners", key: id}, 
                             React.createElement("div", {className: "col-sm-2 img"}, 
-                                React.createElement("a", {href: '/en/organisation/' + id + '/'}, 
+                                React.createElement("a", {href: '/organisation/' + id + '/'}, 
                                     thisApp.orgLogo(partner[0].organisation.logo, 120, 120)
                                 )
                             ), 
                             React.createElement("div", {className: "col-sm-6"}, 
-                                React.createElement("a", {href: '/en/organisation/' + id + '/', className: "org-link"}, 
+                                React.createElement("a", {href: '/organisation/' + id + '/', className: "org-link"}, 
                                     React.createElement("i", {className: "fa fa-users"}), " ", React.createElement("h2", null, thisApp.partnerName(partner))
                                 )
                             ), 

--- a/akvo/rsr/static/scripts-src/project-main/project-main-partners.jsx
+++ b/akvo/rsr/static/scripts-src/project-main/project-main-partners.jsx
@@ -82,9 +82,14 @@ function renderPartnersTab() {
             }
         },
 
+        partnerName: function(partner){
+            var org = partner[0].organisation;
+            return (org.long_name || org.name).trim();
+        },
+
         compare: function(o1, o2) {
-            var o1Name = o1[0].organisation.name;
-            var o2Name = o2[0].organisation.name;
+            var o1Name = this.partnerName(o1),
+                o2Name = this.partnerName(o2);
             if (o1Name < o2Name) {
                 return -1;
             } else if (o1Name > o2Name) {
@@ -102,8 +107,6 @@ function renderPartnersTab() {
                     </div>
                 );
             } else {
-
-
                 var partnershipsArray = [];
                 for (var orgId in this.state.partnerships) {
                     if(this.state.partnerships.hasOwnProperty(orgId)) {
@@ -121,16 +124,18 @@ function renderPartnersTab() {
                         }
                     }
 
+                    var id = partner[0].organisation.id;
+
                     return (
-                        <div className='row verticalPadding projectPartners'>
+                        <div className='row verticalPadding projectPartners' key={id}>
                             <div className="col-sm-2 img">
-                                <a href={'/en/organisation/' + partner[0].organisation.id + '/'}>
+                                <a href={'/en/organisation/' + id + '/'}>
                                     {thisApp.orgLogo(partner[0].organisation.logo, 120, 120)}
                                 </a>
                             </div>
                             <div className="col-sm-6">
-                                <a href={'/en/organisation/' + partner[0].organisation.id + '/'} className="org-link">
-                                    <i className="fa fa-users" /> <h2>{partner[0].organisation.name}</h2>
+                                <a href={'/en/organisation/' + id + '/'} className="org-link">
+                                    <i className="fa fa-users" /> <h2>{thisApp.partnerName(partner)}</h2>
                                 </a>
                             </div>
                             <div className="col-sm-4">

--- a/akvo/rsr/static/scripts-src/project-main/project-main-partners.jsx
+++ b/akvo/rsr/static/scripts-src/project-main/project-main-partners.jsx
@@ -9,6 +9,13 @@ var endpointsPartners,
     i18nPartners,
     projectIdPartners;
 
+// Polyfill from MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function(searchString, position){
+      return this.substr(position || 0, searchString.length) === searchString;
+  };
+}
+
 /* CSRF TOKEN (this should really be added in base.html, we use it everywhere) */
 function getCookie(name) {
     var cookieValue = null;
@@ -83,8 +90,36 @@ function renderPartnersTab() {
         },
 
         partnerName: function(partner){
+            /*
+            Return org.long_name if org.name looks like a truncated version of org.long_name
+
+            When importing organisations from IATI, the name field may have been truncated to 25 or
+            (more seldom) 40 characters.
+            Therefore we check if the name is exactly 25 or 40 chars long AND is identical to the
+            substring of long_name to that length. If this is the case we use the long_name as there
+            is a very high probability that the name field has been truncated.
+
+            NOTE: this is also done in the Organisation.get_name method
+            */
             var org = partner[0].organisation;
-            return (org.long_name || org.name).trim();
+            var SHORT_TRUNCATED_NAME_LENGTH = 25;
+            var LONG_TRUNCATED_NAME_LENGTH = 40;
+            var name = org.name;
+            var long_name = org.long_name;
+            if (
+                    name.length === 0
+                    || (
+                            name.length == SHORT_TRUNCATED_NAME_LENGTH &&
+                            long_name.length > SHORT_TRUNCATED_NAME_LENGTH
+                        ||
+                            name.length == LONG_TRUNCATED_NAME_LENGTH &&
+                            long_name.length > LONG_TRUNCATED_NAME_LENGTH
+                    )
+                    && long_name.startsWith(name))
+            {
+                return long_name.trim()
+            }
+            return name.trim();
         },
 
         compare: function(o1, o2) {
@@ -129,12 +164,12 @@ function renderPartnersTab() {
                     return (
                         <div className='row verticalPadding projectPartners' key={id}>
                             <div className="col-sm-2 img">
-                                <a href={'/en/organisation/' + id + '/'}>
+                                <a href={'/organisation/' + id + '/'}>
                                     {thisApp.orgLogo(partner[0].organisation.logo, 120, 120)}
                                 </a>
                             </div>
                             <div className="col-sm-6">
-                                <a href={'/en/organisation/' + id + '/'} className="org-link">
+                                <a href={'/organisation/' + id + '/'} className="org-link">
                                     <i className="fa fa-users" /> <h2>{thisApp.partnerName(partner)}</h2>
                                 </a>
                             </div>

--- a/akvo/rsr/templatetags/maps.py
+++ b/akvo/rsr/templatetags/maps.py
@@ -76,7 +76,7 @@ def coll_map(coll, width='100%', height='100%', dynamic='dynamic'):
             elif isinstance(item, Organisation):
                 item_type = 'organisation'
                 icon = ORGANISATION_MARKER_ICON
-                text = item.name.encode('utf8')
+                text = item.get_name.encode('utf8')
             elif isinstance(item, ProjectUpdate):
                 item_type = 'projectUpdate'
                 icon = PROJECT_UPDATE_MARKER_ICON

--- a/akvo/templates/organisation_directory.html
+++ b/akvo/templates/organisation_directory.html
@@ -73,11 +73,11 @@
       <li class="row">
         <div class="col-lg-2 col-sm-3 col-xs-5">
           <a href="{% url 'organisation-main' o.id %}">
-            {% img o 165 165 o.name %}
+            {% img o 165 165 o.get_name %}
           </a>
         </div>
         <div class="col-lg-4 col-sm-3 col-xs-7">
-          <h1><a href="{% url 'organisation-main' o.id %}"><i class="fa fa-users"></i> {{o.name}}</a></h1>
+          <h1><a href="{% url 'organisation-main' o.id %}"><i class="fa fa-users"></i> {{o.get_name}}</a></h1>
           {% if o.iati_org_id %}<div class="orgIatiId"><i class="fa fa-key"></i> {{o.iati_org_id}}</div>{% endif %}
           <div class="orgType"><i class="fa fa-tag"></i> {{o.iati_org_type}}</div>
           <div class="projectLocation"><i class="fa fa-map-marker"></i>


### PR DESCRIPTION
Closes #2771


- [ ] Test plan | Unit test | Integration test
  - Check that the name of the organisation Rural Water Supply & Sanitation is displayed fully in https://rsr.akvo.org/en/project/5485/#partners
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
```
Display long names for organisations (whenever available) in the project partners tab -- [#2771](https://github.com/akvo/akvo-rsr/issues/2771)
```