### PR TITLE
[#2735] Disable pipeline collector in development mode

### DIFF
--- a/akvo/settings/66_local.template
+++ b/akvo/settings/66_local.template
@@ -7,11 +7,11 @@
 """
 # Development mode
 DEBUG = TEMPLATE_DEBUG = True
-PIPELINE_ENABLED = False
+PIPELINE['PIPELINE_ENABLED'] = PIPELINE['PIPELINE_COLLECTOR_ENABLED'] = False
 
 # Production mode
 # DEBUG = TEMPLATE_DEBUG = False
-# PIPELINE_ENABLED = True
+# PIPELINE['PIPELINE_ENABLED'] = True
 # STATIC_URL = '/static/'  # Collectstatic
 
 # The console email backend will print emails to console, useful for dev server


### PR DESCRIPTION
Serving of all pages is delayed by about half a minute, since the node_modules
dir created in the static root is too big for the pipeline collector to handle.


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
