### PR TITLE
[#2782] Too many queries to figure if indicator should aggregate

### DIFF
--- a/akvo/rest/views/indicator.py
+++ b/akvo/rest/views/indicator.py
@@ -12,7 +12,12 @@ from akvo.rsr.models import Indicator
 class IndicatorViewSet(PublicProjectViewSet):
     """
     """
-    queryset = Indicator.objects.all()
+    queryset = Indicator.objects.all().select_related(
+        'result',
+        'result__project',
+    ).prefetch_related(
+        'child_indicators'
+    )
     serializer_class = IndicatorSerializer
     project_relation = 'result__project__'
 
@@ -20,6 +25,11 @@ class IndicatorViewSet(PublicProjectViewSet):
 class IndicatorFrameworkViewSet(PublicProjectViewSet):
     """
     """
-    queryset = Indicator.objects.all()
+    queryset = Indicator.objects.all().select_related(
+        'result',
+        'result__project',
+    ).prefetch_related(
+        'child_indicators'
+    )
     serializer_class = IndicatorFrameworkSerializer
     project_relation = 'result__project__'

--- a/akvo/rsr/models/indicator.py
+++ b/akvo/rsr/models/indicator.py
@@ -196,7 +196,7 @@ class Indicator(models.Model):
         """
         if self.measure == '2' and self.is_parent_indicator() and \
                 self.result.project.aggregate_children and \
-                any([ind.result.project.aggregate_to_parent for ind in self.child_indicators.all()]):
+                any(self.child_indicators.values_list('result__project__aggregate_to_parent', flat=True)):
             return True
         return False
 


### PR DESCRIPTION
When an indicator has lots of child_indicators, computing the property
`children_aggregate_percentage` does too many queries. A result with a bunch
of such indicators times out during the call
`/rest/v1/indicator/?result__project=5659`

Closes #2782


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

```
Improve response time for results frameworks with many child indicators [#2782](https://github.com/akvo/akvo-rsr/issues/2782)
```
