### PR TITLE
[#2785] Object.assign is not implemented in IE

### DIFF
--- a/akvo/rsr/static/scripts-src/project-directory-filters.js
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.js
@@ -8,6 +8,34 @@
 var filtersWrapper = document.getElementById('wrapper'),
     options_cache = {};
 
+
+// Polyfill from MDN to add Object.assign
+// Object.assign is not available on any version of IE!
+if (typeof Object.assign != 'function') {
+  Object.assign = function(target, varArgs) { // .length of function is 2
+    'use strict';
+    if (target == null) { // TypeError if undefined or null
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+
+    var to = Object(target);
+
+    for (var index = 1; index < arguments.length; index++) {
+      var nextSource = arguments[index];
+
+      if (nextSource != null) { // Skip over if undefined or null
+        for (var nextKey in nextSource) {
+          // Avoid bugs when hasOwnProperty is shadowed
+          if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+            to[nextKey] = nextSource[nextKey];
+          }
+        }
+      }
+    }
+    return to;
+  };
+}
+
 var trim_label = function(obj) {
     if (obj.hasOwnProperty('label')) {
         obj.label = obj.label.trim();

--- a/akvo/rsr/static/scripts-src/project-directory-filters.jsx
+++ b/akvo/rsr/static/scripts-src/project-directory-filters.jsx
@@ -8,6 +8,34 @@
 var filtersWrapper = document.getElementById('wrapper'),
     options_cache = {};
 
+
+// Polyfill from MDN to add Object.assign
+// Object.assign is not available on any version of IE!
+if (typeof Object.assign != 'function') {
+  Object.assign = function(target, varArgs) { // .length of function is 2
+    'use strict';
+    if (target == null) { // TypeError if undefined or null
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+
+    var to = Object(target);
+
+    for (var index = 1; index < arguments.length; index++) {
+      var nextSource = arguments[index];
+
+      if (nextSource != null) { // Skip over if undefined or null
+        for (var nextKey in nextSource) {
+          // Avoid bugs when hasOwnProperty is shadowed
+          if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+            to[nextKey] = nextSource[nextKey];
+          }
+        }
+      }
+    }
+    return to;
+  };
+}
+
 var trim_label = function(obj) {
     if (obj.hasOwnProperty('label')) {
         obj.label = obj.label.trim();

--- a/akvo/rsr/tests/deployed_code_tests.py
+++ b/akvo/rsr/tests/deployed_code_tests.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+# Akvo RSR is covered by the GNU Affero General Public License.
+
+# See more details in the license.txt file located at the root folder of the
+# Akvo RSR module. For additional details on the GNU license please see <
+# http://www.gnu.org/licenses/agpl.html >.
+
+"""Script to run tests using Browserstack
+
+Currently, the script is meant to be run locally by the developers, but it can
+be easily extended to be run on Travis, etc.
+
+RSR_ENV and BROWSERSTACK_URL need to be set as environment variables for the
+script to run.
+
+When logged in to Browserstack,
+https://www.browserstack.com/automate/python has the url in the examples.
+
+RSR_ENV should be set to "uat" if these tests are being run before a
+deployment, "live" after a deployment and "dev" to test a PR on the dev server.
+
+"""
+
+# *FIXME*: The file, even though in the tests directory, has been named such
+# *that it doesn't automatically run on Travis. This script currently needs to
+# *be run manually by developers.
+
+
+import os
+import unittest
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+# FIXME: Make the URL storable on Travis, etc.
+BROWSERSTACK_URL = os.environ.get('BROWSERSTACK_URL')
+ENV_URLS = {
+    'dev': 'https://rsr-dev.test.akvo.org',
+    'test': 'https://rsr.test.akvo.org',
+    'uat': 'https://rsr.uat.akvo.org',
+    'live': 'https://rsr.akvo.org',
+}
+rsr_env = os.environ.get('RSR_ENV', 'dev')
+BASE_URL = ENV_URLS.get(rsr_env, ENV_URLS['dev'])
+# FIXME: make it easier to use other browsers
+desired_cap = {
+    'browser': 'IE',
+    'browser_version': '11.0',
+    'os': 'Windows',
+    'os_version': '10',
+    'resolution': '1024x768'
+}
+
+
+class DeployedCodeTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # FIXME: Make it easy to test using local chrome/firefox
+        # self.driver = webdriver.Chrome()
+        self.driver = webdriver.Remote(
+            command_executor=BROWSERSTACK_URL,
+            desired_capabilities=desired_cap,
+        )
+
+    def test_advanced_search_data_fetched(self):
+        status_selector = 'li#advanced-filter-status'
+
+        driver = self.driver
+        driver.get(BASE_URL)
+        self.close_password_modal()
+        search = driver.find_element_by_css_selector('#search .showFilters')
+        search_view = driver.find_element_by_id('search-view')
+        driver.execute_script(
+            "arguments[0].scrollIntoView(true);", search_view
+        )
+        search.click()
+        try:
+            WebDriverWait(self.driver, 10).until(
+                EC.text_to_be_present_in_element(
+                    (By.CSS_SELECTOR, status_selector), 'Projects'
+                )
+            )
+        except:
+            status = driver.find_element_by_css_selector(status_selector)
+            raise AssertionError(
+                'Element Text: {}. Failed to get projects'.format(status.text)
+            )
+
+    def tearDown(self):
+        self.driver.quit()
+
+    def close_password_modal(self):
+        element = WebDriverWait(self.driver, 10).until(
+            EC.presence_of_element_located(
+                (By.CSS_SELECTOR, ".modal-content input[type=password]")
+            )
+        )
+        element.send_keys('TesTing!')
+        self.driver.find_element_by_css_selector(
+            '.modal-footer > button'
+        ).click()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/akvo/templates/base.html
+++ b/akvo/templates/base.html
@@ -90,6 +90,9 @@
     {# react-onclickoutside.js should load before date-picker, etc. #}
     {% javascript 'rsr_lib' %}
 
+    <!-- Polyfill for promise for browsers which don't implement it -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/native-promise-only/0.8.1/npo.js"></script>
+
     {% if debug %}
       {# jQuery #}
       <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.js" integrity="sha256-WMJwNbei5YnfOX5dfgVCS5C4waqvc+/0fV7W2uy3DyU=" crossorigin="anonymous"></script>


### PR DESCRIPTION
This commit adds a polyfill version for it in the advanced filters code to get
it working in IE. Object.assign seems to be used in the new results framework
too, but the bundles seem to have polyfill implementations in them.

Also, add a polyfill version of Promise (used by fetch.js) for browsers that
don't implement it.

Closes #2785


- [x] Test plan | Unit test | Integration test

Run the test script for testing if the advanced filters is shown in IE, by running the following command
```bash
$ BROWSERSTACK_URL=<URL> RSR_ENV="uat" python akvo/rsr/tests/deployed_code_tests.py
```
The value to use for `<URL>` can be obtained from the first example on this page: https://www.browserstack.com/automate/python

To test if the test works, this branch can be deployed on the `dev` server and RSR_ENV can be set to "dev" when running the command above

- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
```
Resolve problem with loading the advanced filters pane in IE and older version of other browsers - [#2785](https://github.com/akvo/akvo-rsr/issues/2785)
```