### PR TITLE
[#2798] Add a command to undo results imports for specified projects

### DIFF
--- a/akvo/rsr/management/commands/undo_results_import.py
+++ b/akvo/rsr/management/commands/undo_results_import.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+"""Undo results framework import for the specified projects
+
+Usage:
+
+    python manage.py undo_results_import <project-id1> [<project-id2> ...]
+
+"""
+
+import sys
+
+from django.core.management.base import BaseCommand
+from ...models import Result
+
+
+class Command(BaseCommand):
+    help = u"Undo results framework import for the specified projects"
+
+    def handle(self, *args, **options):
+        if not args:
+            print(__doc__)
+            sys.exit(1)
+
+        project_ids = map(int, args)
+
+        for id_ in project_ids:
+            results = Result.objects.filter(project__id=id_).exclude(parent_result=None)
+            print "Deleting {} results for project {}".format(results.count(), id_)
+            results.delete()


### PR DESCRIPTION
The import undo is essentially just deleting all the results that have a parent
result attached to them, from the specified projects.

Closes #2798


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry

```
Add management command to undo imported results for projects [#2798](https://github.com/akvo/akvo-rsr/issues/2798)
```
