### PR TITLE
[#2446] Fix incorrect constant name - PERCENTAGE_MEASURE

### DIFF
--- a/akvo/rsr/static/scripts-src/my-results/components/Periods.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/Periods.jsx
@@ -277,7 +277,7 @@ export default class Periods extends React.Component {
                     !ui.updateFormDisplay && (
                         ui.activeFilter === c.FILTER_NEED_REPORTING || ui.activeFilter === undefined
                     )) && !(
-                        indicator.measure === c.PERCENTAGE_MEASURE &&
+                        indicator.measure === c.MEASURE_PERCENTAGE &&
                         this.props.periodChildrenIds[id].length >= 1
                     )){
                     newUpdateButton = <NewUpdateButton period={period} user={this.props.user}/>;

--- a/akvo/rsr/static/scripts-src/my-results/components/updates/Updates.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/updates/Updates.jsx
@@ -69,7 +69,7 @@ const TimestampInfo =({update, user, label}) => {
     return (
         <ul>
             <li className="approverMeta">{label}
-                <span class="UpdateDate"> {displayDate(update.last_modified_at)}</span>
+                <span className="UpdateDate"> {displayDate(update.last_modified_at)}</span>
                 <span className="hide"> {displayName(user)}</span>
                 <span className="hide"> {user.approved_organisations[0].name}</span>
             </li>

--- a/akvo/rsr/static/scripts-src/my-results/selectors.js
+++ b/akvo/rsr/static/scripts-src/my-results/selectors.js
@@ -147,7 +147,7 @@ export const getIndicatorsAggregateActualValue = createSelector(
     (indicatorIDs, indicatorObjects, childPeriodIds, periodObjects, actualValue) => {
         return indicatorIDs && indicatorObjects && childPeriodIds && !isEmpty(actualValue) && indicatorIDs.reduce((acc, indicatorId) => {
             let aggregateValue;
-            if (indicatorObjects[indicatorId].measure === c.PERCENTAGE_MEASURE) {
+            if (indicatorObjects[indicatorId].measure === c.MEASURE_PERCENTAGE) {
                 // Computed aggregate percentage -> (sum of all numerators) * 100 / (last/latest denominator)
                 const numerator = childPeriodIds[indicatorId].reduce((sum, periodId) => {
                     return sum + (parseFloat(periodObjects[periodId].numerator)||0);


### PR DESCRIPTION
The constant name was changed in the changes for the qualitative measure, but
the merge with percentage aggregation branch probably messed this up.


- [ ] Test plan | Unit test | Integration test
  1. Verify that the "Insert reporting value" button does not appear for %age indicator periods which already have an update. 
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
