### PR TITLE
[#2854] Change permsissions for OrganisationIndicatorLabel

### DIFF
--- a/akvo/rsr/models/__init__.py
+++ b/akvo/rsr/models/__init__.py
@@ -200,6 +200,10 @@ rules.add_perm('rsr.add_indicatordimension', is_rsr_admin | is_org_admin | is_or
 rules.add_perm('rsr.change_indicatordimension', is_rsr_admin | is_org_admin | is_org_project_editor)
 rules.add_perm('rsr.delete_indicatordimension', is_rsr_admin | is_org_admin | is_org_project_editor)
 
+rules.add_perm('rsr.add_indicatorlabel', is_rsr_admin | is_org_admin |is_org_project_editor)
+rules.add_perm('rsr.change_indicatorlabel', is_rsr_admin | is_org_admin | is_org_project_editor)
+rules.add_perm('rsr.delete_indicatorlabel', is_rsr_admin | is_org_admin | is_org_project_editor)
+
 rules.add_perm('rsr.add_indicatorperiod', is_rsr_admin | is_org_admin | is_org_project_editor)
 rules.add_perm('rsr.change_indicatorperiod', is_rsr_admin | is_org_admin | is_org_project_editor)
 rules.add_perm('rsr.delete_indicatorperiod', is_rsr_admin | is_org_admin | is_org_project_editor)
@@ -272,6 +276,10 @@ rules.add_perm('rsr.add_organisationcustomfield', is_rsr_admin | is_org_admin |
 rules.add_perm('rsr.change_organisationcustomfield', is_rsr_admin | is_org_admin |
                is_org_project_editor)
 rules.add_perm('rsr.delete_organisationcustomfield', is_rsr_admin)
+
+rules.add_perm('rsr.add_organisationindicatorlabel', is_rsr_admin)
+rules.add_perm('rsr.change_organisationindicatorlabel', is_rsr_admin)
+rules.add_perm('rsr.delete_organisationindicatorlabel', is_rsr_admin)
 
 rules.add_perm('rsr.add_benchmark', is_rsr_admin | is_org_admin | is_org_project_editor)
 rules.add_perm('rsr.change_benchmark', is_rsr_admin | is_org_admin | is_org_project_editor)

--- a/akvo/rsr/models/indicator.py
+++ b/akvo/rsr/models/indicator.py
@@ -299,7 +299,7 @@ class IndicatorLabel(models.Model):
     indicator = models.ForeignKey(Indicator, verbose_name=_(u'indicator'),
                                   related_name='labels')
     label = models.ForeignKey(OrganisationIndicatorLabel, verbose_name=_(u'label'),
-                              related_name='indicators')
+                              related_name='indicators', on_delete=models.PROTECT)
 
     class Meta:
         app_label = 'rsr'

--- a/akvo/rsr/tests/rest/test_permissions.py
+++ b/akvo/rsr/tests/rest/test_permissions.py
@@ -462,9 +462,8 @@ class PermissionFilteringTestCase(TestCase):
         }
 
         # one label per indicator
-        # FIXME: change_* permissions weirdness
         model_map[M.IndicatorLabel] = {
-            'group_count': group_count(8, 4, 4, 4),
+            'group_count': group_count(8, 4, 6, 4),
             'project_relation': 'indicator__result__project__'
         }
 


### PR DESCRIPTION
Change permissions for OrganisationIndicatorLabel so they can be managed in the django admin by RSR admins.

Also set on_delete on IndicatorLabel.label to models.PROTECT to avoid foot shooting in the admin.


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
