### PR TITLE
[#2875] Hide Indicator Dimension fields for qualitative indicators

### DIFF
--- a/akvo/rsr/static/scripts-src/project-editor.js
+++ b/akvo/rsr/static/scripts-src/project-editor.js
@@ -1208,7 +1208,10 @@ function setPartialOnClicks() {
                 selectInputs[m].onchange = toggleOtherLabel(selectInputs[m]);
             }
             if (selectInputId[0] == 'rsr_indicator' && selectInputId[1] == 'type') {
-                selectInputs[m].onchange = setMeasureVisibility.bind(null, selectInputs[m]);
+                selectInputs[m].onchange = function(e){
+                    setMeasureVisibility(e.target);
+                    setDimensionVisibility(e.target);
+                };
             }
         }
     }
@@ -1472,6 +1475,25 @@ function setMeasureVisibility(indicatorTypeSelect) {
         elAddClass(measureRow, 'hidden');
     } else {
         elRemoveClass(measureRow, 'hidden');
+    }
+}
+
+function setDimensionVisibility(indicatorTypeSelect) {
+    /*
+       Show or hide dimension fields depending on indicator type
+     */
+    // parent is the div wrapping one whole indicator form, it's the outer node in
+    // related_objects/indicator_input.html
+    var parent = findAncestorByClass(indicatorTypeSelect, 'parent'),
+        dimensionDiv = parent.querySelector('.indicator-dimension-container'),
+        relatedContainer = dimensionDiv.parentElement;
+    // hide indicator dimension fields for qualitative indicators
+    if (indicatorTypeSelect.value === '2') {
+        elAddClass(dimensionDiv, 'hidden');
+        elAddClass(relatedContainer, 'hidden');
+    } else {
+        elRemoveClass(dimensionDiv, 'hidden');
+        elRemoveClass(relatedContainer, 'hidden');
     }
 }
 

--- a/akvo/rsr/static/scripts-src/project-editor.jsx
+++ b/akvo/rsr/static/scripts-src/project-editor.jsx
@@ -1208,7 +1208,10 @@ function setPartialOnClicks() {
                 selectInputs[m].onchange = toggleOtherLabel(selectInputs[m]);
             }
             if (selectInputId[0] == 'rsr_indicator' && selectInputId[1] == 'type') {
-                selectInputs[m].onchange = setMeasureVisibility.bind(null, selectInputs[m]);
+                selectInputs[m].onchange = function(e){
+                    setMeasureVisibility(e.target);
+                    setDimensionVisibility(e.target);
+                };
             }
         }
     }
@@ -1472,6 +1475,25 @@ function setMeasureVisibility(indicatorTypeSelect) {
         elAddClass(measureRow, 'hidden');
     } else {
         elRemoveClass(measureRow, 'hidden');
+    }
+}
+
+function setDimensionVisibility(indicatorTypeSelect) {
+    /*
+       Show or hide dimension fields depending on indicator type
+     */
+    // parent is the div wrapping one whole indicator form, it's the outer node in
+    // related_objects/indicator_input.html
+    var parent = findAncestorByClass(indicatorTypeSelect, 'parent'),
+        dimensionDiv = parent.querySelector('.indicator-dimension-container'),
+        relatedContainer = dimensionDiv.parentElement;
+    // hide indicator dimension fields for qualitative indicators
+    if (indicatorTypeSelect.value === '2') {
+        elAddClass(dimensionDiv, 'hidden');
+        elAddClass(relatedContainer, 'hidden');
+    } else {
+        elRemoveClass(dimensionDiv, 'hidden');
+        elRemoveClass(relatedContainer, 'hidden');
     }
 }
 

--- a/akvo/templates/myrsr/project_editor/related_objects/indicator_input.html
+++ b/akvo/templates/myrsr/project_editor/related_objects/indicator_input.html
@@ -86,10 +86,12 @@
           </div>
         </div>
 
-        <!-- FIXME: Make this visible only to BETA users?  -->
-        <div class="related-object-container {{ validations|mandatory_or_hidden:"rsr_indicatordimension" }}">
+        <div class="related-object-container {% if indicator.type == 2 %} hidden {% endif %}{{ validations|mandatory_or_hidden:"rsr_indicatordimension" }}">
             <h5>{% trans 'Indicator Dimensions' %}</h5>
-            <div class="indicator-dimension-container" id="indicator-dimension-container">
+            <!-- *NOTE*: Just hiding the related container above doesn't work, because the
+                 javascript to deduce hidden fields from validation sets removes that hidden tag,
+                 once the page loads. This child needs to be hidden to prevent that.  -->
+            <div class="indicator-dimension-container {% if indicator.type == 2 %} hidden {% endif %}" id="indicator-dimension-container">
                 {% for dimension in indicator.dimensions.all %}
                 {% include "myrsr/project_editor/related_objects/indicator_dimension_input.html" %}
                 {% empty %}


### PR DESCRIPTION
Closes #2875


- [x] Test plan | Unit test | Integration test
  Verify that the qualitative indicator does not show the indicator dimension fields. Changing the type should toggle the display of indicator measure and indicator dimension fields.
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

```markdown
[#2875] Hide Indicator Dimension fields for qualitative indicators [#2875](https://github.com/akvo/akvo-rsr/issues/)
```
