### PR TITLE
[#2878] Set default view of Results on project page

### DIFF
--- a/akvo/rsr/static/scripts-src/my-results/components/App.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/App.jsx
@@ -41,6 +41,7 @@ import {
     getPendingApprovalPeriods,
     getUpdatesDisaggregationObjects,
     getIndicatorsDimensionIds,
+    getPublicViewDefaultKeys,
 } from "../selectors";
 
 import {
@@ -48,6 +49,7 @@ import {
     collapseId,
     identicalArrays,
     isNewUpdate,
+    openNodes,
     setHash,
     userIsMEManager,
 } from "../utils"
@@ -92,6 +94,7 @@ const modifyUser = (isMEManager) => {
         pendingApprovalPeriods: getPendingApprovalPeriods(store),
         approvedPeriods: getApprovedPeriods(store),
         MEManagerDefaultKeys: getMEManagerDefaultKeys(store),
+        publicViewDefaultKeys: getPublicViewDefaultKeys(store),
     }
 })
 export default class App extends React.Component {
@@ -164,12 +167,17 @@ export default class App extends React.Component {
         };
 
         const setInitialView = () => {
-            // set the initial state of the Results panels to open if the user is an M&E manager
-            if (userIsMEManager(this.props.user) &&
-                    nextProps.ui.allFetched &&
-                    !this.state.initialViewSet) {
-                collapseChange(resultsCollapseID, this.props.MEManagerDefaultKeys);
-                this.setState({initialViewSet: true});
+            // set the initial state of the Results panels to open if the user is an M&E manager or
+            // this is the public view
+            if (nextProps.ui.allFetched && !this.state.initialViewSet) {
+                if (nextProps.page.mode && nextProps.page.mode.public) {
+                    openNodes(c.OBJECTS_INDICATORS, this.props.publicViewDefaultKeys);
+                    this.setState({initialViewSet: true});
+                }
+                if (userIsMEManager(this.props.user)) {
+                    collapseChange(resultsCollapseID, this.props.MEManagerDefaultKeys);
+                    this.setState({initialViewSet: true});
+                }
             }
         };
 

--- a/akvo/rsr/static/scripts-src/my-results/selectors.js
+++ b/akvo/rsr/static/scripts-src/my-results/selectors.js
@@ -378,3 +378,11 @@ export const getMEManagerDefaultKeys = createSelector(
     [getResultIds],
     resultIds => idsToActiveKey(resultIds)
 );
+
+export const getPublicViewDefaultKeys = createSelector(
+    /*
+        Just an array of IDs as string, used for the default view on the project page Results tab
+     */
+    [getIndicatorIds],
+    indicatorIds => idsToActiveKey(indicatorIds)
+);


### PR DESCRIPTION
Closes #2878

Set the Indicator nodes to be opened so that the period headers are visible.


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
