### PR TITLE
[#2880] Fix bug when opening percentage indicators

### DIFF
--- a/akvo/rsr/static/scripts-src/my-results/components/Periods.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/Periods.jsx
@@ -286,7 +286,7 @@ export default class Periods extends React.Component {
                 return false;
             }
             if (indicator.measure === c.MEASURE_PERCENTAGE &&
-                    this.props.periodChildrenIds[id].length >= 1) {
+                    this.props.periodChildrenIds[period.id].length >= 1) {
                 return false;
             }
             return true;


### PR DESCRIPTION
The check to see if we should show the edit button has an incorrect referenct to the period.


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
