### PR TITLE
[#2890] Show OrganisationIndicatorLabels defined by all partners

### DIFF
--- a/akvo/rsr/models/organisation_indicator_label.py
+++ b/akvo/rsr/models/organisation_indicator_label.py
@@ -23,6 +23,7 @@ class OrganisationIndicatorLabel(models.Model):
         verbose_name = _(u'organisation indicator label')
         verbose_name_plural = _(u'organisation indicator labels')
         unique_together = ('organisation', 'label')
+        ordering = ('organisation', 'label')
 
     def __unicode__(self):
         return self.label

--- a/akvo/rsr/templatetags/project_editor.py
+++ b/akvo/rsr/templatetags/project_editor.py
@@ -259,8 +259,8 @@ def choices(obj, field):
         else:
             project = obj.indicator.result.project
         organisation_indicator_labels = get_model('rsr', 'OrganisationIndicatorLabel').objects.filter(
-            organisation=project.primary_organisation
-        )
+            organisation=project.all_partners()
+        ).distinct()
         return choices_and_ids(organisation_indicator_labels, 'id', 'label')
 
 

--- a/akvo/rsr/tests/rest/test_project_editor.py
+++ b/akvo/rsr/tests/rest/test_project_editor.py
@@ -407,8 +407,8 @@ class ChoicesTestCase(TestCase):
             {(label1.pk, label1.label), (label2.pk, label2.label)}
         )
         self.assertEqual(
-            ids,
-            [1, 2]
+            set(ids),
+            {label1.pk, label2.pk}
         )
 
         # When
@@ -420,6 +420,59 @@ class ChoicesTestCase(TestCase):
             {(label1.pk, label1.label), (label2.pk, label2.label)}
         )
         self.assertEqual(
-            ids,
-            [1, 2]
+            set(ids),
+            {label1.pk, label2.pk}
+        )
+
+    def test_indicator_label_choices_multiple_organisations(self):
+        # Given
+        organisation1 = Organisation.objects.create(
+            name='name1', long_name='long name1', can_create_projects=True
+        )
+        organisation2 = Organisation.objects.create(
+            name='name2', long_name='long name2', can_create_projects=True
+        )
+        Partnership.objects.create(
+            organisation=organisation1, project=self.project,
+            iati_organisation_role=Partnership.IATI_ACCOUNTABLE_PARTNER
+        )
+        Partnership.objects.create(
+            organisation=organisation2, project=self.project,
+            iati_organisation_role=Partnership.IATI_ACCOUNTABLE_PARTNER
+        )
+        label1 = OrganisationIndicatorLabel.objects.create(
+            organisation=organisation1, label=u'label 1'
+        )
+        label2 = OrganisationIndicatorLabel.objects.create(
+            organisation=organisation2, label=u'label 2'
+        )
+
+        result = Result.objects.create(project=self.project, title="Result #1", type="1", )
+        indicator = Indicator.objects.create(result=result, title="Indicator #1", measure="1", )
+        indicator_label = IndicatorLabel.objects.create(indicator=indicator, label=label1)
+
+        # When
+        labels, ids = choices(indicator_label, 'label')
+
+        # Then
+        self.assertEqual(
+            set(labels),
+            {(label1.pk, label1.label), (label2.pk, label2.label)}
+        )
+        self.assertEqual(
+            set(ids),
+            {label1.pk, label2.pk}
+        )
+
+        # When
+        labels, ids = choices('IndicatorLabel.{}_1234_567_89'.format(self.project.pk), 'label')
+
+        # Then
+        self.assertEqual(
+            set(labels),
+            {(label1.pk, label1.label), (label2.pk, label2.label)}
+        )
+        self.assertEqual(
+            set(ids),
+            {label1.pk, label2.pk}
         )

--- a/akvo/rsr/tests/rest/test_project_editor.py
+++ b/akvo/rsr/tests/rest/test_project_editor.py
@@ -456,12 +456,12 @@ class ChoicesTestCase(TestCase):
 
         # Then
         self.assertEqual(
-            set(labels),
-            {(label1.pk, label1.label), (label2.pk, label2.label)}
+            list(labels),
+            [(label1.pk, label1.label), (label2.pk, label2.label)]
         )
         self.assertEqual(
-            set(ids),
-            {label1.pk, label2.pk}
+            ids,
+            [label1.pk, label2.pk]
         )
 
         # When
@@ -469,10 +469,10 @@ class ChoicesTestCase(TestCase):
 
         # Then
         self.assertEqual(
-            set(labels),
-            {(label1.pk, label1.label), (label2.pk, label2.label)}
+            list(labels),
+            [(label1.pk, label1.label), (label2.pk, label2.label)]
         )
         self.assertEqual(
-            set(ids),
-            {label1.pk, label2.pk}
+            ids,
+            [label1.pk, label2.pk]
         )


### PR DESCRIPTION
Instead of just relying that we have the right primary organisation for the
project, we choose to display labels defined by all partners instead. In future,
this may turn out to be a problem, when multiple orgs define long lists of
labels.

Closes #2890


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

```markdown
Show OrganisationIndicatorLabels belonging to all partners [2890](https://github.com/akvo/akvo-rsr/issues/2890)
```
