### PR TITLE
[#2897] Handle error being passed to add_error instead of message

### DIFF
--- a/akvo/rest/views/project_editor.py
+++ b/akvo/rest/views/project_editor.py
@@ -73,6 +73,8 @@ MANY_TO_MANY_FIELDS = {
 
 def add_error(errors, message, field_name):
     """Appends a new error to the errors list."""
+    if isinstance(message, BaseException):
+        message = message.message
     errors.append(
         {'name': field_name,
          'error': message.encode('utf8').capitalize()}

--- a/akvo/rsr/tests/rest/test_project_editor.py
+++ b/akvo/rsr/tests/rest/test_project_editor.py
@@ -320,6 +320,19 @@ class ErrorHandlerTestCase(TestCase):
         # Then
         self.assertEquals(1, len(errors))
 
+    def test_should_handle_error_object_errors(self):
+        # Given
+        try:
+            raise ValueError
+        except ValueError as e:
+            errors = []
+            field_name = u'rsr_budgetitem.amount.5966_new-0'
+            # When
+            add_error(errors, e, field_name)
+
+        # Then
+        self.assertEquals(1, len(errors))
+
 
 class SplitKeyTestCase(TestCase):
 


### PR DESCRIPTION
- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
