### PR TITLE
Draft updates should be shown only to the user who created them

### DIFF
--- a/akvo/rest/views/indicator_period_data.py
+++ b/akvo/rest/views/indicator_period_data.py
@@ -25,6 +25,12 @@ class IndicatorPeriodDataViewSet(PublicProjectViewSet):
 
     project_relation = 'period__indicator__result__project__'
 
+    def get_queryset(self):
+        queryset = super(IndicatorPeriodDataViewSet, self).get_queryset()
+        return IndicatorPeriodData.get_user_viewable_updates(
+            queryset, self.request.user
+        )
+
 
 class IndicatorPeriodDataFrameworkViewSet(PublicProjectViewSet):
     """
@@ -39,6 +45,12 @@ class IndicatorPeriodDataFrameworkViewSet(PublicProjectViewSet):
     ).all()
     serializer_class = IndicatorPeriodDataFrameworkSerializer
     project_relation = 'period__indicator__result__project__'
+
+    def get_queryset(self):
+        queryset = super(IndicatorPeriodDataFrameworkViewSet, self).get_queryset()
+        return IndicatorPeriodData.get_user_viewable_updates(
+            queryset, self.request.user
+        )
 
 
 class IndicatorPeriodDataCommentViewSet(PublicProjectViewSet):

--- a/akvo/rsr/models/__init__.py
+++ b/akvo/rsr/models/__init__.py
@@ -172,7 +172,8 @@ __all__ = [
 
 # Permission rules
 import rules
-from ..permissions import (is_rsr_admin, is_org_admin, is_org_user_manager, is_org_project_editor,
+from ..permissions import (is_rsr_admin, is_org_admin, is_org_user_manager,
+                           is_org_me_manager, is_org_project_editor,
                            is_org_user, is_self)
 
 rules.add_perm('rsr', rules.always_allow)
@@ -208,6 +209,7 @@ rules.add_perm('rsr.add_indicatorperiod', is_rsr_admin | is_org_admin | is_org_p
 rules.add_perm('rsr.change_indicatorperiod', is_rsr_admin | is_org_admin | is_org_project_editor)
 rules.add_perm('rsr.delete_indicatorperiod', is_rsr_admin | is_org_admin | is_org_project_editor)
 
+rules.add_perm('rsr.view_indicatorperioddata', is_rsr_admin | is_org_admin | is_org_me_manager)
 rules.add_perm('rsr.add_indicatorperioddata', is_rsr_admin | is_org_admin | is_org_project_editor)
 rules.add_perm('rsr.change_indicatorperioddata', is_rsr_admin | is_org_admin | is_org_project_editor)
 rules.add_perm('rsr.delete_indicatorperioddata', is_rsr_admin | is_org_admin | is_org_project_editor)

--- a/akvo/rsr/permissions.py
+++ b/akvo/rsr/permissions.py
@@ -137,70 +137,31 @@ def is_org_user_manager(user, obj):
 
 
 @rules.predicate
+# FIXME: Bad name:: This is really checking if user is PE/M&E manager
 def is_org_project_editor(user, obj):
     if not user.is_authenticated():
         return False
-    for employment in user.approved_employments():
-        if employment.group.name in set([PROJECT_EDITOR_GROUP_NAME, ME_MANAGER_GROUP_NAME]):
-            if not obj:
-                return True
-            if isinstance(obj, Organisation):
-                if obj in employment.organisation.content_owned_organisations():
-                    return True
-            elif isinstance(obj, Project) and obj in employment.organisation.all_projects():
-                return True
-            elif isinstance(obj, ProjectUpdate) and obj.user == user:
-                return True
-            else:
-                try:
-                    if obj.project and obj.project in employment.organisation.all_projects():
-                        return True
-                except:
-                    pass
-                try:
-                    if obj.result.project and obj.result.project in \
-                            employment.organisation.all_projects():
-                        return True
-                except:
-                    pass
-                try:
-                    if obj.indicator.result.project and obj.indicator.result.project in \
-                            employment.organisation.all_projects():
-                        return True
-                except:
-                    pass
-                try:
-                    if obj.period.indicator.result.project and \
-                        obj.period.indicator.result.project in employment.organisation.\
-                            all_projects():
-                        return True
-                except:
-                    pass
-                try:
-                    if obj.data.period.indicator.result.project and \
-                        obj.data.period.indicator.result.project in employment.organisation.\
-                            all_projects():
-                        return True
-                except:
-                    pass
-                try:
-                    if obj.location.location_target and obj.location.location_target in \
-                            employment.organisation.all_projects():
-                        return True
-                except:
-                    pass
-                try:
-                    if obj.transaction.project and obj.transaction.project in \
-                            employment.organisation.all_projects():
-                        return True
-                except:
-                    pass
-                try:
-                    if isinstance(obj.location_target, Project) and \
-                            obj.location_target in employment.organisation.all_projects():
-                        return True
-                except:
-                    pass
+    group_names = [PROJECT_EDITOR_GROUP_NAME, ME_MANAGER_GROUP_NAME]
+    for employment in user.approved_employments(group_names=group_names):
+        is_privileged = is_organisation_or_user_owned(user, employment, obj)
+        if is_privileged:
+            return True
+        else:
+            continue
+    return False
+
+
+@rules.predicate
+def is_org_me_manager(user, obj):
+    if not user.is_authenticated():
+        return False
+    group_names = [ME_MANAGER_GROUP_NAME]
+    for employment in user.approved_employments(group_names=group_names):
+        is_privileged = is_organisation_or_user_owned(user, employment, obj)
+        if is_privileged:
+            return True
+        else:
+            continue
     return False
 
 
@@ -228,3 +189,68 @@ def is_self(user, obj):
     if isinstance(obj, Employment) and obj.user == user:
         return True
     return False
+
+
+# FIXME: This method could be re-used in the other predicates too - for
+# instance, in is_org_admin, is_org_user_manager, if some of the rules defined
+# there are incorporated into this function.
+def is_organisation_or_user_owned(user, employment, obj):
+    if not obj:
+        return True
+    if isinstance(obj, Organisation):
+        if obj in employment.organisation.content_owned_organisations():
+            return True
+    elif isinstance(obj, Project) and obj in employment.organisation.all_projects():
+        return True
+    elif isinstance(obj, ProjectUpdate) and obj.user == user:
+        return True
+    else:
+        try:
+            if obj.project and obj.project in employment.organisation.all_projects():
+                return True
+        except:
+            pass
+        try:
+            if obj.result.project and obj.result.project in \
+                    employment.organisation.all_projects():
+                return True
+        except:
+            pass
+        try:
+            if obj.indicator.result.project and obj.indicator.result.project in \
+                    employment.organisation.all_projects():
+                return True
+        except:
+            pass
+        try:
+            if obj.period.indicator.result.project and \
+                obj.period.indicator.result.project in employment.organisation.\
+                    all_projects():
+                return True
+        except:
+            pass
+        try:
+            if obj.data.period.indicator.result.project and \
+                obj.data.period.indicator.result.project in employment.organisation.\
+                    all_projects():
+                return True
+        except:
+            pass
+        try:
+            if obj.location.location_target and obj.location.location_target in \
+                    employment.organisation.all_projects():
+                return True
+        except:
+            pass
+        try:
+            if obj.transaction.project and obj.transaction.project in \
+                    employment.organisation.all_projects():
+                return True
+        except:
+            pass
+        try:
+            if isinstance(obj.location_target, Project) and \
+                    obj.location_target in employment.organisation.all_projects():
+                return True
+        except:
+            pass

--- a/akvo/rsr/tests/rest/test_indicator_period_data.py
+++ b/akvo/rsr/tests/rest/test_indicator_period_data.py
@@ -16,7 +16,7 @@ from django.test import TestCase, Client
 from akvo.rsr.models import (
     Project, Organisation, Partnership, User,
     Employment, Result, Indicator, IndicatorPeriod,
-    IndicatorDimension
+    IndicatorDimension, IndicatorPeriodData
 )
 
 from akvo.utils import check_auth_groups
@@ -79,6 +79,27 @@ class IndicatorPeriodDataTestCase(TestCase):
         Organisation.objects.all().delete()
         Group.objects.all().delete()
 
+    def _create_new_user(self, group, is_admin=False, is_superuser=False):
+        self.username2 = "username2"
+        self.password2 = "password2"
+        self.user2 = User.objects.create_user(
+            username=self.username2,
+            password=self.password2,
+            email='{}@test.akvo.org'.format(self.username2),
+        )
+        self.user2.is_active = True
+        self.user2.is_admin = is_admin
+        self.user2.is_superuser = is_superuser
+        self.user2.save()
+        group = Group.objects.get(name='M&E Managers')
+        employment = Employment.objects.create(
+            user=self.user2,
+            organisation=self.reporting_org,
+            group=group,
+            is_approved=True,
+        )
+        return employment
+
     def test_create_update(self):
         """Test that posting an update works."""
 
@@ -97,7 +118,6 @@ class IndicatorPeriodDataTestCase(TestCase):
 
         # Then
         self.assertEqual(201, response.status_code)
-        response.content
 
     def test_modify_update(self):
         """Test that modifying an update works."""
@@ -192,6 +212,168 @@ class IndicatorPeriodDataTestCase(TestCase):
         self.assertEqual(str(new_value), content['value'])
         self.assertEqual(1, len(content['disaggregations']))
         self.assertEqual(float(new_value), float(content['disaggregations'][0]['value']))
+
+    def test_draft_update_invisible_to_me_manager(self):
+        """Test that draft update is invisible to M&E managers."""
+
+        # Given
+        self.c.login(username=self.username, password=self.password)
+        url = '/rest/v1/indicator_period_data_framework/?format=json'
+        data = {
+            'period': self.period.id,
+            'user': self.user.id
+        }
+        response = self.c.post(url,
+                               data=json.dumps(data),
+                               content_type='application/json')
+        content = json.loads(response.content)
+        self._create_new_user(group='M&E Managers')
+
+        # When
+        self.c.logout()
+        self.c.login(username=self.username2, password=self.password2)
+        response = self.c.get(url, content_type='application/json')
+
+        # Then
+        self.assertEqual(200, response.status_code)
+        content = json.loads(response.content)
+        self.assertEqual(0, len(content['results']))
+
+    def test_draft_update_invisible_to_other_project_editors(self):
+        """Test that draft update is invisible to other Project Editors."""
+
+        # Given
+        self.c.login(username=self.username, password=self.password)
+        url = '/rest/v1/indicator_period_data_framework/?format=json'
+        data = {
+            'period': self.period.id,
+            'user': self.user.id
+        }
+        response = self.c.post(url,
+                               data=json.dumps(data),
+                               content_type='application/json')
+        content = json.loads(response.content)
+        self._create_new_user(group='Project Editors')
+
+        # When
+        self.c.logout()
+        self.c.login(username=self.username2, password=self.password2)
+        response = self.c.get(url, content_type='application/json')
+
+        # Then
+        self.assertEqual(200, response.status_code)
+        content = json.loads(response.content)
+        self.assertEqual(0, len(content['results']))
+
+    def test_draft_update_visible_to_admin(self):
+        """Test that draft update is visible to admins."""
+
+        # Given
+        self.c.login(username=self.username, password=self.password)
+        url = '/rest/v1/indicator_period_data_framework/?format=json'
+        data = {
+            'period': self.period.id,
+            'user': self.user.id
+        }
+        response = self.c.post(url,
+                               data=json.dumps(data),
+                               content_type='application/json')
+        content = json.loads(response.content)
+        self._create_new_user(group='Project Editors', is_admin=True)
+        update = IndicatorPeriodData.objects.get(id=content['id'])
+
+        # When
+        self.c.logout()
+        self.c.login(username=self.username2, password=self.password2)
+        response = self.c.get(url, content_type='application/json')
+
+        # Then
+        self.assertEqual(200, response.status_code)
+        content = json.loads(response.content)
+        self.assertEqual(1, len(content['results']))
+        self.assertEqual(update.id, content['results'][0]['id'])
+
+    def test_period_framework_hides_draft_updates_for_me_managers(self):
+        """Test draft updates hidden from M&E Managers in period framework."""
+        # Given
+        self.c.login(username=self.username, password=self.password)
+        url = '/rest/v1/indicator_period_data_framework/?format=json'
+        data = {
+            'period': self.period.id,
+            'user': self.user.id
+        }
+        response = self.c.post(url,
+                               data=json.dumps(data),
+                               content_type='application/json')
+        content = json.loads(response.content)
+        self._create_new_user(group='M&E Managers')
+
+        # When
+        self.c.logout()
+        self.c.login(username=self.username2, password=self.password2)
+        url = '/rest/v1/indicator_period_framework/?format=json'
+        response = self.c.get(url, content_type='application/json')
+
+        # Then
+        self.assertEqual(200, response.status_code)
+        content = json.loads(response.content)
+        self.assertEqual(0, len(content['results'][0]['data']))
+
+    def test_period_framework_hides_draft_updates_for_project_editors(self):
+        """Test draft updates hidden from other Project Editors in period framework."""
+
+        # Given
+        self.c.login(username=self.username, password=self.password)
+        url = '/rest/v1/indicator_period_data_framework/?format=json'
+        data = {
+            'period': self.period.id,
+            'user': self.user.id
+        }
+        response = self.c.post(url,
+                               data=json.dumps(data),
+                               content_type='application/json')
+        content = json.loads(response.content)
+        self._create_new_user(group='Project Editors')
+
+        # When
+        self.c.logout()
+        self.c.login(username=self.username2, password=self.password2)
+        url = '/rest/v1/indicator_period_framework/?format=json'
+        response = self.c.get(url, content_type='application/json')
+
+        # Then
+        self.assertEqual(200, response.status_code)
+        content = json.loads(response.content)
+        self.assertEqual(0, len(content['results'][0]['data']))
+
+    def test_period_framework_lists_draft_updates_for_admin(self):
+        """Test draft updates visible to admins in the period framework."""
+
+        # Given
+        self.c.login(username=self.username, password=self.password)
+        url = '/rest/v1/indicator_period_data_framework/?format=json'
+        data = {
+            'period': self.period.id,
+            'user': self.user.id
+        }
+        response = self.c.post(url,
+                               data=json.dumps(data),
+                               content_type='application/json')
+        content = json.loads(response.content)
+        self._create_new_user(group='Project Editors', is_admin=True)
+        update = IndicatorPeriodData.objects.get(id=content['id'])
+
+        # When
+        self.c.logout()
+        self.c.login(username=self.username2, password=self.password2)
+        url = '/rest/v1/indicator_period_framework/?format=json'
+        response = self.c.get(url, content_type='application/json')
+
+        # Then
+        self.assertEqual(200, response.status_code)
+        content = json.loads(response.content)
+        self.assertEqual(1, len(content['results'][0]['data']))
+        self.assertEqual(update.id, content['results'][0]['data'][0]['id'])
 
     def setup_results_framework(self):
         self.result = Result.objects.create(

--- a/akvo/rsr/tests/rest/test_indicator_period_data.py
+++ b/akvo/rsr/tests/rest/test_indicator_period_data.py
@@ -226,7 +226,6 @@ class IndicatorPeriodDataTestCase(TestCase):
         response = self.c.post(url,
                                data=json.dumps(data),
                                content_type='application/json')
-        content = json.loads(response.content)
         self._create_new_user(group='M&E Managers')
 
         # When
@@ -252,7 +251,6 @@ class IndicatorPeriodDataTestCase(TestCase):
         response = self.c.post(url,
                                data=json.dumps(data),
                                content_type='application/json')
-        content = json.loads(response.content)
         self._create_new_user(group='Project Editors')
 
         # When
@@ -305,7 +303,6 @@ class IndicatorPeriodDataTestCase(TestCase):
         response = self.c.post(url,
                                data=json.dumps(data),
                                content_type='application/json')
-        content = json.loads(response.content)
         self._create_new_user(group='M&E Managers')
 
         # When
@@ -332,7 +329,6 @@ class IndicatorPeriodDataTestCase(TestCase):
         response = self.c.post(url,
                                data=json.dumps(data),
                                content_type='application/json')
-        content = json.loads(response.content)
         self._create_new_user(group='Project Editors')
 
         # When


### PR DESCRIPTION
Closes #2861 

This PR hides draft updates from all users who haven't created them, unless the user is an admin/superuser. 

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
