### PR TITLE
[#2913] Fix percentage indicators without periods

### DIFF
--- a/akvo/rsr/static/scripts-src/my-results/selectors.js
+++ b/akvo/rsr/static/scripts-src/my-results/selectors.js
@@ -171,28 +171,39 @@ export const getIndicatorsAggregateActualValue = createSelector(
      */
     [getIndicatorIds, getIndicatorObjects, getIndicatorsChildrenIds, getPeriodObjects, getPeriodsActualValue],
     (indicatorIDs, indicatorObjects, childPeriodIds, periodObjects, actualValue) => {
-        return indicatorIDs && indicatorObjects && childPeriodIds && !isEmpty(actualValue) && indicatorIDs.reduce((acc, indicatorId) => {
-            let aggregateValue;
-            if (indicatorObjects[indicatorId].measure === c.MEASURE_PERCENTAGE) {
-                // Computed aggregate percentage -> (sum of all numerators) * 100 / (last/latest denominator)
-                const numerator = childPeriodIds[indicatorId].reduce((sum, periodId) => {
-                    return sum + (parseFloat(periodObjects[periodId].numerator)||0);
-                }, 0);
-                const childPeriods = childPeriodIds[indicatorId].map((id) => {return periodObjects[id];});
-                const latestPeriod = (periods) => {
-                    periods.sort((period1, period2) => {return period1.period_end < period2.period_end?1:-1;});
-                    return periods[0];
-                };
-                const denominator = (childPeriods.length == 1)?
-                          childPeriods[0].denominator:latestPeriod(childPeriods).denominator;
-                aggregateValue = computePercentage(numerator, denominator);
-            } else {
-                aggregateValue = childPeriodIds[indicatorId].reduce((sum, periodId) => {
-                    return sum + actualValue[periodId];
-                }, 0);
-            }
-            return {...acc, [indicatorId]: aggregateValue};
-        }, {});
+        return indicatorIDs && indicatorObjects && childPeriodIds && !isEmpty(actualValue) && indicatorIDs.reduce(
+            (acc, indicatorId) => {
+                let aggregateValue;
+                if (indicatorObjects[indicatorId].measure === c.MEASURE_PERCENTAGE) {
+                    // Computed aggregate percentage -> (sum of all numerators) * 100 / (last/latest denominator)
+                    const numerator = childPeriodIds[indicatorId].reduce(
+                        (sum, periodId) => {
+                            return sum + (parseFloat(periodObjects[periodId].numerator)||0);
+                        }, 0);
+                    const childPeriods = childPeriodIds[indicatorId].map((id) => {
+                        return periodObjects[id];
+                    });
+                    const latestPeriod = (periods) => {
+                        periods.sort((period1, period2) => {
+                            return period1.period_end < period2.period_end?1:-1;
+                        });
+                        return periods[0];
+                    };
+                    const denominator = (childPeriods.length == 0) ?
+                        0
+                    :
+                        (childPeriods.length == 1) ?
+                            childPeriods[0].denominator
+                        :
+                            latestPeriod(childPeriods).denominator;
+                    aggregateValue = computePercentage(numerator, denominator);
+                } else {
+                    aggregateValue = childPeriodIds[indicatorId].reduce((sum, periodId) => {
+                        return sum + actualValue[periodId];
+                    }, 0);
+                }
+                return {...acc, [indicatorId]: aggregateValue};
+            }, {});
     }
 );
 


### PR DESCRIPTION
Closes #2913 

The aggregate actual value calculation fails for percentage indicators without periods.

Fix by adding a check to see if there are periods.

- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

```markdown
The aggregate actual value calculation fails for percentage indicators without periods [#2913](https://github.com/akvo/akvo-rsr/issues/2913)
```
