### PR TITLE
Change the project editor link in the results framework

### DIFF
--- a/akvo/rsr/static/scripts-src/project-editor.js
+++ b/akvo/rsr/static/scripts-src/project-editor.js
@@ -4044,3 +4044,15 @@ document.addEventListener('DOMContentLoaded', function() {
         loadAndRenderReact();
     }
 });
+
+function expandSection() {
+    if (location.hash.indexOf('#step') < 0) {return;}
+    var stepInput = document.querySelector(location.hash);
+    if (!stepInput) {return;}
+    stepInput.parentElement.firstElementChild.click();
+    stepInput.parentElement.firstElementChild.scrollIntoView();
+};
+
+window.onload = function(){
+    expandSection();
+}

--- a/akvo/rsr/static/scripts-src/project-editor.jsx
+++ b/akvo/rsr/static/scripts-src/project-editor.jsx
@@ -4044,3 +4044,15 @@ document.addEventListener('DOMContentLoaded', function() {
         loadAndRenderReact();
     }
 });
+
+function expandSection() {
+    if (location.hash.indexOf('#step') < 0) {return;}
+    var stepInput = document.querySelector(location.hash);
+    if (!stepInput) {return;}
+    stepInput.parentElement.firstElementChild.click();
+    stepInput.parentElement.firstElementChild.scrollIntoView();
+};
+
+window.onload = function(){
+    expandSection();
+}

--- a/akvo/templates/myrsr/my_results.html
+++ b/akvo/templates/myrsr/my_results.html
@@ -7,7 +7,7 @@
 {% block myrsr_main %}
     <h4 class="resultProjectTitle" id="resultProjectTitle">
         Results for: <a href="{% url 'project-main' project.pk %}">{{ project.title }}</a>
-        <a href="{% url 'project_editor' project.pk %}"><button class="btn btn-default btn-sm"><i class="fa fa-pencil-square-o"></i> {% trans 'Edit project' %}</button></a>
+        <a href="{% url 'project_editor' project.pk %}"><i class="fa fa-pencil"></i></a>
     </h4>
     {% if not project.is_impact_project %}
         <div id="draft" class="">{% trans 'This is not an RSR Impact project, it is not possible to place updates on this project.' %}</div>

--- a/akvo/templates/myrsr/my_results.html
+++ b/akvo/templates/myrsr/my_results.html
@@ -7,7 +7,7 @@
 {% block myrsr_main %}
     <h4 class="resultProjectTitle" id="resultProjectTitle">
         Results for: <a href="{% url 'project-main' project.pk %}">{{ project.title }}</a>
-        <a href="{% url 'project_editor' project.pk %}"><i class="fa fa-pencil"></i></a>
+        <a href="{% url 'project_editor' project.pk %}#stepFive"><i class="fa fa-pencil"></i></a>
     </h4>
     {% if not project.is_impact_project %}
         <div id="draft" class="">{% trans 'This is not an RSR Impact project, it is not possible to place updates on this project.' %}</div>


### PR DESCRIPTION
- [ ] Test plan | Unit test | Integration test
  - The button should now be a simple pencil icon
  - Clicking on the icon should take you to the project editor page, scrolled to the results section, expanded. 
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry

```markdown
Change the 'Edit Project' button in the Results Framework [#2935](https://github.com/akvo/akvo-rsr/issues/2935)
```
