### PR TITLE
[#2949] Change opening view of Results to always be "overview"

### DIFF
--- a/akvo/rsr/static/scripts-src/my-results/components/App.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/App.jsx
@@ -24,7 +24,6 @@ import {setPageData} from "../actions/page-actions";
 import {
     activateFilterCSS,
     activateToggleAll,
-    filterActive,
     selectPeriodByDates,
     filterPeriods,
     updateFormClose,
@@ -34,7 +33,7 @@ import * as c from "../const"
 
 import {
     getApprovedPeriods,
-    getMEManagerDefaultKeys,
+    getResultsDefaultKeys,
     getNeedReportingPeriods,
     getPendingApprovalPeriods,
     getUpdatesDisaggregationObjects,
@@ -91,8 +90,7 @@ const modifyUser = (isMEManager) => {
         needReportingPeriods: getNeedReportingPeriods(store),
         pendingApprovalPeriods: getPendingApprovalPeriods(store),
         approvedPeriods: getApprovedPeriods(store),
-        MEManagerDefaultKeys: getMEManagerDefaultKeys(store),
-        publicViewDefaultKeys: getPublicViewDefaultKeys(store),
+        ResultsDefaultKeys: getResultsDefaultKeys(store),
     }
 })
 export default class App extends React.Component {
@@ -176,18 +174,8 @@ export default class App extends React.Component {
         };
 
         const setInitialView = () => {
-            // set the initial state of the Results panels to open if the user is an M&E manager or
-            // this is the public view
-            if (nextProps.ui.allFetched && !this.state.initialViewSet) {
-                if (nextProps.page.mode && nextProps.page.mode.public) {
-                    openNodes(c.OBJECTS_INDICATORS, this.props.publicViewDefaultKeys);
-                    this.setState({initialViewSet: true});
-                }
-                if (userIsMEManager(this.props.user)) {
-                    collapseChange(resultsCollapseID, this.props.MEManagerDefaultKeys);
-                    this.setState({initialViewSet: true});
-                }
-            }
+            collapseChange(resultsCollapseID, this.props.ResultsDefaultKeys);
+            this.setState({initialViewSet: true});
         };
 
         const prepareUpdateForm = () => {

--- a/akvo/rsr/static/scripts-src/my-results/components/FilterBar.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/FilterBar.jsx
@@ -27,7 +27,7 @@ import * as c from "../const"
 
 import {
     getApprovedPeriods,
-    getMEManagerDefaultKeys,
+    getResultsDefaultKeys,
     getNeedReportingPeriods,
     getPendingUpdates,
 } from "../selectors";
@@ -78,7 +78,7 @@ const PeriodLockingButtons = ({user, disabled}) => {
         pendingUpdates: getPendingUpdates(store),
         approvedPeriods: getApprovedPeriods(store),
         needReportingPeriods: getNeedReportingPeriods(store),
-        MEManagerDefaultKeys: getMEManagerDefaultKeys(store),
+        ResultsDefaultKeys: getResultsDefaultKeys(store),
     }
 })
 export default class FilterBar extends React.Component {
@@ -101,12 +101,12 @@ export default class FilterBar extends React.Component {
 
     createToggleKeys() {
         const open = this.openResults();
-        let MEManagerKeys;
+        let resultsKeys;
         if (userIsMEManager(this.props.user)) {
-            MEManagerKeys = this.props.MEManagerDefaultKeys;
+            resultsKeys = this.props.ResultsDefaultKeys;
         }
         // construct the array of Collapse activeKeys for the sub-tree
-        return toggleTree(c.OBJECTS_RESULTS, c.OBJECTS_RESULTS, open, MEManagerKeys);
+        return toggleTree(c.OBJECTS_RESULTS, c.OBJECTS_RESULTS, open, resultsKeys);
     }
 
     toggleAll() {
@@ -121,17 +121,12 @@ export default class FilterBar extends React.Component {
     openResults() {
         // Determine if we should open the full tree or close it
         const activeKey = this.props.keys["results-results"];
-        if (userIsMEManager(this.props.user)) {
-            const keys = this.props.keys;
-            // if activeKey is identical to the MEManagerDefaultKeys selector we are at the "closed"
-            // closed view for an M&E manager
-            const openCollapses = Object.keys(keys).filter(key => keys[key].length !== 0);
-            return identicalArrays(activeKey, this.props.MEManagerDefaultKeys) &&
-                openCollapses.length === 1;
-        } else {
-            // otherwise open only if the whole tree is closed
-            return activeKey === undefined || activeKey.length === 0;
-        }
+        const keys = this.props.keys;
+        // if activeKey is identical to the ResultsDefaultKeys selector we are at the "closed"
+        // closed view for an M&E manager
+        const openCollapses = Object.keys(keys).filter(key => keys[key].length !== 0);
+        return identicalArrays(activeKey, this.props.ResultsDefaultKeys) &&
+            openCollapses.length === 1;
     }
 
     filterButtonClass(button) {

--- a/akvo/rsr/static/scripts-src/my-results/selectors.js
+++ b/akvo/rsr/static/scripts-src/my-results/selectors.js
@@ -382,18 +382,10 @@ export const getUpdatesForPendingApprovalPeriods = createSelector(
 );
 
 
-export const getMEManagerDefaultKeys = createSelector(
+export const getResultsDefaultKeys = createSelector(
     /*
         Just an array of IDs as string, used to set the top collapse (for Results) to all open
      */
     [getResultIds],
     resultIds => idsToActiveKey(resultIds)
-);
-
-export const getPublicViewDefaultKeys = createSelector(
-    /*
-        Just an array of IDs as string, used for the default view on the project page Results tab
-     */
-    [getIndicatorIds],
-    indicatorIds => idsToActiveKey(indicatorIds)
 );


### PR DESCRIPTION
The overview being whith the results nodes opened, and the indicators are closed.

Closes #2949 

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry

```markdown
The public Results view should open as Overview [#2949](https://github.com/akvo/akvo-rsr/issues/2949)
```
