### PR TITLE
[#2962] Hide honeypot field on registration page

### DIFF
--- a/akvo/rsr/static/styles-src/main.css
+++ b/akvo/rsr/static/styles-src/main.css
@@ -2810,6 +2810,12 @@ div.iatiFilters {
 .fa-paperclip, .fa-camera {
   margin-right: 0.3em; }
 
+/* Registration */
+#id_hp_title {
+  display: none;
+  position: absolute;
+  top: -9999px; }
+
 /* Results Framework */
 header[role="banner"] {
   display: block;

--- a/akvo/rsr/static/styles-src/main.scss
+++ b/akvo/rsr/static/styles-src/main.scss
@@ -4063,6 +4063,13 @@ div.iatiFilters {
     margin-right: 0.3em;
 }
 
+/* Registration */
+#id_hp_title {
+    display: none;
+    position: absolute;
+    top: -9999px;
+}
+
 /* Results Framework */
 
 header[role="banner"] {


### PR DESCRIPTION
Closes #2962 

The style to hide the honeypot field on the registration page went missing very soon after the field was added. Quick look at the git commit history doesn't explain exactly what happened, looks like for some reason the added CSS was removed in a later commit that had an older parent than the one where the style was added.


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry

```markdown
Honeypot field on register page visible [#2962](https://github.com/akvo/akvo-rsr/issues/2962)