### PR TITLE
[#2946] Add a script to recalculate periods

### DIFF
--- a/akvo/rsr/management/commands/recalculate_periods.py
+++ b/akvo/rsr/management/commands/recalculate_periods.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+from django.core.management.base import BaseCommand
+from django.db.models import Count
+
+from ...models import IndicatorPeriod
+
+
+class Command(BaseCommand):
+
+    args = '[<project_id>]'
+    help = 'Script for recalculating periods which have children'
+
+    def handle(self, *args, **options):
+
+        # parse options
+        verbosity = int(options['verbosity'])
+
+        if len(args) == 1:
+            project_id = args[0]
+        else:
+            project_id = None
+
+        periods = IndicatorPeriod.objects\
+                                 .annotate(child_count=Count('child_periods'))\
+                                 .filter(child_count__gt=0)
+
+        if project_id:
+            periods = periods.filter(indicator__result__project=project_id)
+            if verbosity > 1:
+                print('Recalculating periods on project {}'.format(project_id))
+
+        if verbosity > 1:
+            print('Recalculating {} periods'.format(periods.count()))
+
+        for period in periods:
+            if verbosity > 1:
+                print('Recalculating period {}'.format(period.id))
+            period.recalculate_period()


### PR DESCRIPTION
The script that fixes orphaned periods does not recalculate the fixed parent
periods, and hence the aggregated actual values are still incorrect.


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
