### PR TITLE
[#2968] Show attachments for all indicators

### DIFF
--- a/akvo/rsr/static/scripts-src/my-results/components/updates/Updates.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/updates/Updates.jsx
@@ -187,6 +187,7 @@ const QuantitativeUpdateBody = ({update, dimensions, disaggregations}) => {
                 {approvedOn}
             </div>
             <UpdateStatus update={update} />
+            <UpdateAttachments update={update} />
         </div>
     )
 };


### PR DESCRIPTION
For some reason the attachments in updates were only shown for qualitative indicators.

Closes #2968 

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
