### PR TITLE
[#2940] Allow selecting multiple updates and bulk approving

### DIFF
--- a/akvo/rsr/static/scripts-src/my-results/actions/model-actions.js
+++ b/akvo/rsr/static/scripts-src/my-results/actions/model-actions.js
@@ -10,10 +10,14 @@ import store from "../store"
 import * as c from "../const"
 import {
     getCookie,
-    endpoints
-} from "../utils"
+    endpoints,
+    pruneUpdateForPATCH,
+} from "../utils";
 
-import { periodSelectReset } from "./ui-actions"
+import {
+    periodSelectReset,
+    updateSelectReset,
+} from "./ui-actions";
 
 //TODO: refactor backend-calling functions, currently lots of overlap functionality that can be extracted
 
@@ -430,14 +434,29 @@ function periodLockingParams(locked) {
     patchMultiple(c.OBJECTS_PERIODS, data, periodSelectReset);
 }
 
+function approveAllSelectedUpdates(userId) {
+    const selectedUpdates = store.getState().ui[c.SELECTED_UPDATES];
+    const data = selectedUpdates.map((id) => {
+        const update = store.getState().models.updates.objects[id];
+        const pruned_update = pruneUpdateForPATCH(update);
+        pruned_update.status = c.UPDATE_STATUS_APPROVED;
+        pruned_update.approved_by = userId;
+        return {url: endpoints.update_and_comments(id), data: pruned_update};
+    });
+    patchMultiple(c.OBJECTS_UPDATES, data, updateSelectReset);
+}
+
 
 export function lockSelectedPeriods() {
     periodLockingParams(true)
 }
 
-
 export function unlockSelectedPeriods() {
     periodLockingParams(false)
+}
+
+export function approveSelectedUpdates(userId) {
+    approveAllSelectedUpdates(userId);
 }
 
 

--- a/akvo/rsr/static/scripts-src/my-results/actions/ui-actions.js
+++ b/akvo/rsr/static/scripts-src/my-results/actions/ui-actions.js
@@ -24,12 +24,25 @@ export function periodSelectReset() {
     })
 }
 
+export function updateSelectReset() {
+    store.dispatch({
+        type: c.UI_ID_RESET,
+        payload: {element: c.SELECTED_UPDATES}
+    });
+}
 
 export function periodSelectToggle(id) {
     store.dispatch({
         type: c.UI_ID_TOGGLE,
         payload: {element: c.SELECTED_PERIODS, id: id}
     })
+}
+
+export function updateSelectToggle(id) {
+    store.dispatch({
+        type: c.UI_ID_TOGGLE,
+        payload: {element: c.SELECTED_UPDATES, id: id}
+    });
 }
 
 

--- a/akvo/rsr/static/scripts-src/my-results/components/FilterBar.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/FilterBar.jsx
@@ -21,6 +21,7 @@ import {
 import {
     lockSelectedPeriods,
     unlockSelectedPeriods,
+    approveSelectedUpdates,
 } from "../actions/model-actions";
 
 import * as c from "../const"
@@ -69,6 +70,18 @@ const PeriodLockingButtons = ({user, disabled}) => {
         <div className="col-xs-6">
         </div>;
 };
+
+const ApproveUpdatesButton = ({user, activeFilter}) => {
+    return (userIsMEManager(user) && activeFilter == c.FILTER_SHOW_PENDING) ?
+           <div className="col-xs-6">
+               <ToggleButton onClick={()=>{approveSelectedUpdates(user.ids[0])}}
+                             label={_("approve_updates")}/>
+           </div>
+ :
+           <div className="col-xs-6">
+           </div>;
+};
+
 
 @connect((store) => {
     return {
@@ -160,95 +173,97 @@ export default class FilterBar extends React.Component {
             // TODO: this is a hideously ugly hack to show the filterbar in two modes depending on
             // if we're on the results page or the project page. Needs refactoring!
             page.mode && page.mode.public ?
-                <header role="banner" className="periodMenuBar">
-                    <nav>
-                        <div className={'periodBtns'}>
-                            <div className={'row'}>
-                                <div className={'periodBulkAct col-sm-6'}>
-                                    <h5>View</h5>
-                                    <ToggleButton onClick={this.toggleAll}
-                                                  label={openCloseLabel}
-                                                  disabled={buttonDisabled}
-                                                  className="overviewBtn btn btn-sm btn-default"/>
-                                </div>
-                                <div className={'periodBulkAct col-sm-6'}>
-                                    <div className={'row'}><h5>{_("filter_periods")}</h5>
-                                        <div className="col-xs-6">
-                                            <Select options={selectOptions}
-                                                    value={this.state.selectedOption}
-                                                    multi={false}
-                                                    placeholder={_("select_periods")}
-                                                    searchable={false}
-                                                    clearable={false}
-                                                    onChange={this.selectChange}
-                                                    className={
-                                                        this.filterSelectClass(c.FILTER_BULK_SELECT)}/>
-                                        </div>
-                                        <PeriodLockingButtons user={this.props.user}
-                                                              disabled={buttonDisabled}/>
+            <header role="banner" className="periodMenuBar">
+                <nav>
+                    <div className={'periodBtns'}>
+                        <div className={'row'}>
+                            <div className={'periodBulkAct col-sm-6'}>
+                                <h5>View</h5>
+                                <ToggleButton onClick={this.toggleAll}
+                                              label={openCloseLabel}
+                                              disabled={buttonDisabled}
+                                              className="overviewBtn btn btn-sm btn-default"/>
+                            </div>
+                            <div className={'periodBulkAct col-sm-6'}>
+                                <div className={'row'}><h5>{_("filter_periods")}</h5>
+                                    <div className="col-xs-6">
+                                        <Select options={selectOptions}
+                                                value={this.state.selectedOption}
+                                                multi={false}
+                                                placeholder={_("select_periods")}
+                                                searchable={false}
+                                                clearable={false}
+                                                onChange={this.selectChange}
+                                                className={
+                                                    this.filterSelectClass(c.FILTER_BULK_SELECT)}/>
                                     </div>
+                                    <PeriodLockingButtons user={this.props.user}
+                                                          disabled={buttonDisabled}/>
                                 </div>
                             </div>
                         </div>
-                    </nav>
-                </header>
+                    </div>
+                </nav>
+            </header>
             :
-                <header role="banner" className="periodMenuBar">
-                    <nav>
-                        <div className={'periodBtns'}>
-                            <div className={'row'}>
-                                <div className={'periodFilter col-sm-6'}>
-                                    <div className={'row'}>
-                                        <h5>{_("indicator_reporting")}</h5>
-                                        <div className="col-xs-12">
-                                            <ToggleButton onClick={callbacks.needReporting}
-                                                          label={needReportingLabel}
-                                                          disabled={buttonDisabled}
-                                                          className={
-                                                              this.filterButtonClass(c.FILTER_NEED_REPORTING)
-                                                          }/>
-                                            <ToggleButton onClick={callbacks.showPending} label={draftUpdateLabel}
-                                                          disabled={buttonDisabled}
-                                                          className={
-                                                              this.filterButtonClass(c.FILTER_SHOW_PENDING)
-                                                          }/>
-                                            <ToggleButton onClick={callbacks.showApproved}
-                                                          label={approvedUpdateLabel}
-                                                          disabled={buttonDisabled}
-                                                          className={
-                                                              this.filterButtonClass(c.FILTER_SHOW_APPROVED)
-                                                          }/>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div className={'periodBulkAct col-sm-6'}>
-                                    <div className={'row'}><h5>{_("filter_periods")}</h5>
-                                        <div className="col-xs-6">
-                                            <Select options={selectOptions}
-                                                    value={this.state.selectedOption}
-                                                    multi={false}
-                                                    placeholder={_("select_periods")}
-                                                    searchable={false}
-                                                    clearable={false}
-                                                    onChange={this.selectChange}
-                                                    className={
-                                                        this.filterSelectClass(c.FILTER_BULK_SELECT)}/>
-                                        </div>
-                                        <PeriodLockingButtons user={this.props.user}
-                                                              disabled={buttonDisabled}/>
+            <header role="banner" className="periodMenuBar">
+                <nav>
+                    <div className={'periodBtns'}>
+                        <div className={'row'}>
+                            <div className={'periodFilter col-sm-6'}>
+                                <div className={'row'}>
+                                    <h5>{_("indicator_reporting")}</h5>
+                                    <div className="col-xs-12">
+                                        <ToggleButton onClick={callbacks.needReporting}
+                                                      label={needReportingLabel}
+                                                      disabled={buttonDisabled}
+                                                      className={
+                                                          this.filterButtonClass(c.FILTER_NEED_REPORTING)
+                                                      }/>
+                                        <ToggleButton onClick={callbacks.showPending} label={draftUpdateLabel}
+                                                      disabled={buttonDisabled}
+                                                      className={
+                                                          this.filterButtonClass(c.FILTER_SHOW_PENDING)
+                                                      }/>
+                                        <ToggleButton onClick={callbacks.showApproved}
+                                                      label={approvedUpdateLabel}
+                                                      disabled={buttonDisabled}
+                                                      className={
+                                                          this.filterButtonClass(c.FILTER_SHOW_APPROVED)
+                                                      }/>
                                     </div>
                                 </div>
                             </div>
-                            <div className={'row'}>
-                                <div className="col-xs-12">
-                                    <ToggleButton onClick={this.toggleAll} label={openCloseLabel}
-                                                  disabled={buttonDisabled} className="overviewBtn btn btn-sm btn-default"/>
-
+                            <div className={'periodBulkAct col-sm-6'}>
+                                <div className={'row'}><h5>{_("filter_periods")}</h5>
+                                    <div className="col-xs-6">
+                                        <Select options={selectOptions}
+                                                value={this.state.selectedOption}
+                                                multi={false}
+                                                placeholder={_("select_periods")}
+                                                searchable={false}
+                                                clearable={false}
+                                                onChange={this.selectChange}
+                                                className={
+                                                    this.filterSelectClass(c.FILTER_BULK_SELECT)}/>
+                                    </div>
+                                    <PeriodLockingButtons user={this.props.user}
+                                                          disabled={buttonDisabled}/>
+                                    <ApproveUpdatesButton user={this.props.user}
+                                                          activeFilter={this.props.ui.activeFilter}/>
                                 </div>
                             </div>
                         </div>
-                    </nav>
-                </header>
+                        <div className={'row'}>
+                            <div className="col-xs-12">
+                                <ToggleButton onClick={this.toggleAll} label={openCloseLabel}
+                                              disabled={buttonDisabled} className="overviewBtn btn btn-sm btn-default"/>
+
+                            </div>
+                        </div>
+                    </div>
+                </nav>
+            </header>
         )
     }
 };

--- a/akvo/rsr/static/scripts-src/my-results/components/updates/UpdateForm.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/updates/UpdateForm.jsx
@@ -40,6 +40,8 @@ import {
     isNumeric,
     getAncestor,
     computePercentage,
+    pruneUpdateForPATCH,
+    pruneUpdateForPOST,
 } from '../../utils.js';
 
 import AlertFactory from "../alertContainer"
@@ -716,21 +718,6 @@ DisaggregatedValueInput.propTypes = {
 };
 
 
-const pruneForPATCH = (update) => {
-    // Only include the listed fields when PATCHing an update
-    // currently the list mimics the old MyResults data
-    const fields = ['value', 'narrative', 'numerator', 'denominator', 'text',
-                    'status', '_file', '_photo', 'approved_by', 'disaggregations'];
-    return fields.reduce((acc, f) => {return Object.assign(acc, {[f]: update[f]})}, {});
-};
-
-const pruneForPOST = (update) => {
-    // Delete the listed fields when POSTing an update
-    let updateForPOST = Object.assign({}, update);
-    delete updateForPOST['user_details'];
-    return updateForPOST;
-};
-
 @connect((store) => {
     return {
         user: store.models.user.objects[store.models.user.ids[0]],
@@ -1089,12 +1076,12 @@ export default class UpdateForm extends React.Component {
 
         if (isNewUpdate(update)) {
             saveUpdateToBackend(
-                endpoints.updates_and_comments(), pruneForPOST(update),
+                endpoints.updates_and_comments(), pruneUpdateForPOST(update),
                 this.props.collapseId, callbacksFactory(update.id, _('update_not_created'))
             );
         } else {
             updateUpdateToBackend(
-                endpoints.update_and_comments(update.id), pruneForPATCH(update),
+                endpoints.update_and_comments(update.id), pruneUpdateForPATCH(update),
                 this.props.collapseId, callbacksFactory(update.id, _("update_not_saved"))
             );
         }

--- a/akvo/rsr/static/scripts-src/my-results/components/updates/Updates.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/updates/Updates.jsx
@@ -5,31 +5,25 @@
    < http://www.gnu.org/licenses/agpl.html >.
  */
 
+import React from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
 
-import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from "react-redux"
+import groupBy from "lodash/groupBy";
+import keyBy from "lodash/keyBy";
 
-import groupBy from 'lodash/groupBy';
-import keyBy from 'lodash/keyBy';
+import * as alertActions from "../../actions/alert-actions";
 
-import * as alertActions from "../../actions/alert-actions"
-
-import { collapseChange } from "../../actions/collapse-actions"
-
-import {
-    uiHideMode,
-    updateFormOpen
-} from "../../actions/ui-actions"
-
-import  * as c from '../../const.js';
+import { collapseChange } from "../../actions/collapse-actions";
+import { uiHideMode, updateFormOpen, updateSelectToggle } from "../../actions/ui-actions";
+import * as c from "../../const.js";
 
 import {
     getPeriodsChildrenIds,
     getUpdatesForApprovedPeriods,
     getUpdatesForNeedReportingPeriods,
     getUpdatesForPendingApprovalPeriods,
-    getUpdatesDisaggregationIds,
+    getUpdatesDisaggregationIds
 } from "../../selectors";
 
 import {
@@ -41,108 +35,98 @@ import {
     openNodes
 } from "../../utils";
 
-import {
-    displayDate,
-    _,
-    createToggleKeys,
-    collapseId,
-} from '../../utils.js';
+import { displayDate, _, createToggleKeys, collapseId } from "../../utils.js";
 
-import {
-    DisaggregationsDisplay,
-    ToggleButton
-} from "../common"
+import { DisaggregationsDisplay, ToggleButton } from "../common";
 
-import Comments from "../Comments"
+import Comments from "../Comments";
 
-import {Markdown} from 'react-showdown';
-
+import { Markdown } from "react-showdown";
 
 function displayName(user) {
-    return user.last_name ?
-        user.first_name ?
-            user.first_name + " " + user.last_name
-        :
-            user.last_name
-    :
-        user.first_name ?
-            user.first_name
-        :
-            user.email;
+    return user.last_name
+        ? user.first_name ? user.first_name + " " + user.last_name : user.last_name
+        : user.first_name ? user.first_name : user.email;
 }
 
-
-const TimestampInfo =({update, user, label}) => {
+const TimestampInfo = ({ update, user, label }) => {
     //TODO: tranlsate! Will need some refactoring to handle possible different word sequences
     return (
         <ul>
-            <li className="approverMeta">{label}
+            <li className="approverMeta">
+                {label}
                 <span className="UpdateDate"> {displayDate(update.last_modified_at)}</span>
-                {user ?
-                    <span className="hide"> {displayName(user)}</span>
-                :
+                {user ? <span className="hide"> {displayName(user)}</span> : undefined}
+                {user ? (
+                    <span className="hide">
+                        {" "}
+                        {user.approved_organisations[0] && user.approved_organisations[0].name}
+                    </span>
+                ) : (
                     undefined
-                }
-                {user ?
-                    <span className="hide"> {
-                        user.approved_organisations[0] && user.approved_organisations[0].name
-                    }</span>
-                :
-                    undefined
-                }
+                )}
             </li>
         </ul>
-    )
+    );
 };
 TimestampInfo.propTypes = {
     update: PropTypes.object.isRequired,
     user: PropTypes.object,
-    label: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired
 };
 
-
-const UpdateValue =({update}) => {
-    const {value, text} = update;
+const UpdateValue = ({ update }) => {
+    const { value, text } = update;
     return (
         <ul className="valueMeta">
-            <li className="updateValue">Update value: <span>{value}</span></li>
-            <li className="updateValueComment">Update comment: <span>{text}</span></li>
+            <li className="updateValue">
+                Update value: <span>{value}</span>
+            </li>
+            <li className="updateValueComment">
+                Update comment: <span>{text}</span>
+            </li>
         </ul>
-    )
+    );
 };
 UpdateValue.propTypes = {
     update: PropTypes.object.isRequired
 };
 
-
-const UpdateStatus =({update}) => {
+const UpdateStatus = ({ update }) => {
     return (
         <ul>
-            <li className="statusMeta">Status:
-                <span> {_('update_statuses')[update.status]}</span>
+            <li className="statusMeta">
+                Status:
+                <span> {_("update_statuses")[update.status]}</span>
             </li>
         </ul>
-    )
+    );
 };
 UpdateStatus.propTypes = {
     update: PropTypes.object.isRequired
 };
 
-
-const UpdateAttachments =({update}) => {
-    const {photo, file} = update;
-    const photo_container = photo?(
+const UpdateAttachments = ({ update }) => {
+    const { photo, file } = update;
+    const photo_container = photo ? (
         <div className="update-photo">
             <div className="image-container">
-                <img src={photo}/>
+                <img src={photo} />
             </div>
         </div>
-    ): undefined;
-    const file_container = file?(
+    ) : (
+        undefined
+    );
+    const file_container = file ? (
         <div className="update-attachment">
-            Attachment: <a href={file} target="_blank">{decodeURIComponent(file.split('/').pop())}</a>
+            Attachment:{" "}
+            <a href={file} target="_blank">
+                {decodeURIComponent(file.split("/").pop())}
+            </a>
         </div>
-    ):undefined;
+    ) : (
+        undefined
+    );
     return (
         <div>
             {photo_container}
@@ -154,15 +138,14 @@ UpdateAttachments.propTypes = {
     update: PropTypes.object.isRequired
 };
 
-
-const QuantitativeUpdateBody = ({update, disaggregationIds, dimensions, disaggregations}) => {
-    const {user_details, approver_details} = update;
-    const approvedOn = update.status === c.UPDATE_STATUS_APPROVED ?
-                       <TimestampInfo update={update}
-                                      user={approver_details}
-                                      label={_('approved_on') + ':'} />
-    :
-                       undefined;
+const QuantitativeUpdateBody = ({ update, disaggregationIds, dimensions, disaggregations }) => {
+    const { user_details, approver_details } = update;
+    const approvedOn =
+        update.status === c.UPDATE_STATUS_APPROVED ? (
+            <TimestampInfo update={update} user={approver_details} label={_("approved_on") + ":"} />
+        ) : (
+            undefined
+        );
     // sort to uphold order defined by creation of dimensions in the project editor
     // TODO: selectors.getUpdatesDisaggregationIds() could be updated to handle the sorting
     disaggregationIds = disaggregationIds.sort(
@@ -176,151 +159,159 @@ const QuantitativeUpdateBody = ({update, disaggregationIds, dimensions, disaggre
     return (
         <div className="UpdateBody">
             <UpdateValue update={update} />
-            <DisaggregationsDisplay disaggregationData={disaggregationData}/>
+            <DisaggregationsDisplay disaggregationData={disaggregationData} />
             <div className="timestamp-info-container">
-                <TimestampInfo update={update} user={user_details} label={_('created_on') + ':'} />
+                <TimestampInfo update={update} user={user_details} label={_("created_on") + ":"} />
                 {approvedOn}
             </div>
             <UpdateStatus update={update} />
             <UpdateAttachments update={update} />
         </div>
-    )
+    );
 };
 QuantitativeUpdateBody.propTypes = {
     update: PropTypes.object.isRequired
 };
 
-
-const UpdateNarrative =({period, update}) => {
+const UpdateNarrative = ({ period, update }) => {
     return (
         <ul className="valueMeta">
-            <li className="updateValue">Target:
-                <div className="markdown"> <Markdown markup={period.target_value}/> </div>
+            <li className="updateValue">
+                Target:
+                <div className="markdown">
+                    {" "}
+                    <Markdown markup={period.target_value} />{" "}
+                </div>
             </li>
-            <li className="updateValue">Actual:
-                <div className="markdown"><Markdown markup={update.narrative}/></div>
+            <li className="updateValue">
+                Actual:
+                <div className="markdown">
+                    <Markdown markup={update.narrative} />
+                </div>
             </li>
         </ul>
-    )
+    );
 };
 UpdateValue.propTypes = {
     update: PropTypes.object.isRequired
 };
 
-
-const QualitativeUpdateBody = ({period, update}) => {
-    const {user_details, approver_details} = update;
-    const approvedOn = update.status === c.UPDATE_STATUS_APPROVED ?
-                       <TimestampInfo update={update}
-                                      user={approver_details}
-                                      label={_('approved_on') + ':'} />
-    :
-                       undefined;
+const QualitativeUpdateBody = ({ period, update }) => {
+    const { user_details, approver_details } = update;
+    const approvedOn =
+        update.status === c.UPDATE_STATUS_APPROVED ? (
+            <TimestampInfo update={update} user={approver_details} label={_("approved_on") + ":"} />
+        ) : (
+            undefined
+        );
     return (
         <div className="UpdateBody">
             <UpdateNarrative period={period} update={update} />
-            <TimestampInfo update={update} user={user_details} label={_('created_on') + ':'} />
+            <TimestampInfo update={update} user={user_details} label={_("created_on") + ":"} />
             {approvedOn}
             <UpdateStatus update={update} />
             <UpdateAttachments update={update} />
         </div>
-    )
+    );
 };
 QualitativeUpdateBody.propTypes = {
     period: PropTypes.object.isRequired,
-    update: PropTypes.object.isRequired,
+    update: PropTypes.object.isRequired
 };
 
-
-const UserInfo = ({user_details}) => {
-    const {approved_organisations, first_name, last_name} = user_details;
-    const organisation = approved_organisations.length ?
-        approved_organisations[0].name
-    :
-        null;
+const UserInfo = ({ user_details }) => {
+    const { approved_organisations, first_name, last_name } = user_details;
+    const organisation = approved_organisations.length ? approved_organisations[0].name : null;
     const userName = first_name + " " + last_name;
 
     return (
-        <span><span>{userName}</span> {organisation ? " at " + organisation: ''}</span>
-    )
+        <span>
+            <span>{userName}</span> {organisation ? " at " + organisation : ""}
+        </span>
+    );
 };
 UserInfo.propTypes = {
-    user_details: PropTypes.object.isRequired,
+    user_details: PropTypes.object.isRequired
 };
 
-
-const QuantitativeUpdate = (
-    {id, update, disaggregationIds, disaggregations, dimensions, periodLocked, collapseId}) => {
+const QuantitativeUpdate = ({
+    id,
+    update,
+    disaggregationIds,
+    disaggregations,
+    dimensions,
+    periodLocked,
+    collapseId
+}) => {
     return (
         <div className="row" key={id}>
-            <UpdateHeader update={update} periodLocked={periodLocked}
-                          collapseId={collapseId}/>
+            <UpdateHeader update={update} periodLocked={periodLocked} collapseId={collapseId} />
             <div className="row">
-                <QuantitativeUpdateBody update={update}
-                                        disaggregationIds={disaggregationIds}
-                                        dimensions={dimensions}
-                                        disaggregations={disaggregations}/>
-                <Comments parentId={id} inForm={false}/>
-                <hr className="delicate"/>
+                <QuantitativeUpdateBody
+                    update={update}
+                    disaggregationIds={disaggregationIds}
+                    dimensions={dimensions}
+                    disaggregations={disaggregations}
+                />
+                <Comments parentId={id} inForm={false} />
+                <hr className="delicate" />
             </div>
         </div>
-    )
+    );
 };
 QuantitativeUpdate.propTypes = {
-    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number,]).isRequired,
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     update: PropTypes.object.isRequired,
     disaggregationIds: PropTypes.array,
     disaggregations: PropTypes.object,
     dimensions: PropTypes.object,
     periodLocked: PropTypes.bool.isRequired,
-    collapseId: PropTypes.string.isRequired,
+    collapseId: PropTypes.string.isRequired
 };
 
-
-const QualitativeUpdate = ({id, period, update, collapseId}) => {
+const QualitativeUpdate = ({ id, period, update, collapseId }) => {
     return (
         <div className="row" key={id}>
-            <UpdateHeader update={update} periodLocked={period.locked} collapseId={collapseId}/>
+            <UpdateHeader update={update} periodLocked={period.locked} collapseId={collapseId} />
             <div className="row">
-                <QualitativeUpdateBody period={period} update={update}/>
-                <Comments parentId={id} inForm={false}/>
-                <hr className="delicate"/>
+                <QualitativeUpdateBody period={period} update={update} />
+                <Comments parentId={id} inForm={false} />
+                <hr className="delicate" />
             </div>
         </div>
-    )
+    );
 };
 QualitativeUpdate.propTypes = {
-    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number,]).isRequired,
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
     period: PropTypes.object.isRequired,
     update: PropTypes.object.isRequired,
-    collapseId: PropTypes.string.isRequired,
+    collapseId: PropTypes.string.isRequired
 };
 
-
-@connect((store) => {
+@connect(store => {
     return {
         page: store.page,
         [c.UPDATE_FORM_DISPLAY]: store.ui[c.UPDATE_FORM_DISPLAY],
+        [c.SELECTED_UPDATES]: store.ui[c.SELECTED_UPDATES],
         activeFilter: store.ui.activeFilter,
-        user: store.models.user.objects[store.models.user.ids[0]],
-    }
+        user: store.models.user.objects[store.models.user.ids[0]]
+    };
 }, alertActions)
 class UpdateHeader extends React.Component {
-
     static propTypes = {
         update: PropTypes.object.isRequired,
         collapseId: PropTypes.string.isRequired,
-        periodLocked: PropTypes.bool.isRequired,
+        periodLocked: PropTypes.bool.isRequired
     };
 
-    constructor (props) {
+    constructor(props) {
         super(props);
         this.formToggle = this.formToggle.bind(this);
         this.showEditButton = this.showEditButton.bind(this);
     }
 
     formToggle(e) {
-        const {collapseId, update} = this.props;
+        const { collapseId, update } = this.props;
         updateFormOpen(update.id);
         uiHideMode(c.OBJECTS_PERIODS);
         openNodes(c.OBJECTS_PERIODS, [update.period]);
@@ -331,22 +322,22 @@ class UpdateHeader extends React.Component {
     showEditButton() {
         // Only show the Edit update button if the period is unlocked, the update is shown in the
         // relevant filter and the user can edit at this time
-        const {page, update, activeFilter} = this.props;
+        const { page, update, activeFilter } = this.props;
         if (page.mode.public) {
             return false;
         }
         const show = fullUpdateVisibility(update, activeFilter);
         if (!show) {
-            return false
+            return false;
         }
         if (this.props.periodLocked) {
-            return false
+            return false;
         }
         // M&E manager
         if (this.props.user.isMEManager) {
             // M&E manager can always edit updates
             return true;
-        // Project editor
+            // Project editor
         } else {
             // Can't edit other's updates
             if (this.props.user.id !== update.user) {
@@ -360,34 +351,60 @@ class UpdateHeader extends React.Component {
         }
     }
 
+    toggleCheckbox(e) {
+        e.stopPropagation();
+        const updateId = parseInt(e.target.id);
+        updateSelectToggle(updateId);
+    }
+
     render() {
-        let editUpdateButton;
-        const {updateFormDisplay, update} = this.props;
+        let editUpdateButton, selectUpdate;
+        const { updateFormDisplay, update, activeFilter } = this.props;
+        const isChecked = new Set(this.props[c.SELECTED_UPDATES]).has(update.id);
+
+        if (this.props.user.isMEManager && activeFilter == c.FILTER_SHOW_PENDING) {
+            selectUpdate = (
+                <span>
+                    <input
+                        id={update.id}
+                        type="checkbox"
+                        checked={isChecked ? "checked" : ""}
+                        onChange={this.toggleCheckbox}
+                    />
+                </span>
+            );
+        }
 
         if (this.showEditButton()) {
             let className;
             if (updateFormDisplay) {
-                className = 'btn btn-sm btn-default editingForm';
+                className = "btn btn-sm btn-default editingForm";
             } else {
-                className = 'btn btn-sm btn-default';
+                className = "btn btn-sm btn-default";
             }
-            editUpdateButton = <ToggleButton onClick={this.formToggle}
-                                             className={className}
-                                             label={_('edit')}
-                                             disabled={updateFormDisplay !== false}/>;
+            editUpdateButton = (
+                <ToggleButton
+                    onClick={this.formToggle}
+                    className={className}
+                    label={_("edit")}
+                    disabled={updateFormDisplay !== false}
+                />
+            );
         }
         return (
             <div className="UpdateHead">
-                <span className="updateName"><UserInfo user_details={update.user_details}/></span>
-                <span className="updateStatus">{_('update_statuses')[update.status]}</span>
+                {selectUpdate}
+                <span className="updateName">
+                    <UserInfo user_details={update.user_details} />
+                </span>
+                <span className="updateStatus">{_("update_statuses")[update.status]}</span>
                 <span>{editUpdateButton}</span>
             </div>
-        )
+        );
     }
 }
 
-
-@connect((store) => {
+@connect(store => {
     return {
         page: store.page,
         indicators: store.models.indicators,
@@ -400,14 +417,13 @@ class UpdateHeader extends React.Component {
         periodChildrenIds: getPeriodsChildrenIds(store),
         needReportingUpdates: getUpdatesForNeedReportingPeriods(store),
         pendingApprovalUpdates: getUpdatesForPendingApprovalPeriods(store),
-        approvedUpdates: getUpdatesForApprovedPeriods(store),
-    }
+        approvedUpdates: getUpdatesForApprovedPeriods(store)
+    };
 })
 export default class Updates extends React.Component {
-
     static propTypes = {
         indicatorId: PropTypes.number.isRequired,
-        period: PropTypes.object.isRequired,
+        period: PropTypes.object.isRequired
     };
 
     constructor(props) {
@@ -415,7 +431,7 @@ export default class Updates extends React.Component {
         this.collapseChange = this.collapseChange.bind(this);
         this.toggleAll = this.toggleAll.bind(this);
         this.hideMe = this.hideMe.bind(this);
-        this.state = {collapseId: collapseId(c.OBJECTS_UPDATES, this.props.period.id)};
+        this.state = { collapseId: collapseId(c.OBJECTS_UPDATES, this.props.period.id) };
     }
 
     activeKey() {
@@ -429,9 +445,9 @@ export default class Updates extends React.Component {
 
     toggleAll() {
         const keys = createToggleKeys(this.props.period.id, c.OBJECTS_UPDATES, this.activeKey());
-        keys.map((collapse) => {
+        keys.map(collapse => {
             collapseChange(collapse.collapseId, collapse.activeKey);
-        })
+        });
     }
 
     hideMe(id) {
@@ -440,16 +456,20 @@ export default class Updates extends React.Component {
 
     getUpdateIds() {
         let updateIds = this.props.periodChildrenIds[this.props.period.id] || [];
-        const {page} = this.props;
+        const { page } = this.props;
         const updates = this.props.updates.objects;
-        const needReporting = [c.UPDATE_STATUS_NEW, c.UPDATE_STATUS_DRAFT, c.UPDATE_STATUS_REVISION];
+        const needReporting = [
+            c.UPDATE_STATUS_NEW,
+            c.UPDATE_STATUS_DRAFT,
+            c.UPDATE_STATUS_REVISION
+        ];
         const pending = [c.UPDATE_STATUS_PENDING];
         const approved = [c.UPDATE_STATUS_APPROVED];
 
         if (page.mode && page.mode.public) {
             updateIds = [];
         } else {
-            switch(this.props.ui.activeFilter) {
+            switch (this.props.ui.activeFilter) {
                 case c.FILTER_NEED_REPORTING: {
                     updateIds = filterUpdatesByStatus(updates, updateIds, needReporting);
                     break;
@@ -470,63 +490,64 @@ export default class Updates extends React.Component {
 
     renderPanels(updateIds) {
         let actualValue = 0;
-        return (updateIds.map(
-            (id) => {
-                const {period, updatesDisaggregationIds, disaggregations, dimensions} = this.props;
-                const indicator = this.props.indicators.objects[this.props.indicatorId];
-                const update = this.props.updates.objects[id];
-                // Calculate running total of numeric update values
-                const value = parseInt(update.value);
-                if (value && update.status == c.UPDATE_STATUS_APPROVED) {
-                    actualValue += value;
+        return updateIds.map(id => {
+            const { period, updatesDisaggregationIds, disaggregations, dimensions } = this.props;
+            const indicator = this.props.indicators.objects[this.props.indicatorId];
+            const update = this.props.updates.objects[id];
+            // Calculate running total of numeric update values
+            const value = parseInt(update.value);
+            if (value && update.status == c.UPDATE_STATUS_APPROVED) {
+                actualValue += value;
+            }
+            update.actual_value = actualValue;
+            switch (indicator.type) {
+                case c.INDICATOR_QUANTATIVE: {
+                    return (
+                        <QuantitativeUpdate
+                            key={id}
+                            id={id}
+                            update={update}
+                            disaggregationIds={updatesDisaggregationIds[id]}
+                            disaggregations={disaggregations}
+                            dimensions={dimensions}
+                            periodLocked={this.props.period.locked}
+                            collapseId={this.state.collapseId}
+                        />
+                    );
                 }
-                update.actual_value = actualValue;
-                switch(indicator.type) {
-                    case c.INDICATOR_QUANTATIVE: {
-                        return <QuantitativeUpdate key={id}
-                                                   id={id}
-                                                   update={update}
-                                                   disaggregationIds={updatesDisaggregationIds[id]}
-                                                   disaggregations={disaggregations}
-                                                   dimensions={dimensions}
-                                                   periodLocked={this.props.period.locked}
-                                                   collapseId={this.state.collapseId}/>
-                    }
-                    case c.INDICATOR_QUALITATIVE: {
-                        return <QualitativeUpdate key={id}
-                                                  id={id}
-                                                  update={update}
-                                                  period={period}
-                                                  collapseId={this.state.collapseId}/>
-                    }
+                case c.INDICATOR_QUALITATIVE: {
+                    return (
+                        <QualitativeUpdate
+                            key={id}
+                            id={id}
+                            update={update}
+                            period={period}
+                            collapseId={this.state.collapseId}
+                        />
+                    );
                 }
             }
-        ))
+        });
     }
 
     render() {
         let updateIds = this.getUpdateIds();
-        const {page} = this.props;
+        const { page } = this.props;
 
         // const toggleKey = createToggleKey(ids, this.activeKey());
         if (!this.props.updates.fetched) {
             return (
-                <p className="loading">Loading <i className="fa fa-spin fa-spinner" /></p>
+                <p className="loading">
+                    Loading <i className="fa fa-spin fa-spinner" />
+                </p>
             );
         } else if (updateIds.length > 0) {
-            return (
-                <div className={c.OBJECTS_UPDATES}>
-                    {this.renderPanels(updateIds)}
-                </div>
-            );
+            return <div className={c.OBJECTS_UPDATES}>{this.renderPanels(updateIds)}</div>;
         } else {
-            return (
-                page.mode && page.mode.public ?
-                    null
-                :
-                    <div className="emptyData">
-                        <p>No updates</p>
-                    </div>
+            return page.mode && page.mode.public ? null : (
+                <div className="emptyData">
+                    <p>No updates</p>
+                </div>
             );
         }
     }

--- a/akvo/rsr/static/scripts-src/my-results/const.js
+++ b/akvo/rsr/static/scripts-src/my-results/const.js
@@ -104,6 +104,7 @@ export const
 
     // UI state
     SELECTED_PERIODS = 'selectedPeriods',
+    SELECTED_UPDATES = 'selectedUpdates',
     UPDATE_FORMS = 'updateForms',
     UPDATE_FORM_DISPLAY = 'updateFormDisplay', // boolean, keeping track if the update form is open
     REPORT_FORM_DISPLAY = 'reportFormDisplay', // boolean, keeping track if the narrative report form is open

--- a/akvo/rsr/static/scripts-src/my-results/reducers/uiReducer.js
+++ b/akvo/rsr/static/scripts-src/my-results/reducers/uiReducer.js
@@ -21,11 +21,10 @@
         updateFormDisplay: Boolean determining the visibility of the update form
  */
 
-import update from 'immutability-helper';
+import update from "immutability-helper";
 
-import * as c from "../const"
-import {distinct} from "../utils";
-
+import * as c from "../const";
+import { distinct } from "../utils";
 
 const uiState = {
     allFetched: false, // allFetched becomes true when all models have been fetched from the backend
@@ -35,97 +34,98 @@ const uiState = {
     activeFilter: undefined, //indicates if a filter is currently in force
     visibleKeys: undefined,
     [c.SELECTED_PERIODS]: [], //list of periods that are currently checked, used for bulk actions
-    [c.UPDATE_FORM_DISPLAY]: false, // keeping track if the indicator update form is open
-    [c.REPORT_FORM_DISPLAY]: false, // keeping track if the narrative report form is open
+    [c.SELECTED_UPDATES]: [], //list of updates that are currently checked, used for bulk actions
+    [c.UPDATE_FORM_DISPLAY]: false, //list of currently open indicator update forms
+    [c.REPORT_FORM_DISPLAY]: false // keeping track if the narrative report form is open
 };
 
-export default function uiReducer(state=uiState, action) {
-    switch(action.type) {
-
+export default function uiReducer(state = uiState, action) {
+    switch (action.type) {
         case c.UI_ID_RESET: {
-            const {element} = action.payload;
-            return {...state, [element]: []};
+            const { element } = action.payload;
+            return { ...state, [element]: [] };
         }
 
         case c.UI_ID_TOGGLE: {
-            const {element, id} = action.payload;
+            const { element, id } = action.payload;
             // Make a set of the state[element] array
             let newState = new Set(state[element]);
             if (newState.has(id)) {
-                newState.delete(id)
+                newState.delete(id);
             } else {
-                newState.add(id)
+                newState.add(id);
             }
             // Put back the values as an array.
-            return {...state, [element]: [...newState]};
+            return { ...state, [element]: [...newState] };
         }
 
         case c.UI_ID_TRUE: {
-            const {element, id} = action.payload;
-            return {...state, [element]: [...new Set(state[element]).add(id)]};
+            const { element, id } = action.payload;
+            return { ...state, [element]: [...new Set(state[element]).add(id)] };
         }
 
         case c.UI_ID_FALSE: {
-            const {element, id} = action.payload;
+            const { element, id } = action.payload;
             //Set.delete() doesn't return the modified set, se we have to create the set and only
             // then call delete(). BAH!
             const elementSet = new Set(state[element]);
             elementSet.delete(id);
-            return {...state, [element]: [...elementSet]};
+            return { ...state, [element]: [...elementSet] };
         }
 
         case c.UI_FLAG_TOGGLE: {
-            const {element, id} = action.payload;
-            return state[element] ?
-                {...state, [element]: false}
-            :
-                {...state, [element]: id};
+            const { element, id } = action.payload;
+            return state[element] ? { ...state, [element]: false } : { ...state, [element]: id };
         }
 
         case c.UI_FLAG_TRUE: {
-            const {element, id} = action.payload;
-            return {...state, [element]: id};
+            const { element, id } = action.payload;
+            return { ...state, [element]: id };
         }
 
         case c.UI_FLAG_FALSE: {
-            const {element} = action.payload;
-            return {...state, [element]: false};
+            const { element } = action.payload;
+            return { ...state, [element]: false };
         }
 
         case c.UI_HIDE: {
-            const {mode} = action.payload;
-            return {...state, hide: mode};
+            const { mode } = action.payload;
+            return { ...state, hide: mode };
         }
 
         case c.ALL_MODELS_FETCHED: {
-            return {...state, allFetched: true};
+            return { ...state, allFetched: true };
         }
 
         case c.SET_PERIOD_DATES: {
-            return {...state, periodDates: action.payload};
+            return { ...state, periodDates: action.payload };
         }
 
         case c.UI_FILTER_BUTTON_ACTIVE: {
-            const {button} = action.payload;
-            return {...state, activeFilter: button};
+            const { button } = action.payload;
+            return { ...state, activeFilter: button };
         }
 
         case c.KEYS_COPY_TO_VISIBLE: {
-            const {keys} = action.payload;
-            return {...state, visibleKeys: keys};
+            const { keys } = action.payload;
+            return { ...state, visibleKeys: keys };
         }
 
         case c.UPDATE_MODEL_FULFILLED: {
-            const {collapseId, object} = action.payload;
+            const { collapseId, object } = action.payload;
             // if collapseId isn't supplied we don't have to update keys
             const visibleKeys = state.visibleKeys;
             if (collapseId && visibleKeys) {
                 const key = object.id.toString();
                 if (visibleKeys[collapseId]) {
-                    const newVisibleKeys = distinct(update(visibleKeys[collapseId], {$push: [key]}));
-                    return update(state, {visibleKeys: {$merge: {[collapseId]: newVisibleKeys}}});
+                    const newVisibleKeys = distinct(
+                        update(visibleKeys[collapseId], { $push: [key] })
+                    );
+                    return update(state, {
+                        visibleKeys: { $merge: { [collapseId]: newVisibleKeys } }
+                    });
                 } else {
-                    return update(state, {visibleKeys: {$merge: {[collapseId]: [key]}}});
+                    return update(state, { visibleKeys: { $merge: { [collapseId]: [key] } } });
                 }
             }
             return state;
@@ -133,12 +133,11 @@ export default function uiReducer(state=uiState, action) {
 
         case c.UPDATE_MODEL_DELETE_FULFILLED: {
             // make sure the update form is closed when the update is deleted
-            const {model} = action.payload;
+            const { model } = action.payload;
             if (model === c.OBJECTS_UPDATES) {
-                return {...state, [c.UPDATE_FORM_DISPLAY]: false};
+                return { ...state, [c.UPDATE_FORM_DISPLAY]: false };
             }
         }
-
     }
     return state;
 }

--- a/akvo/rsr/static/scripts-src/my-results/utils.js
+++ b/akvo/rsr/static/scripts-src/my-results/utils.js
@@ -5,42 +5,40 @@
     < http://www.gnu.org/licenses/agpl.html >.
  */
 
-import React from 'react';
+import React from "react";
 
-import * as c from "./const"
-import store from "./store"
+import * as c from "./const";
+import store from "./store";
 
-import {collapseChange, collapseRecordState, resetKeys,} from "./actions/collapse-actions";
+import { collapseChange, collapseRecordState, resetKeys } from "./actions/collapse-actions";
 
-import {updateModel} from "./actions/model-actions";
-import keyBy from 'lodash/keyBy';
-import update from 'immutability-helper';
-
+import { updateModel } from "./actions/model-actions";
+import keyBy from "lodash/keyBy";
+import update from "immutability-helper";
 
 // Note: this function used to be a method of the App class, but the the transpiling messes something
 // up the result being the the update function from immuatbility-helper can't be found/called
 export function createNewDisaggregations(update_id, dimensions, disaggregations) {
-    const dimension_disaggregations = keyBy(disaggregations, 'dimension');
+    const dimension_disaggregations = keyBy(disaggregations, "dimension");
     let changedDisaggregations = disaggregations;
-    dimensions.forEach((dimension) => {
+    dimensions.forEach(dimension => {
         if (dimension_disaggregations[dimension.id] === undefined) {
             const disaggregation = {
-                'update': update_id,
-                'dimension': dimension.id,
-                'id': 'new-' + dimension.id,
-                'value': '',
-                'numerator': '',
-                'denominator': '',
-                'narrative': '',
+                update: update_id,
+                dimension: dimension.id,
+                id: "new-" + dimension.id,
+                value: "",
+                numerator: "",
+                denominator: "",
+                narrative: ""
             };
-            changedDisaggregations = update(changedDisaggregations, {$push: [disaggregation]});
+            changedDisaggregations = update(changedDisaggregations, { $push: [disaggregation] });
             /* disaggregations.push(disaggregation)*/
-            updateModel('disaggregations', disaggregation);
+            updateModel("disaggregations", disaggregation);
         }
     });
     return changedDisaggregations;
 }
-
 
 export function distinct(arr) {
     //return an array of uniques values
@@ -51,20 +49,18 @@ export function identicalArrays(array1, array2) {
     // Compare two arrays and return true if they are identical, otherwise false
     try {
         return (
-            (array1.length == array2.length) &&
-            array1.every((element, index) => (element === array2[index]))
-        )
+            array1.length == array2.length &&
+            array1.every((element, index) => element === array2[index])
+        );
     } catch (e) {
         return false;
     }
 }
 
-
 // From https://stackoverflow.com/questions/4994201/is-object-empty
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 export function isEmpty(obj) {
-
     // null and undefined are "empty"
     if (obj == null) return true;
 
@@ -88,12 +84,10 @@ export function isEmpty(obj) {
     return true;
 }
 
-
 // From https://stackoverflow.com/questions/18082/validate-decimal-numbers-in-javascript-isnumeric/1830844#1830844
 export function isNumeric(n) {
     return !isNaN(parseFloat(n)) && isFinite(n);
 }
-
 
 // global holding the month's translation strings
 let months;
@@ -102,7 +96,7 @@ export function displayDate(dateString) {
     // Display a dateString like "25 Jan 2016"
     // read from the DOM once
     if (!months) {
-        months = JSON.parse(document.getElementById('i18nMonths').innerHTML);
+        months = JSON.parse(document.getElementById("i18nMonths").innerHTML);
     }
     if (dateString) {
         const locale = "en-gb";
@@ -115,14 +109,13 @@ export function displayDate(dateString) {
     return "Unknown date";
 }
 
-
 export function getCookie(name) {
     var cookieValue = null;
-    if (document.cookie && document.cookie !== '') {
-        var cookies = document.cookie.split(';');
+    if (document.cookie && document.cookie !== "") {
+        var cookies = document.cookie.split(";");
         for (var i = 0; i < cookies.length; i++) {
             var cookie = cookies[i].trim();
-            if (cookie.substring(0, name.length + 1) == (name + '=')) {
+            if (cookie.substring(0, name.length + 1) == name + "=") {
                 cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
                 break;
             }
@@ -131,50 +124,52 @@ export function getCookie(name) {
     return cookieValue;
 }
 
-
 // Object holds callback URL functions as values, most of them called with an id parameter
 // Usage: endpoints.result(17) -> "http://rsr.akvo.org/rest/v1/result/17/?format=json"
 export const endpoints = {
-    "result": (id) => `/rest/v1/result/${id}/?format=json`,
-    "results": (id) => `/rest/v1/result/?format=json&limit=${c.API_LIMIT}&project=${id}`,
-    "indicators": (id) =>
-        `/rest/v1/indicator/?format=json&limit=${c.API_LIMIT}&result__project=${id}`,
-    "dimensions": (id) =>
+    result: id => `/rest/v1/result/${id}/?format=json`,
+    results: id => `/rest/v1/result/?format=json&limit=${c.API_LIMIT}&project=${id}`,
+    indicators: id => `/rest/v1/indicator/?format=json&limit=${c.API_LIMIT}&result__project=${id}`,
+    dimensions: id =>
         `/rest/v1/indicator_dimension/?format=json&limit=${c.API_LIMIT}&result__project=${id}`,
-    "periods": (id) =>
-        `/rest/v1/indicator_period/?format=json&limit=${c.API_LIMIT}&indicator__result__project=${id}`,
-    "updates": (id) =>
-        `/rest/v1/indicator_period_data/?format=json&limit=${c.API_LIMIT}&period__indicator__result__project=${id}`,
-    "disaggregations": (id) =>
-        `/rest/v1/disaggregation/?format=json&limit=${c.API_LIMIT}&update__period__indicator__result__project=${id}`,
-    "comments": (id) =>
-        `/rest/v1/indicator_period_data_comment/?format=json&limit=${c.API_LIMIT}&data__period__indicator__result__project=${id}`,
-    "reports": (id) =>
-        `/rest/v1/narrative_report/?format=json&limit=${c.API_LIMIT}&project=${id}`,
-    "update_report": (id) =>
-        `/rest/v1/narrative_report/${id}/?format=json`,
-    "save_report": (id) =>
-        `/rest/v1/narrative_report/?format=json`,
-    "categories": (id) =>
-        `/rest/v1/organisation_indicator_label/?format=json&limit=${c.API_LIMIT}&filter={'organisation__in':[${id}]}`,
-    "post_comment": () =>
-        "/rest/v1/indicator_period_data_comment/?format=json",
-    "period": (id) => `/rest/v1/indicator_period/${id}/?format=json`,
-    "update_and_comments": (id) => `/rest/v1/indicator_period_data_framework/${id}/?format=json`,
-    "updates_and_comments": () =>
+    periods: id =>
+        `/rest/v1/indicator_period/?format=json&limit=${
+            c.API_LIMIT
+        }&indicator__result__project=${id}`,
+    updates: id =>
+        `/rest/v1/indicator_period_data/?format=json&limit=${
+            c.API_LIMIT
+        }&period__indicator__result__project=${id}`,
+    disaggregations: id =>
+        `/rest/v1/disaggregation/?format=json&limit=${
+            c.API_LIMIT
+        }&update__period__indicator__result__project=${id}`,
+    comments: id =>
+        `/rest/v1/indicator_period_data_comment/?format=json&limit=${
+            c.API_LIMIT
+        }&data__period__indicator__result__project=${id}`,
+    reports: id => `/rest/v1/narrative_report/?format=json&limit=${c.API_LIMIT}&project=${id}`,
+    update_report: id => `/rest/v1/narrative_report/${id}/?format=json`,
+    save_report: id => `/rest/v1/narrative_report/?format=json`,
+    categories: id =>
+        `/rest/v1/organisation_indicator_label/?format=json&limit=${
+            c.API_LIMIT
+        }&filter={'organisation__in':[${id}]}`,
+    post_comment: () => "/rest/v1/indicator_period_data_comment/?format=json",
+    period: id => `/rest/v1/indicator_period/${id}/?format=json`,
+    update_and_comments: id => `/rest/v1/indicator_period_data_framework/${id}/?format=json`,
+    updates_and_comments: () =>
         `/rest/v1/indicator_period_data_framework/?format=json&limit=${c.API_LIMIT}`,
-    "user": (id) => `/rest/v1/user/${id}/?format=json`,
-    "partnerships": (id) => `/rest/v1/partnership/?format=json&limit=${c.API_LIMIT}&project=${id}`,
-    "file_upload": (id) => `/rest/v1/indicator_period_data/${id}/upload_file/?format=json`
+    user: id => `/rest/v1/user/${id}/?format=json`,
+    partnerships: id => `/rest/v1/partnership/?format=json&limit=${c.API_LIMIT}&project=${id}`,
+    file_upload: id => `/rest/v1/indicator_period_data/${id}/upload_file/?format=json`
 };
-
 
 // Translation a la python. Let's hope we never need lodash...
 export function _(s) {
     const strings = store.getState().page.strings;
     return strings && strings[s];
 }
-
 
 export const findChildren = (parentId, childModel) => {
     //TODO: remove when _meta.children is fully used
@@ -183,17 +178,16 @@ export const findChildren = (parentId, childModel) => {
     const parentField = c.PARENT_FIELD[childModel];
     const model = store.getState().models[childModel];
     if (model && model.ids) {
-        const {ids, objects} = model;
+        const { ids, objects } = model;
         const filteredIds = ids.filter(
             // if parentField is undefined return all ids (This applies to Result)
-            id => parentField ? objects[id][parentField] === parentId : true
+            id => (parentField ? objects[id][parentField] === parentId : true)
         );
         const filteredObjects = filteredIds.map(id => objects[id]);
-        return {ids: filteredIds, [childModel]: filteredObjects}
+        return { ids: filteredIds, [childModel]: filteredObjects };
     }
-    return {ids: [], [childModel]: undefined};
+    return { ids: [], [childModel]: undefined };
 };
-
 
 export const findChildrenFromCurrentState = (modelsState, parentId, childModel) => {
     // Filter childModel based on equality of FK field (parentField) with parent id (props.parentId)
@@ -201,52 +195,45 @@ export const findChildrenFromCurrentState = (modelsState, parentId, childModel) 
     const parentField = c.PARENT_FIELD[childModel];
     const model = modelsState[childModel];
     if (model && model.ids) {
-        const {ids, objects} = model;
+        const { ids, objects } = model;
         const filteredIds = ids.filter(
             // if parentField is undefined return all ids (This applies to Result)
-            id => parentField ? objects[id][parentField] === parentId : true
+            id => (parentField ? objects[id][parentField] === parentId : true)
         );
-        const filteredObjects = filteredIds.reduce(
-            (acc, id) => {
-                acc[id] = objects[id];
-                return acc;
-            }, {}
-        );
-        return {ids: filteredIds, objects: filteredObjects}
+        const filteredObjects = filteredIds.reduce((acc, id) => {
+            acc[id] = objects[id];
+            return acc;
+        }, {});
+        return { ids: filteredIds, objects: filteredObjects };
     }
-    return {ids: [], objects: undefined};
+    return { ids: [], objects: undefined };
 };
-
 
 export function idsToActiveKey(ids) {
     // Return the IDs as an array of strings, used as activeKey
     return distinct(ids).map(id => id.toString());
 }
 
-
 export function createToggleKey(ids, activeKey) {
     // Create an activeKey array for a Collapse element with either all panels open or none
     // uses the IDs of the panels derived from the relevant model IDs
-    const allOpen = (ids && ids.length > 0) && idsToActiveKey(ids);
+    const allOpen = ids && ids.length > 0 && idsToActiveKey(ids);
     // If allOpen is identical to activeKey, all panels are already open and we close them
     return identicalArrays(activeKey, allOpen) ? [] : allOpen;
 }
 
-
 // Newly created updates get the id 'new-<N>' where N is an int starting at 1
 export const isNewUpdate = updateOrId => {
-    if (typeof updateOrId === 'object') {
-        return updateOrId.id.toString().substr(0, 4) === 'new-';
+    if (typeof updateOrId === "object") {
+        return updateOrId.id.toString().substr(0, 4) === "new-";
     }
-    return updateOrId.toString().substr(0, 4) === 'new-';
+    return updateOrId.toString().substr(0, 4) === "new-";
 };
-
 
 export function collapseId(model, id) {
     // The collapseId is created from the model name and the ID of the parent object of the Collapse
     return `${model}-${id}`;
 }
-
 
 export function childModelName(model) {
     try {
@@ -256,7 +243,6 @@ export function childModelName(model) {
     }
 }
 
-
 export function parentModelName(model) {
     try {
         return c.MODELS_LIST[c.MODELS_LIST.indexOf(model) - 1];
@@ -265,16 +251,13 @@ export function parentModelName(model) {
     }
 }
 
-
 export function levelAbove(model, compare) {
     return c.MODEL_INDEX[model] < c.MODEL_INDEX[compare];
 }
 
-
 export function levelBelow(model, compare) {
     return c.MODEL_INDEX[model] > c.MODEL_INDEX[compare];
 }
-
 
 export function hideMe(model, parentId, objectId) {
     /*
@@ -289,13 +272,12 @@ export function hideMe(model, parentId, objectId) {
         // otherwise, find the parent collapse, check that it's in ui.visibleKeys
         const parentCollapse = ui.visibleKeys[collapseId(model, parentId)];
         // if we have a parent, check if I'm one of the open panels
-        const mePresent = parentCollapse && parentCollapse.find((id) => id === String(objectId));
+        const mePresent = parentCollapse && parentCollapse.find(id => id === String(objectId));
         // hide me if I'm not present and this.props.ui.hide is not false
         return !mePresent;
     }
     return false;
 }
-
 
 export function fullUpdateVisibility(update, activeFilter) {
     // determine if an update should be "dimmed" indicating it is shown in a filter where it's not
@@ -323,62 +305,48 @@ export function fullUpdateVisibility(update, activeFilter) {
     return visible.indexOf(update.status) > -1;
 }
 
-
 function tree(model, parentId) {
     // Construct a tree representation of the subtree of data with object model[parentId] as root
     //TODO: refactor, we shouldn't need findChildren here
     const ids = findChildren(parentId, model).ids;
     const childModel = childModelName(model);
-    const children = ids.map((cId) => {
-        return tree(childModel, cId)
+    const children = ids.map(cId => {
+        return tree(childModel, cId);
     });
     if (children.length > 0) {
-        return {id: parentId, model: model, children: children}
+        return { id: parentId, model: model, children: children };
     } else {
-        return {id: parentId}
+        return { id: parentId };
     }
 }
 
-
 export function flatten(arr) {
     // Flatten an array of arrays
-    return arr.reduce(
-        (acc, val) => acc.concat(
-            Array.isArray(val) ? flatten(val) : val),
-        []
-    );
+    return arr.reduce((acc, val) => acc.concat(Array.isArray(val) ? flatten(val) : val), []);
 }
-
 
 function keysList(node, open, MEManagerKeys) {
     // "Disassemble" the tree representation of the data from tree() and return a list of objects.
     // Each object holds the collapseID of the corresponding Collapse and its activeKey
     const key = {
         collapseId: collapseId(node.model, node.id),
-        activeKey: open ?
-            idsToActiveKey(node.children.map(child => child.id.toString()))
-        :
-            MEManagerKeys || [],
+        activeKey: open
+            ? idsToActiveKey(node.children.map(child => child.id.toString()))
+            : MEManagerKeys || []
     };
-    const children = node.children.filter((child) =>
-        child.model !== undefined
-    );
-    const childKeys = children.map((node) =>
-        keysList(node, open)
-    );
+    const children = node.children.filter(child => child.model !== undefined);
+    const childKeys = children.map(node => keysList(node, open));
     return flatten([key].concat(childKeys));
 }
-
 
 export function toggleTree(model, id, open, MEManagerKeys) {
     const fullTree = tree(model, id);
     return keysList(fullTree, open, MEManagerKeys);
 }
 
-
 export function openResults(activeKey, isMEManager) {
     if (isMEManager) {
-        return isMEManagerDefaultKeys(activeKey)
+        return isMEManagerDefaultKeys(activeKey);
     } else {
         return activeKey == undefined || activeKey.length == 0;
     }
@@ -395,7 +363,6 @@ export function createToggleKeys(parentId, model, activeKey) {
     return toggleTree(model, parentId, open);
 }
 
-
 function lineage(model, id) {
     // return the model and ID of me and my ancestors all the way up to results
     const parentModel = parentModelName(model);
@@ -403,12 +370,11 @@ function lineage(model, id) {
         const storeModel = store.getState().models[model];
         if (storeModel.objects) {
             const parentId = storeModel.objects[id][c.PARENT_FIELD[model]];
-            return [{model, id}].concat(lineage(parentModel, parentId));
+            return [{ model, id }].concat(lineage(parentModel, parentId));
         }
     }
-    return [{model, id}];
+    return [{ model, id }];
 }
-
 
 export function getAncestor(model, id, ancestorModel) {
     // return the specified ancestor object for an object given the ancestorModel
@@ -423,21 +389,16 @@ export function getAncestor(model, id, ancestorModel) {
     return store.getState().models[model].objects[id];
 }
 
-
 function lineageKeys(model, id) {
     // construct collapse activeKey keys for me and all my ancestors so I will be visible
     const reversedLineage = lineage(model, id).reverse();
     let parentId = c.OBJECTS_RESULTS;
-    return reversedLineage.reduce(
-        (keys, obj) => {
-            const key = keys.concat({[collapseId(obj.model, parentId)]: [obj.id]});
-            parentId = obj.id;
-            return key;
-        },
-        []
-    )
+    return reversedLineage.reduce((keys, obj) => {
+        const key = keys.concat({ [collapseId(obj.model, parentId)]: [obj.id] });
+        parentId = obj.id;
+        return key;
+    }, []);
 }
-
 
 export function closeNodes(model, ids) {
     // Closes nodes with the given ids
@@ -448,93 +409,76 @@ export function closeNodes(model, ids) {
 
     const storeModel = store.getState().models[model];
     // Construct a list of collapse keys, based on ids
-    const collapseIds = ids.map((id) => {
-        const parent_id = parentModelName(model) ?
-            storeModel.objects[id][c.PARENT_FIELD[model]]
-        :
-            model;
+    const collapseIds = ids.map(id => {
+        const parent_id = parentModelName(model)
+            ? storeModel.objects[id][c.PARENT_FIELD[model]]
+            : model;
         return collapseId(model, parent_id);
     });
     // Collapse/close all children of the collected collapse keys
-    distinct(collapseIds).map((id) => collapseChange(id, []));
+    distinct(collapseIds).map(id => collapseChange(id, []));
 }
-
 
 export function openNodes(model, ids) {
     // construct collapse keys that represent the open state of all nodes in ids list of type model
     // and all required parents. If the reset boolean is true then first reset the whole tree.
 
     // get lineages of all objects based on model and ids
-    const lineages = ids.map((id) => lineageKeys(model, id));
+    const lineages = ids.map(id => lineageKeys(model, id));
     // flatten to get an array of objects: [{collapseId: id}, ...]
     const individualKeys = flatten(lineages);
 
-    const mergedKeys = individualKeys.reduce(
-        (keys, key) => {
-            const keyName = Object.keys(key)[0];
-            return Object.assign(keys, {[keyName]: (keys[keyName] || []).concat(key[keyName])});
-        },
-        {}
-    );
+    const mergedKeys = individualKeys.reduce((keys, key) => {
+        const keyName = Object.keys(key)[0];
+        return Object.assign(keys, { [keyName]: (keys[keyName] || []).concat(key[keyName]) });
+    }, {});
     resetKeys();
-    Object.keys(mergedKeys).map((key) => {
+    Object.keys(mergedKeys).map(key => {
         collapseChange(key, idsToActiveKey(mergedKeys[key]));
     });
     collapseRecordState();
 }
-
 
 export function fieldValueOrSpinner(obj, field) {
     /*
         If obj is defined return obj[field] otherwise return the spinner icon
      */
     if (obj) {
-        return {value: obj[field]};
+        return { value: obj[field] };
     } else {
-        return {icon: <i className="fa fa-spin fa-spinner"/>};
+        return { icon: <i className="fa fa-spin fa-spinner" /> };
     }
 }
-
 
 export function setHash(hash) {
     if (hash) {
         window.location.hash = `#${hash}`;
     } else {
-        window.location.hash = '';
+        window.location.hash = "";
     }
 }
 
-
 export function userIsMEManager(user) {
-    return user.fetched ?
-        user.objects[user.ids[0]].isMEManager
-    :
-        false;
+    return user.fetched ? user.objects[user.ids[0]].isMEManager : false;
 }
-
 
 export function computePercentage(numerator, denominator) {
     numerator = parseFloat(numerator) || 0;
     denominator = parseFloat(denominator) || 0;
     if (denominator != 0) {
-        return Math.round10((numerator * 100) / denominator, -2);
+        return Math.round10(numerator * 100 / denominator, -2);
     } else {
         return 0;
     }
 }
 
-
 export const filterUpdatesByStatus = (updates, ids, status) => {
-    return ids.filter(
-        id => status.indexOf(updates[id].status) > -1
-    )
+    return ids.filter(id => status.indexOf(updates[id].status) > -1);
 };
 
-
-export const isResultsKey = (key) => {
+export const isResultsKey = key => {
     return c.MODELS_LIST.some(model => key.startsWith(model));
 };
-
 
 export const disaggregationsToDisplayData = (disaggregationIds, disaggregations, dimensions) => {
     /*  maps a number of disaggregations to the following format:
@@ -553,29 +497,55 @@ export const disaggregationsToDisplayData = (disaggregationIds, disaggregations,
         see https://github.com/kolodny/immutability-helper#autovivification for some insight
         into the use uf update() below
     */
-    return disaggregationIds && disaggregationIds.reduce((acc, id) => {
-        const disaggregation = disaggregations[id];
-        const dimension = dimensions[disaggregation.dimension];
-        return update(acc, {
+    return (
+        disaggregationIds &&
+        disaggregationIds.reduce((acc, id) => {
+            const disaggregation = disaggregations[id];
+            const dimension = dimensions[disaggregation.dimension];
+            return update(acc, {
                 [dimension.name]: {
                     $apply: value =>
                         update(value || {}, {
-                            [dimension.value]:
-                                {
-                                    $apply: disagg =>
-                                        (disagg || 0) + parseInt(disaggregation.value)
-                                }
+                            [dimension.value]: {
+                                $apply: disagg => (disagg || 0) + parseInt(disaggregation.value)
+                            }
                         })
                 }
-            }
-        )
-    }, {})
+            });
+        }, {})
+    );
 };
 
+export const pruneUpdateForPATCH = update => {
+    // Only include the listed fields when PATCHing an update
+    // currently the list mimics the old MyResults data
+    const fields = [
+        "value",
+        "narrative",
+        "numerator",
+        "denominator",
+        "text",
+        "status",
+        "_file",
+        "_photo",
+        "approved_by",
+        "disaggregations"
+    ];
+    return fields.reduce((acc, f) => {
+        return Object.assign(acc, { [f]: update[f] });
+    }, {});
+};
+
+export const pruneUpdateForPOST = update => {
+    // Delete the listed fields when POSTing an update
+    let updateForPOST = Object.assign({}, update);
+    delete updateForPOST["user_details"];
+    return updateForPOST;
+};
 
 // Decimal rounding function (from MDN)
 // https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Math/round
-(function () {
+(function() {
     /**
      * Decimal adjustment of a number.
      *
@@ -586,13 +556,13 @@ export const disaggregationsToDisplayData = (disaggregationIds, disaggregations,
      */
     function decimalAdjust(type, value, exp) {
         // If the exp is undefined or zero...
-        if (typeof exp === 'undefined' || +exp === 0) {
+        if (typeof exp === "undefined" || +exp === 0) {
             return Math[type](value);
         }
         value = +value;
         exp = +exp;
         // If the value is not a number or the exp is not an integer...
-        if (isNaN(value) || !(typeof exp === 'number' && exp % 1 === 0)) {
+        if (isNaN(value) || !(typeof exp === "number" && exp % 1 === 0)) {
             return NaN;
         }
         // If the value is negative...
@@ -600,17 +570,17 @@ export const disaggregationsToDisplayData = (disaggregationIds, disaggregations,
             return -decimalAdjust(type, -value, exp);
         }
         // Shift
-        value = value.toString().split('e');
-        value = Math[type](+(value[0] + 'e' + (value[1] ? (+value[1] - exp) : -exp)));
+        value = value.toString().split("e");
+        value = Math[type](+(value[0] + "e" + (value[1] ? +value[1] - exp : -exp)));
         // Shift back
-        value = value.toString().split('e');
-        return +(value[0] + 'e' + (value[1] ? (+value[1] + exp) : exp));
+        value = value.toString().split("e");
+        return +(value[0] + "e" + (value[1] ? +value[1] + exp : exp));
     }
 
     // Decimal round
     if (!Math.round10) {
-        Math.round10 = function (value, exp) {
-            return decimalAdjust('round', value, exp);
+        Math.round10 = function(value, exp) {
+            return decimalAdjust("round", value, exp);
         };
     }
 })();

--- a/akvo/templates/results_base.html
+++ b/akvo/templates/results_base.html
@@ -144,6 +144,7 @@
         "lock_selected": "{% trans "Lock selected"|escapejs %}",
         "unlock_selected": "{% trans "Unlock selected"|escapejs %}",
         "filter_periods": "{% trans "Filter periods"|escapejs %}",
+        "approve_updates": "{% trans "Approve updates"|escapejs %}",
         "indicator_reporting": "{% trans "Indicator reporting"|escapejs %}",
         "comment_not_saved": "{% trans "Couldn't save comment, please try again"|escapejs %}",
         "enter_comment": "{% trans "Please enter a comment text"|escapejs %}",


### PR DESCRIPTION
Closes #2940

The bulk approve button is shown next to the lock and unlock buttons, but only in the pending approval view. 

Periods get a selection checkbox similar to indicators, to help select multiple periods at once. 

Uses the same `patchMultiple` mechanism as lock and unlock, so that the error handling can be re-used.  Error handling for all these actions needs to be improved. 

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
