### PR TITLE
[#2965] Exclude qualitative indicators from that IATI export

### DIFF
--- a/akvo/iati/exports/elements/result.py
+++ b/akvo/iati/exports/elements/result.py
@@ -6,6 +6,8 @@
 
 from lxml import etree
 
+from akvo.rsr.models.result.utils import QUANTITATIVE
+
 
 def result(project):
     """
@@ -37,7 +39,7 @@ def result(project):
                 narrative_element = etree.SubElement(description_element, "narrative")
                 narrative_element.text = res.description
 
-            for indicator in res.indicators.all():
+            for indicator in res.indicators.filter(type=QUANTITATIVE):
                 if indicator.measure or indicator.ascending is not None or indicator.title or \
                         indicator.description or indicator.references.all() or \
                         indicator.baseline_year or indicator.baseline_value or \

--- a/akvo/rsr/tests/iati_export/test_iati_export.py
+++ b/akvo/rsr/tests/iati_export/test_iati_export.py
@@ -18,6 +18,7 @@ from akvo.rsr.models import (IatiExport, Organisation, Partnership, Project, Use
                              IndicatorPeriodActualDimension, IndicatorPeriodActualLocation,
                              IndicatorPeriodTargetDimension, IndicatorPeriodTargetLocation,
                              IndicatorReference)
+from akvo.rsr.models.result.utils import QUALITATIVE
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
@@ -410,6 +411,13 @@ class IatiExportTestCase(TestCase, XmlTestMixin):
             baseline_value="1",
             baseline_comment="Comment"
         )
+        # Create a qualitative indicator
+        Indicator.objects.create(
+            result=result,
+            title="Qualitative indicator",
+            description="Indicator Description",
+            type=QUALITATIVE,
+        )
         IndicatorReference.objects.create(
             indicator=indicator,
             vocabulary="1",
@@ -494,6 +502,9 @@ class IatiExportTestCase(TestCase, XmlTestMixin):
         self.assertXpathsExist(root_test, (indicator_description_xpath,))
         indicators = root_test.xpath(indicator_description_xpath)
         self.assertEqual(indicators[0].text, 'Indicator Description')
+
+        # Test qualitative indicator is not included
+        self.assertEqual(1, len(indicators))
 
     def test_different_complete_project_export(self):
         """


### PR DESCRIPTION
Closes #2965


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

```markdown
Exclude data from qualitative indicators from IATI export files [#2965](https://github.com/akvo/akvo-rsr/issues/2965)
```
