### PR TITLE
[#3010] Bunch of select related calls when adding child periods

### DIFF
--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -1366,7 +1366,10 @@ class Project(TimestampsMixin, models.Model):
 
         """
         IndicatorPeriod = get_model('rsr', 'IndicatorPeriod')
-        child_period, created = IndicatorPeriod.objects.update_or_create(
+        child_period, created = IndicatorPeriod.objects.select_related(
+            'indicator',
+            'indicator__result',
+        ).update_or_create(
             indicator=indicator,
             parent_period=period,
             defaults=dict(

--- a/akvo/rsr/models/result/indicator_period.py
+++ b/akvo/rsr/models/result/indicator_period.py
@@ -102,7 +102,12 @@ class IndicatorPeriod(models.Model):
 
         super(IndicatorPeriod, self).save(*args, **kwargs)
 
-        for child_indicator in self.indicator.child_indicators.all():
+        child_indicators = self.indicator.child_indicators.select_related(
+            'result',
+            'result__project',
+        )
+
+        for child_indicator in child_indicators.all():
             child_indicator.result.project.add_period(child_indicator, self)
 
         # If the actual value has changed, the period has a parent period and aggregations are on,


### PR DESCRIPTION
Closes #3010


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry

```markdown
Adding a new period to parent results framework is super slow [#3010](https://github.com/akvo/akvo-rsr/issues/3010)
```
