### PR TITLE
[#3019] Set a measure value for qualitative indicators automatically

### DIFF
--- a/akvo/iati/checks/fields/results.py
+++ b/akvo/iati/checks/fields/results.py
@@ -4,6 +4,8 @@
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
+from akvo.rsr.models.result.utils import QUALITATIVE
+
 
 def results(project):
     """
@@ -32,7 +34,7 @@ def results(project):
             checks.append((u'error', u'result (id: %s) has no indicator(s)' % str(result.pk)))
 
         for indicator in result.indicators.all():
-            if not indicator.measure:
+            if indicator.type != QUALITATIVE and not indicator.measure:
                 all_checks_passed = False
                 checks.append((u'error', u'indicator (id: %s) has no measure specified' %
                                str(indicator.pk)))

--- a/akvo/rsr/static/scripts-src/project-editor.js
+++ b/akvo/rsr/static/scripts-src/project-editor.js
@@ -1470,6 +1470,9 @@ function setMeasureVisibility(indicatorTypeSelect) {
     // hide measure fields for qualitative indicators
     if (indicatorTypeSelect.value === '2') {
         elAddClass(measureRow, 'hidden');
+        // HACK: To deal with mandatory fields, we set indicator measure to be
+        // Unit for qualitative indicators automatically.
+        measureRow.querySelector('select').selectedIndex = 1;
     } else {
         elRemoveClass(measureRow, 'hidden');
     }

--- a/akvo/rsr/static/scripts-src/project-editor.jsx
+++ b/akvo/rsr/static/scripts-src/project-editor.jsx
@@ -1470,6 +1470,9 @@ function setMeasureVisibility(indicatorTypeSelect) {
     // hide measure fields for qualitative indicators
     if (indicatorTypeSelect.value === '2') {
         elAddClass(measureRow, 'hidden');
+        // HACK: To deal with mandatory fields, we set indicator measure to be
+        // Unit for qualitative indicators automatically.
+        measureRow.querySelector('select').selectedIndex = 1;
     } else {
         elRemoveClass(measureRow, 'hidden');
     }


### PR DESCRIPTION
This is a hack to set the measure value of qualitative indicators automatically
in the project editor.  The field is hidden, but the validation doesn't ignore
the field and it's quite hard to change that without changing a lot in the
validation logic.

Closes #3019


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
