### PR TITLE
[#3026] Postgres views of aggregated values

### DIFF
--- a/akvo/rsr/management/commands/rsr_sync_pgviews.py
+++ b/akvo/rsr/management/commands/rsr_sync_pgviews.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+from optparse import make_option
+import logging
+
+from django.core.management.base import BaseCommand
+
+from django_pgviews.models import ViewSyncer
+
+log = logging.getLogger('django_pgviews.sync_pgviews')
+
+
+class Command(BaseCommand):
+    help = """Create/update Postgres views for all installed apps."""
+
+    option_list = BaseCommand.option_list + (
+        make_option('--no-update',
+                    action='store_false',
+                    dest='update',
+                    default=True,
+                    help="Don't update existing views, only create new ones."),
+        make_option('--force',
+                    action='store_true',
+                    dest='force',
+                    default=False,
+                    help="Force replacement of pre-existing views where breaking changes have been "
+                         "made to the schema.")
+    )
+
+    def handle(self, *args, **options):
+        vs = ViewSyncer()
+        vs.run(options['force'], options['update'])

--- a/akvo/rsr/models/__init__.py
+++ b/akvo/rsr/models/__init__.py
@@ -45,7 +45,7 @@ from .result import (Disaggregation, Indicator, IndicatorDimension,
                      IndicatorPeriodActualDimension,
                      IndicatorPeriodTargetDimension,
                      IndicatorPeriodActualLocation,
-                     IndicatorPeriodTargetLocation, NarrativeReport)
+                     IndicatorPeriodTargetLocation, NarrativeReport, PeriodActualValue)
 from .internal_organisation_id import InternalOrganisationID
 from .keyword import Keyword
 from .legacy_data import LegacyData
@@ -147,6 +147,7 @@ __all__ = [
     'ProjectUpdateLocation',
     'PartnerSite',
     'Partnership',
+    'PeriodActualValue',
     'PlannedDisbursement',
     'PolicyMarker',
     'Project',

--- a/akvo/rsr/models/result/__init__.py
+++ b/akvo/rsr/models/result/__init__.py
@@ -10,6 +10,7 @@ from .indicator_dimension import IndicatorDimension
 from .indicator_label import IndicatorLabel
 from .indicator_period import IndicatorPeriod
 from .indicator_period_actual_dimension import IndicatorPeriodActualDimension
+from .indicator_period_aggregation import PeriodActualValue
 from .indicator_period_actual_location import IndicatorPeriodActualLocation
 from .indicator_period_data import IndicatorPeriodData
 from .indicator_period_data_comment import IndicatorPeriodDataComment
@@ -33,5 +34,6 @@ __all__ = [
     'IndicatorPeriodTargetLocation',
     'IndicatorReference',
     'NarrativeReport',
+    'PeriodActualValue',
     'Result',
 ]

--- a/akvo/rsr/models/result/indicator_period_aggregation.py
+++ b/akvo/rsr/models/result/indicator_period_aggregation.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+from django.db import models
+
+from django_pgviews import view as pg
+
+
+VIEW_SQL = """
+    SELECT
+        -- row_number() OVER... creates an artificial "pk" column, without which Django will protest
+        row_number() OVER (ORDER BY period.id ) AS id,
+        period.id AS period_id,
+        sum((update.value) :: BIGINT) AS value
+    FROM
+        rsr_indicatorperiod period,
+        rsr_indicator indicator,
+        rsr_indicatorperioddata update
+    WHERE
+        indicator.id = period.indicator_id AND
+        period.id = update.period_id AND
+        ((indicator.measure) :: TEXT = '1' :: TEXT) AND
+        ((update.status) :: TEXT = 'A' :: TEXT)
+        -- Ignore non-numerical update.values. This can be removed when values is numeric
+        AND ((update.value) :: TEXT ~ '^\d+$' :: TEXT)
+    GROUP BY
+        period.id
+"""
+
+
+class PeriodActualValue(pg.View):
+    period = models.ForeignKey('IndicatorPeriod')
+    value = models.IntegerField()
+    sql = VIEW_SQL
+
+    class Meta:
+        app_label = 'rsr'
+        db_table = 'rsr_indicator_period_actual_value'
+        managed = False

--- a/akvo/settings/10-base.conf
+++ b/akvo/settings/10-base.conf
@@ -42,6 +42,7 @@ INSTALLED_APPS = (
     'bootstrap3',
     'rules',
     'django_crontab',
+    'django_pgviews',
 )
 
 gettext = lambda s: s

--- a/scripts/deployment/pip/requirements/2_rsr.txt
+++ b/scripts/deployment/pip/requirements/2_rsr.txt
@@ -51,6 +51,7 @@ django-embed-video==0.11
 # Database requirements
 South==0.8.4
 psycopg2==2.6.2
+django-pgviews==0.5.3
 
 # App container
 gunicorn==18.0


### PR DESCRIPTION
First cut of a Postgres view aggregating a value.

The view calculates the "actual value" of an indicator period, i.e. the sum of all value fields on the period's approved updates.

Also includes a management command script. This is a "fixed" version of the manangement command included in django-pgviews, since the original script only works with Django 1.9+.


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
