### PR TITLE
[#3034] Raise Http404 instead of returning it when project not found

### DIFF
--- a/akvo/rsr/views/my_rsr.py
+++ b/akvo/rsr/views/my_rsr.py
@@ -274,7 +274,7 @@ def project_editor(request, project_id):
             'primary_organisation',
         ).get(pk=project_id)
     except Project.DoesNotExist:
-        return Http404
+        raise Http404('No project exists with the given id.')
 
     if (not request.user.has_perm('rsr.change_project', project) or project.iati_status in Project.EDIT_DISABLED) and not \
             (request.user.is_superuser or request.user.is_admin):


### PR DESCRIPTION
Closes #3034


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
