### PR TITLE
[#1935] Unmount carousel when not in summary tab, and remount it

### DIFF
--- a/akvo/rsr/static/scripts-src/project-main/project-main.js
+++ b/akvo/rsr/static/scripts-src/project-main/project-main.js
@@ -320,7 +320,7 @@ function renderReactComponents() {
                     React.createElement(CarouselItem, {key: photo.url}, photoLink, carouselCaption)
                 );
             });
-            return (React.createElement(Carousel, null, photos));
+            return (React.createElement(Carousel, {controls: this.props.source.photos.length > 1}, photos));
         }
     });
 

--- a/akvo/rsr/static/scripts-src/project-main/project-main.js
+++ b/akvo/rsr/static/scripts-src/project-main/project-main.js
@@ -334,16 +334,20 @@ function renderReactComponents() {
     }
 
     function renderCarousel() {
-        ReactDOM.render(
-            React.createElement(CarouselInstance, {
-                source: JSON.parse(document.getElementById("akvo-rsr-carousel").innerHTML)
-            }),
-            document.getElementById('carousel')
-        );
+        var source=JSON.parse(document.getElementById("akvo-rsr-carousel").innerHTML);
+        ReactDOM.render(React.createElement(CarouselInstance, {source: source}),
+                        document.getElementById('carousel'));
     }
 
     renderAccordion();
     renderCarousel();
+
+    // HACK: Re-render carousel when we switch to the summary tab
+    var summary_tab = document.querySelector('#summary-tab');
+    summary_tab.addEventListener('click', function () {
+        ReactDOM.unmountComponentAtNode(document.querySelector('#carousel'));
+        renderCarousel();
+    });
 }
 
 function readMoreOnClicks() {

--- a/akvo/rsr/static/scripts-src/project-main/project-main.jsx
+++ b/akvo/rsr/static/scripts-src/project-main/project-main.jsx
@@ -320,7 +320,7 @@ function renderReactComponents() {
                     React.createElement(CarouselItem, {key: photo.url}, photoLink, carouselCaption)
                 );
             });
-            return (React.createElement(Carousel, null, photos));
+            return (React.createElement(Carousel, {controls: this.props.source.photos.length > 1}, photos));
         }
     });
 

--- a/akvo/rsr/static/scripts-src/project-main/project-main.jsx
+++ b/akvo/rsr/static/scripts-src/project-main/project-main.jsx
@@ -334,16 +334,20 @@ function renderReactComponents() {
     }
 
     function renderCarousel() {
-        ReactDOM.render(
-            React.createElement(CarouselInstance, {
-                source: JSON.parse(document.getElementById("akvo-rsr-carousel").innerHTML)
-            }),
-            document.getElementById('carousel')
-        );
+        var source=JSON.parse(document.getElementById("akvo-rsr-carousel").innerHTML);
+        ReactDOM.render(<CarouselInstance source={source} />,
+                        document.getElementById('carousel'));
     }
 
     renderAccordion();
     renderCarousel();
+
+    // HACK: Re-render carousel when we switch to the summary tab
+    var summary_tab = document.querySelector('#summary-tab');
+    summary_tab.addEventListener('click', function () {
+        ReactDOM.unmountComponentAtNode(document.querySelector('#carousel'));
+        renderCarousel();
+    });
 }
 
 function readMoreOnClicks() {

--- a/akvo/templates/project_main.html
+++ b/akvo/templates/project_main.html
@@ -12,7 +12,7 @@
                 <div class="col-md-12 ">
                     <nav class="navbar navbar-nav nav-justified">
                         <ul class="nav nav-tabs">
-                            <li><a href="#summary" class="tab-link selected">{% trans 'Summary' %}</a></li>
+                            <li><a href="#summary" id="summary-tab" class="tab-link selected">{% trans 'Summary' %}</a></li>
                             <li><a href="#report" class="tab-link">{% trans 'Full report' %}</a></li>
                             <li><a href="#partners" class="tab-link">{% trans 'Project partners' %}</a></li>
                             <li><a href="#finance" class="tab-link">{% trans 'Finances' %}</a></li>


### PR DESCRIPTION
Closes #1935


- [x] Test plan | Unit test | Integration test
  - Open any project page
  - Go the summary tab
  - Switch to any other tab, and wait for at least 5 seconds (for one carousel transition)
  - Switch back to the summary tab, carousel should still be working, though it resets to first picture
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
