### PR TITLE
[#3088] Add initial configuration for prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,2 @@
+# .prettierrc
+tabWidth: 4

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,2 +1,3 @@
 # .prettierrc
 tabWidth: 4
+printWidth: 100

--- a/akvo/rsr/static/package.json
+++ b/akvo/rsr/static/package.json
@@ -56,6 +56,7 @@
     "ignore-styles": "^5.0.1",
     "json-loader": "^0.5.7",
     "mocha": "^3.4.2",
+    "prettier": "^1.10.2",
     "react-test-renderer": "^15.6.1",
     "style-loader": "^0.13.1",
     "webpack": "^1.14.0"

--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,16 +1,11 @@
 #!/bin/sh
-#
-# Called by git-commit with no arguments. The hook should
-# exit with non-zero status after issuing an appropriate message if
-# it wants to stop the commit.
+jsfiles=$(git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" | tr '\n' ' ')
+[ -z "$jsfiles" ] && exit 0
 
+# Prettify all staged .js files
+echo "$jsfiles" | xargs ./akvo/rsr/static/node_modules/.bin/prettier --write
 
+# Add back the modified/prettified files to staging
+echo "$jsfiles" | xargs git add
 
-# --- Command line
-
-#echo 'In update pre-commit'
-
-exec python `pwd`'/akvo/scripts/asset_manager/packer.py'
-
-# --- Finished
 exit 0


### PR DESCRIPTION
Closes #3088

I've added a `pre-commit` hook, if someone prefers to use that. 
But, I personally prefer Editor integration. 

- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
