### PR TITLE
[#3110] add indicator periods to OneDrop projects

### DIFF
--- a/akvo/rsr/management/commands/add_periods.py
+++ b/akvo/rsr/management/commands/add_periods.py
@@ -8,15 +8,13 @@ from django.core.management.base import BaseCommand
 
 from ...models import Indicator, IndicatorPeriod
 
-QUANTITATIVE = 1
-RESULT_TYPE_OUTCOME = u"2"
+RESULT_TYPE_OUTPUT = u"1"
 
 
 class Command(BaseCommand):
     help = """
-    Script that replaces indicator periods for a project if it doesn't have exactly 9 periods.
+    Script that adds indicator periods for a project to indicators of output results.
     The new periods have the following start and end dates:
-        2017-07-01", "2017-12-31"
         2018-01-01", "2018-06-30"
         2018-07-01", "2018-12-31"
         2019-01-01", "2019-06-30"
@@ -26,15 +24,12 @@ class Command(BaseCommand):
         2021-01-01", "2021-06-30"
         2021-07-01", "2021-12-31"
 
-    Only results of type "outcome" will be changed in this way.
-
     NOTE: this is a custom command for OneDrop.
     """
 
     def handle(self, *args, **options):
 
         DATES = [
-            ["2017-07-01", "2017-12-31"],
             ["2018-01-01", "2018-06-30"],
             ["2018-07-01", "2018-12-31"],
             ["2019-01-01", "2019-06-30"],
@@ -52,14 +47,13 @@ class Command(BaseCommand):
             indicators = Indicator.objects.filter(
                 result__project=project_id
             ).filter(
-                result__type=RESULT_TYPE_OUTCOME
-            ).select_related('result')
+                result__type=RESULT_TYPE_OUTPUT
+            )
 
             for indicator in indicators:
                 periods = IndicatorPeriod.objects.filter(indicator=indicator)
-                if periods.count() != 9:
+                if periods.count() == 1:
                     print u"{}\t{}".format(indicator.pk, indicator.title).encode('utf-8')
-                    periods.delete()
                     for (period_start, period_end) in DATES:
                         IndicatorPeriod.objects.create(indicator=indicator,
                                                        period_start=period_start,

--- a/akvo/rsr/management/commands/replace_periods.py
+++ b/akvo/rsr/management/commands/replace_periods.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+import argparse
+
+from django.core.management.base import BaseCommand
+
+from ...models import Indicator, IndicatorPeriod
+
+QUANTITATIVE = 1
+RESULT_TYPE_OUTCOME = u"2"
+
+class Command(BaseCommand):
+    help = """ 
+    Script that replaces indicator periods for a project if it doesn't have exactly 9 periods. 
+    The new periods have the following start and end dates:
+        2017-07-01", "2017-12-31"
+        2018-01-01", "2018-06-30"
+        2018-07-01", "2018-12-31"
+        2019-01-01", "2019-06-30"
+        2019-07-01", "2019-12-31"
+        2020-01-01", "2020-06-30"
+        2020-07-01", "2020-12-31"
+        2021-01-01", "2021-06-30"
+        2021-07-01", "2021-12-31"
+
+    Only results of type "outcome" will be changed in this way.
+    
+    NOTE: this is a custom command for OneDrop.
+    """
+
+    def handle(self, *args, **options):
+
+        DATES = [
+            ["2017-07-01", "2017-12-31"],
+            ["2018-01-01", "2018-06-30"],
+            ["2018-07-01", "2018-12-31"],
+            ["2019-01-01", "2019-06-30"],
+            ["2019-07-01", "2019-12-31"],
+            ["2020-01-01", "2020-06-30"],
+            ["2020-07-01", "2020-12-31"],
+            ["2021-01-01", "2021-06-30"],
+            ["2021-07-01", "2021-12-31"],
+        ]
+
+        project_ids = args
+
+        print('ID\tTitle')
+        for project_id in project_ids:
+            indicators = Indicator.objects.filter(
+                result__project=project_id
+            ).filter(
+                result__type=RESULT_TYPE_OUTCOME
+            ).select_related('result')
+
+            for indicator in indicators:
+                periods = IndicatorPeriod.objects.filter(indicator=indicator)
+                if periods.count() != 9:
+                    print u"{}\t{}".format(indicator.pk, indicator.title).encode('utf-8')
+                    periods.delete()
+                    for (period_start, period_end) in DATES:
+                        IndicatorPeriod.objects.create(indicator=indicator,
+                                                       period_start=period_start,
+                                                       period_end=period_end)

--- a/akvo/rsr/management/commands/replace_periods.py
+++ b/akvo/rsr/management/commands/replace_periods.py
@@ -4,8 +4,6 @@
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
-import argparse
-
 from django.core.management.base import BaseCommand
 
 from ...models import Indicator, IndicatorPeriod
@@ -13,9 +11,10 @@ from ...models import Indicator, IndicatorPeriod
 QUANTITATIVE = 1
 RESULT_TYPE_OUTCOME = u"2"
 
+
 class Command(BaseCommand):
-    help = """ 
-    Script that replaces indicator periods for a project if it doesn't have exactly 9 periods. 
+    help = """
+    Script that replaces indicator periods for a project if it doesn't have exactly 9 periods.
     The new periods have the following start and end dates:
         2017-07-01", "2017-12-31"
         2018-01-01", "2018-06-30"
@@ -28,7 +27,7 @@ class Command(BaseCommand):
         2021-07-01", "2021-12-31"
 
     Only results of type "outcome" will be changed in this way.
-    
+
     NOTE: this is a custom command for OneDrop.
     """
 


### PR DESCRIPTION
This is a management script that adds 8 half-year periods to indicators for output results. It is to be used on project 5562.

To test this, run the script (./manage.sh add_periods 5562) using recent RSR data. All "output indicators" of the project should now have 9 half year periods starting with 2017-07-01 - 2017-12-31 and ending with 2021-07-01 - 2021-12-31. This should also be true for 5562's child projects.

Closes #3110 

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
