### PR TITLE
[#3150] Report error when exporting project with only qualitative indicators

### DIFF
--- a/akvo/iati/checks/fields/results.py
+++ b/akvo/iati/checks/fields/results.py
@@ -4,7 +4,7 @@
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
-from akvo.rsr.models.result.utils import QUALITATIVE
+from akvo.rsr.models.result.utils import QUALITATIVE, QUANTITATIVE
 
 DGIS_VALIDATION_SET_NAME = u"DGIS IATI"
 
@@ -28,12 +28,14 @@ def results(project):
             all_checks_passed = False
             checks.append((u'error', u'result (id: %s) has no title specified' % str(result.pk)))
 
-        if not result.indicators.all():
+        if not result.indicators.filter(type=QUANTITATIVE):
             all_checks_passed = False
-            checks.append((u'error', u'result (id: %s) has no indicator(s)' % str(result.pk)))
+            checks.append(
+                (u'error', u'result (id: %s) has no quantitative indicator(s)' % str(result.pk))
+            )
 
-        for indicator in result.indicators.all():
-            if indicator.type != QUALITATIVE and not indicator.measure:
+        for indicator in result.indicators.filter(type=QUANTITATIVE):
+            if not indicator.measure:
                 all_checks_passed = False
                 checks.append((u'error', u'indicator (id: %s) has no measure specified' %
                                str(indicator.pk)))

--- a/akvo/iati/exports/iati_export.py
+++ b/akvo/iati/exports/iati_export.py
@@ -114,6 +114,8 @@ class IatiXML(object):
         :param iati_export: IatiExport Django object
         :param excluded_elements: List of fieldnames that should be ignored when exporting
         """
+        from akvo.rsr.models import IatiExport
+
         self.projects = projects
         self.version = version
         self.iati_export = iati_export
@@ -139,5 +141,5 @@ class IatiXML(object):
             # Update IATI activity export's status to indicate that export has finished
             iati_activity_export = getattr(self, 'iati_activity_export', None)
             if iati_activity_export:
-                iati_activity_export.status = 2
+                iati_activity_export.status = IatiExport.STATUS_IN_PROGRESS
                 iati_activity_export.save(update_fields=['status'])


### PR DESCRIPTION
The IATI checks now generate an error if all indicators are qualitative, since they are not included in the export.

Closes #3150 

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
