### PR TITLE
[#3157] Extend file name length in IndicatorPeriodData

### DIFF
--- a/akvo/rsr/migrations/0124_auto_20180309_0923.py
+++ b/akvo/rsr/migrations/0124_auto_20180309_0923.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import sorl.thumbnail.fields
+import akvo.rsr.models.result.utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rsr', '0123_periodactualvalue_perioddisaggregation'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='indicatorperioddata',
+            name='file',
+            field=models.FileField(upload_to=akvo.rsr.models.result.utils.file_path, max_length=255, verbose_name='file', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='indicatorperioddata',
+            name='photo',
+            field=sorl.thumbnail.fields.ImageField(upload_to=akvo.rsr.models.result.utils.image_path, max_length=255, verbose_name='photo', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/akvo/rsr/models/result/indicator_period_data.py
+++ b/akvo/rsr/models/result/indicator_period_data.py
@@ -65,8 +65,8 @@ class IndicatorPeriodData(TimestampsMixin, models.Model):
     status = ValidXMLCharField(_(u'status'), max_length=1, choices=STATUSES, db_index=True,
                                default=STATUS_DRAFT_CODE)
     text = ValidXMLTextField(_(u'text'), blank=True)
-    photo = ImageField(_(u'photo'), blank=True, upload_to=image_path)
-    file = models.FileField(_(u'file'), blank=True, upload_to=file_path)
+    photo = ImageField(_(u'photo'), blank=True, upload_to=image_path, max_length=255)
+    file = models.FileField(_(u'file'), blank=True, upload_to=file_path, max_length=255)
     update_method = ValidXMLCharField(_(u'update method'), blank=True, max_length=1,
                                       choices=UPDATE_METHODS, db_index=True, default='W')
 


### PR DESCRIPTION
Extend the maximum file name length for the photo and file fields to 255 cars,
since the name includes the path making the effective max length of the actual
file name around 50 chars with the default max_length of 100.

Closes #3157 

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
