### PR TITLE
[#3121] Make adding partners slightly faster

### DIFF
--- a/akvo/rsr/models/partnership.py
+++ b/akvo/rsr/models/partnership.py
@@ -198,8 +198,10 @@ class Partnership(models.Model):
 
     def clean(self):
         # Don't allow multiple reporting organisations
+        Project = models.get_model('rsr', 'project')
+        project = Project.objects.get(id=self.project_id)
         if self.iati_organisation_role == self.IATI_REPORTING_ORGANISATION:
-            reporting_orgs = self.project.partnerships.filter(
+            reporting_orgs = project.partnerships.filter(
                 iati_organisation_role=self.IATI_REPORTING_ORGANISATION
             )
 
@@ -220,5 +222,7 @@ class Partnership(models.Model):
     def set_primary_organisation(self):
         # Check which organisation should be set to the primary organisation of the project
         # This is done to get better performance on the project list page
-        self.project.primary_organisation = self.project.find_primary_organisation()
-        self.project.save(update_fields=['primary_organisation'])
+        Project = models.get_model('rsr', 'project')
+        project = Project.objects.get(id=self.project_id)
+        project.primary_organisation = project.find_primary_organisation()
+        project.save(update_fields=['primary_organisation'])

--- a/akvo/rsr/signals.py
+++ b/akvo/rsr/signals.py
@@ -304,8 +304,10 @@ def update_project_funding(sender, **kwargs):
     # kwargs['raw'] is True when we're running manage.py loaddata
     if not kwargs.get('raw', False):
         try:
-            kwargs['instance'].project.update_funds()
-            kwargs['instance'].project.update_funds_needed()
+            Project = get_model('rsr', 'project')
+            project = Project.objects.get(id=kwargs['instance'].project_id)
+            project.update_funds()
+            project.update_funds_needed()
         except ObjectDoesNotExist:
             # this happens when a project is deleted, and thus any invoices linked to it go the
             # same way.


### PR DESCRIPTION
Adding partners seems to cause the following query to run, multiple times, when
`self.project` is accessed on a partnership

```sql
SELECT ••• FROM "rsr_project" ORDER BY "rsr_project"."id" DESC
```

This is a slow query and takes about 1.5seconds to run.  This commit prevents
such queries from running and improves performance, when adding multiple
partners to a project.

Closes #3121


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
