### PR TITLE
[#3142] Change the view permissions check to be lax

### DIFF
--- a/akvo/rsr/static/scripts-src/my-results/components/App.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/App.jsx
@@ -348,6 +348,7 @@ export default class App extends React.Component {
             );
         }
         const show_reports = page.mode && page.mode.show_narrative_reports;
+        const show_results = page.mode && page.mode.show_results;
         const projectId = dataFromElement("project").id;
         const has_results = dataFromElement("project").has_results;
         const results_tab = (
@@ -375,12 +376,12 @@ export default class App extends React.Component {
                 </a>
                 <Tabs onSelect={this.onSelectTab}>
                     <TabList>
-                        {has_results ? <Tab>Results</Tab> : undefined}
+                        {show_results && has_results ? <Tab>Results</Tab> : undefined}
                         {show_reports ? <Tab>Narrative summaries</Tab> : undefined}
                         <Tab>Reports</Tab>
                         <Tab>Add an update</Tab>
                     </TabList>
-                    {has_results ? <TabPanel>{results_tab}</TabPanel> : undefined}
+                    {show_results && has_results ? <TabPanel>{results_tab}</TabPanel> : undefined}
                     {show_reports ? (
                         <TabPanel>
                             <NarrativeReports />

--- a/akvo/rsr/views/utils.py
+++ b/akvo/rsr/views/utils.py
@@ -54,7 +54,3 @@ def org_projects(organisation):
 def show_filter_class(qs, filters):
     """To simplify template, instead of bool adhere to bootstrap class name."""
     return "" if frozenset(qs.keys()).isdisjoint(filters) else "in"
-
-
-def toJSBoolean(bool):
-    return 'true' if bool else 'false'

--- a/akvo/templates/myrsr/my_project.html
+++ b/akvo/templates/myrsr/my_project.html
@@ -25,7 +25,8 @@
     <script type="application/json" id="mode">
         {
             "public": false,
-            "show_narrative_reports": {{ show_narrative_reports }}
+            "show_narrative_reports": {{ show_narrative_reports }},
+            "show_results": {{ show_results }}
         }
     </script>
     {% include "results_base.html" %}


### PR DESCRIPTION
The decision of showing or hiding a particular tab, is made based on specific
permissions the user has, rather than preventing the whole page from loading.

Closes #3142


- [ ] Test plan | Unit test | Integration test

  - Log in as an ordinary user (belongs to `Users` group only), and verify that the `/en/myrsr/my_project/<id>` page opens for a project with the user's org as a partner.  
  - Once the page loads, verify that only the reports tab and the add update tab are shown. 

- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
