### PR TITLE
Release v3.36.7 (hot-fix)

### DIFF
--- a/akvo/rsr/models/user.py
+++ b/akvo/rsr/models/user.py
@@ -379,7 +379,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         """
         employments = self.employers.all().exclude(is_approved=False)
         if group_names is not None:
-            employments.filter(group__name__in=group_names)
+            employments = employments.filter(group__name__in=group_names)
         return employments.select_related('organisation', 'group', 'user')
 
     def can_create_project(self):


### PR DESCRIPTION
Broken filtering of employments in user.approved_employments caused users to
have permissions which they were not supposed to have. This commit fixes the bug
and restricts users in the Users group to only have the intended permissions.


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
