### PR TITLE
[#3205] Fix subtle bug with user & enumerator permissions for None

### DIFF
--- a/akvo/rsr/permissions.py
+++ b/akvo/rsr/permissions.py
@@ -170,12 +170,13 @@ def is_org_me_manager(user, obj):
 def is_org_user(user, obj):
     if not user.is_authenticated():
         return False
-    if not obj:
+    employments = user.approved_employments(group_names=[USER_GROUP_NAME])
+    has_employments = employments.exists()
+    if obj is None and has_employments:
         return True
     if isinstance(obj, ProjectUpdate):
         return obj.user == user
     if isinstance(obj, Project):
-        employments = user.approved_employments(group_names=[USER_GROUP_NAME])
         return obj in employments.organisations().all_projects()
     return False
 
@@ -184,15 +185,16 @@ def is_org_user(user, obj):
 def is_org_enumerator(user, obj):
     if not user.is_authenticated():
         return False
-    if obj is None:
+    employments = user.approved_employments(group_names=[ENUMERATOR_GROUP_NAME])
+    has_employments = employments.exists()
+    if obj is None and has_employments:
         return True
     if isinstance(obj, ProjectUpdate):
         return obj.user == user
     if isinstance(obj, IndicatorPeriodData):
-        # Show only own updates or approved updates of others
+        # Fetch the corresponding project for the indicator update
         obj = Project.objects.get(results__indicators__periods__data__in=[obj.id])
     if isinstance(obj, Project):
-        employments = user.approved_employments(group_names=[ENUMERATOR_GROUP_NAME])
         return obj in employments.organisations().all_projects()
     return False
 

--- a/akvo/rsr/tests/test_permissions.py
+++ b/akvo/rsr/tests/test_permissions.py
@@ -192,6 +192,9 @@ class PermissionsTestCase(TestCase):
         # None object permissions
         self.assertTrue(user.has_perm('rsr.view_project', None))
 
+        # Test no permissions on None, if user doesn't have required employment
+        self.assertFalse(user.has_perm('rsr.add_indicatorperioddata'))
+
         # Project Update permissions
         for i, project_update in enumerate(self.project_updates):
             test = self.assertTrue if i == 0 else self.assertFalse
@@ -211,8 +214,19 @@ class PermissionsTestCase(TestCase):
         employment.group = group
         employment.save()
 
-        # Assert user all Users group permissions
-        self.test_org_user_permissions()
+        # Permissions on None
+        self.assertTrue(user.has_perm('rsr.view_project', None))
+
+        # Project Update permissions
+        for i, project_update in enumerate(self.project_updates):
+            test = self.assertTrue if i == 0 else self.assertFalse
+            test(user.has_perm('rsr.change_projectupdate', project_update))
+
+        # Project permissions
+        for i, project in enumerate(self.projects):
+            test = self.assertTrue if i == 0 else self.assertFalse
+            test(user.has_perm('rsr.view_project', project))
+            self.assertFalse(user.has_perm('rsr.change_project', project))
 
         # Can add indicator
         project = self.projects[0]


### PR DESCRIPTION
The permission predicates for is_org_user and is_org_enumerator were returning
True for None objects without checking if the user has a corresponding
employment of that kind. This isn't a problem for the User group, because users
in the User group have the least permissions, so this bug didn't really manifest
anywhere. When the enumerator role is added, though, users in the Users group,
but not in the Enumerators group will get permissions to add indicator updates,
for example.


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
