### PR TITLE
[#3270] Increase max-width for subtitle in my projects listing

### DIFF
--- a/akvo/rsr/static/styles-src/main.css
+++ b/akvo/rsr/static/styles-src/main.css
@@ -859,7 +859,7 @@ div.paginationWrap {
   .table-responsive .media > a {
     min-width: 80px; }
   .table-responsive .media .media-body p {
-    max-width: 170px;
+    max-width: 300px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap; }

--- a/akvo/rsr/static/styles-src/main.scss
+++ b/akvo/rsr/static/styles-src/main.scss
@@ -1024,7 +1024,7 @@ div.paginationWrap {
         }
         .media-body {
             p {
-                max-width: 170px;
+                max-width: 300px;
                 @include noWrapTxt;
                 @include responsive(small-max-screens) {
                     max-width: 120px;


### PR DESCRIPTION
EUTF's project codes are in the subtitles and they are cut off with the current
max-width. Increasing this makes the entire project code visible.

Closes #3270


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
