### PR TITLE
[#3278] Update singe_period_indicators management script

### DIFF
--- a/akvo/rsr/management/commands/single_period_indicators.py
+++ b/akvo/rsr/management/commands/single_period_indicators.py
@@ -49,9 +49,9 @@ class Command(BaseCommand):
             modified_periods = []
             unmodified_periods = []
             for period in periods:
-                updates = IndicatorPeriodData.objects.filter(period=period)
+                updates_exist = IndicatorPeriodData.objects.filter(period=period).exists()
                 if (period.target_value or period.target_comment or
-                        period.actual_value or period.actual_comment or updates):
+                        period.actual_value or period.actual_comment or updates_exist):
                     modified_periods += [period]
                 else:
                     unmodified_periods += [period]


### PR DESCRIPTION
Change the behaviour slightly when more than one period is encountered.

If there's more than one period, check if only one if "modified". If so keep the modified period and delete the others.

A period is modified if one of the fields target_value, target_comment, actual_value or actual_comment has a value or the period has at least one update.


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
