### PR TITLE
[#3285] project updates: Send credentials with fetch requests

### DIFF
--- a/akvo/rsr/static/scripts-src/my-results/components/RSRUpdates.jsx
+++ b/akvo/rsr/static/scripts-src/my-results/components/RSRUpdates.jsx
@@ -53,7 +53,7 @@ class RSRUpdateList extends React.Component {
             return `/rest/v1/project_update/?project=${project}&format=json`;
         };
         const self = this;
-        fetch(api_endpoint(this.props))
+        fetch(api_endpoint(this.props), { credentials: "same-origin" })
             .then(function(response) {
                 self.setState({ loading: false });
                 if (response.status == 200) {


### PR DESCRIPTION
Fixes a problem with project updates not being listed for private projects,
since the credentials for the API call is not sent by default in some browsers.

Closes #3285


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
