### PR TITLE
[#3289] directories: Fix incorrect pagination

### DIFF
--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -5,6 +5,7 @@ See more details in the license.txt file located at the root folder of the Akvo 
 For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 """
 
+from django.conf import settings
 from django.db.models import Q
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
@@ -289,6 +290,7 @@ def project_directory(request):
         'organisation': cached_organisations,
         'sector': TypeaheadSectorSerializer(sectors, many=True).data,
         'location': cached_locations,
+        'page_size_default': settings.PROJECT_DIRECTORY_PAGE_SIZES[0],
     }
 
     return Response(response)

--- a/akvo/rsr/static/scripts-src/directory-utils.js
+++ b/akvo/rsr/static/scripts-src/directory-utils.js
@@ -124,17 +124,17 @@ var Update = React.createClass({displayName: "Update",
                         React.createElement("a", {href: project.url}, project.title)
                     ), 
                     React.createElement("div", null, 
-                        React.createElement("span", {className: ""}, "Project: "), 
+                        React.createElement("span", null, "Project: "), 
                         React.createElement("a", {href: project.project_url, class: "projectTitle"}, 
                             project.project
                         )
                     ), 
                     React.createElement("div", null, 
-                        React.createElement("span", {class: "small"}, "Created by: "), 
+                        React.createElement("span", null, "Created by: "), 
                         React.createElement("span", {class: "userFullName"}, project.user_fullname)
                     ), 
                     React.createElement("div", null, 
-                        React.createElement("span", {class: "small"}, "Org: "), 
+                        React.createElement("span", null, "Org: "), 
                         React.createElement("a", {href: project.organisation_url, class: "orgName"}, 
                             project.organisation
                         )
@@ -526,7 +526,6 @@ var App = React.createClass({displayName: "App",
     },
     render: function() {
         var elements_text = this.props.i18n[this.props.type + "_text"];
-
         return (
             React.createElement("div", null, 
                 React.createElement(SearchBar, {
@@ -549,7 +548,7 @@ var App = React.createClass({displayName: "App",
                     onChange: this.onFilterChange, 
                     limitOptions: this.state.options.limit, 
                     page: this.state.selected.page || 1, 
-                    limit: this.state.selected.limit || 15, 
+                    limit: this.state.selected.limit || this.state.page_size_default, 
                     projects: this.state.projects, 
                     project_count: this.state.project_count, 
                     i18n: this.props.i18n, 
@@ -723,6 +722,7 @@ var App = React.createClass({displayName: "App",
             options: options,
             disabled: false,
             project_count: options.project_count,
+            page_size_default: options.page_size_default,
             projects: options.projects
         });
     }

--- a/akvo/rsr/static/scripts-src/directory-utils.jsx
+++ b/akvo/rsr/static/scripts-src/directory-utils.jsx
@@ -526,7 +526,6 @@ var App = React.createClass({
     },
     render: function() {
         var elements_text = this.props.i18n[this.props.type + "_text"];
-
         return (
             <div>
                 <SearchBar
@@ -549,7 +548,7 @@ var App = React.createClass({
                     onChange={this.onFilterChange}
                     limitOptions={this.state.options.limit}
                     page={this.state.selected.page || 1}
-                    limit={this.state.selected.limit || 15}
+                    limit={this.state.selected.limit || this.state.page_size_default}
                     projects={this.state.projects}
                     project_count={this.state.project_count}
                     i18n={this.props.i18n}
@@ -723,6 +722,7 @@ var App = React.createClass({
             options: options,
             disabled: false,
             project_count: options.project_count,
+            page_size_default: options.page_size_default,
             projects: options.projects
         });
     }


### PR DESCRIPTION
Due to incorrect hard-coded default page size, there can be empty pages in the
pagination shown on directory pages.

Closes #3289


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
