### PR TITLE
[#3312] Fix map marker placement

### DIFF
--- a/akvo/rsr/static/scripts-src/rsr.js
+++ b/akvo/rsr/static/scripts-src/rsr.js
@@ -164,10 +164,16 @@ $(document).ready(function() {
                 window.mapMarkers = [];
 
                 _(this.locations).forEach(function(location) {
+                    var markerImage = new google.maps.MarkerImage(
+                        location.icon,
+                        new google.maps.Size(38, 38),
+                        new google.maps.Point(0, 0),
+                        new google.maps.Point(19, 19)
+                    );
                     var position = new google.maps.LatLng(location.latitude, location.longitude),
                         markerOpts = {
                             position: position,
-                            icon: location.icon,
+                            icon: markerImage,
                             map: map,
                             highlightId: location.highlightId
                         },


### PR DESCRIPTION
Create and use a google.maps.MarkerImage object to get the placement of the marker to use the icon's center for positioning.

closes #3312

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
