### PR TITLE
[#3320] Limit access to the project access restrictions

### DIFF
--- a/akvo/settings/30-rsr.conf
+++ b/akvo/settings/30-rsr.conf
@@ -111,3 +111,10 @@ SINGLE_PERIOD_INDICATORS = {
         'period_end': datetime.date(2025, 12, 31),
     },
 }
+
+# List of organisations for which the access restrictions are accessible.
+# Set to "ALL" to apply restrictions to all of RSR
+ACCESS_RESTRICTIONS_ORGS = [
+    3394, #EUTF
+    42, #Akvo
+]


### PR DESCRIPTION
Add settings.ACCESS_RESTRICTIONS_ORGS. This is a list of organistaion IDs, indicating that users of the orgs are shown the links to the project access restrictions page where applicable. Users of other orgs will not see any links.

Add helper function _restrictions_turned_on() in my_rsr.user_management() that checks if the current user is eligible to see the access restrictions links.

Hide the links to the project access restrictions page for users that are not


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
