### PR TITLE
[#3327] project directory map: Allow zoom levels less than 2

### DIFF
--- a/akvo/rsr/static/scripts-src/rsr.js
+++ b/akvo/rsr/static/scripts-src/rsr.js
@@ -227,8 +227,6 @@ $(document).ready(function() {
                 listener = google.maps.event.addListener(map, "idle", function() {
                     // Don't let the map be too zoomed in
                     if (map.getZoom() > 8) map.setZoom(8);
-                    // Don't let the map be too zoomed out
-                    if (map.getZoom() < 2) map.setZoom(2);
                     google.maps.event.removeListener(listener);
                 });
 


### PR DESCRIPTION
On smaller screens, the zoom level is sometimes set to 1, to be able to show all
the location markers on the map. We had some custom logic to prevent such zoomed
out maps, which doesn't seem to be working well.

This commit removes this logic and lets the maps API figure out what the best
zoom level for the current screen would be.

Closes #3327


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
