### PR TITLE
[#3344] results template: Use null value no primary_organisation

### DIFF
--- a/akvo/templates/results_base.html
+++ b/akvo/templates/results_base.html
@@ -16,7 +16,7 @@
     {
         "currentLanguage": "{{ request.LANGUAGE_CODE }}",
         "id": {{ project.pk }},
-        "primaryOrganisationId": {{ project.primary_organisation.pk }},
+        "primaryOrganisationId": {{ project.primary_organisation.pk|default:"null" }},
         "partners": [
             {% for partner in project.all_partners %}
             {{ partner.id }}


### PR DESCRIPTION
JSON holding information about a project in the results template fails to parse
if there is no primary organisation for a project.

Closes #3344


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
