### PR TITLE
[#3358] Add custom stylesheet

### DIFF
--- a/akvo/rsr/static/styles-src/akvo-wordpress.css
+++ b/akvo/rsr/static/styles-src/akvo-wordpress.css
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------
+
+            Title:   Custom CSS for use in Akvo's Wordpress site
+            Author:  Gabriel von Heijne
+            LICENSE: GNU Affero General Public License
+
+/*---------------------------------------------------------------------------------*/
+
+nav.navbar {
+    display: none !important;
+}
+header.projectHeader {
+    display: none !important;
+}
+footer {
+    display: none !important;
+}
+footer#project-footer {
+    display: block !important;
+}
+#supporthero-button {
+    display: none !important;
+}

--- a/akvo/rsr/static/styles-src/akvo-wordpress.css
+++ b/akvo/rsr/static/styles-src/akvo-wordpress.css
@@ -6,6 +6,9 @@
 
 /*---------------------------------------------------------------------------------*/
 
+body > nav.navbar {
+    display: none !important;
+}
 header.projectHeader {
     display: none !important;
 }

--- a/akvo/rsr/static/styles-src/akvo-wordpress.css
+++ b/akvo/rsr/static/styles-src/akvo-wordpress.css
@@ -6,9 +6,6 @@
 
 /*---------------------------------------------------------------------------------*/
 
-nav.navbar {
-    display: none !important;
-}
 header.projectHeader {
     display: none !important;
 }

--- a/akvo/rsr/views/project.py
+++ b/akvo/rsr/views/project.py
@@ -107,6 +107,9 @@ def main(request, project_id, template="project_main.html"):
     page = request.GET.get('page')
     page, paginator, page_range = pagination(page, updates, 10)
 
+    # Wordpress custom CSS trigger
+    iframe = request.GET.get('iframe')
+
     # Related documents
     related_documents = []
     for d in project.documents.all():
@@ -139,6 +142,7 @@ def main(request, project_id, template="project_main.html"):
         'update_timeout': settings.PROJECT_UPDATE_TIMEOUT,
         'update_statuses': json.dumps(dict(IndicatorPeriodData.STATUSES)),
         'user_is_me_manager': 'false',
+        'load_wp_css': iframe is not None,
     }
 
     context = project.project_hierarchy_context(context)

--- a/akvo/settings/40-pipeline.conf
+++ b/akvo/settings/40-pipeline.conf
@@ -32,6 +32,15 @@ PIPELINE = {
                 'media': 'screen,projection',
             },
         },
+        'rsr_wp_style': {
+            'source_filenames': (
+                'styles-src/akvo-wordpress.css',
+            ),
+            'output_filename': 'styles/akvo-wordpress.min.css',
+            'extra_context': {
+                'media': 'screen,projection',
+            },
+        },
         'new_results': {
             'source_filenames': (
                 'styles-src/results.css',

--- a/akvo/templates/base.html
+++ b/akvo/templates/base.html
@@ -53,7 +53,9 @@
     {# CSS #}
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.0/css/bootstrap.min.css">
     {% stylesheet 'rsr_v3_style' %}
+    {% if load_wp_css %}{% stylesheet 'rsr_wp_style' %}{% endif %}
     {% if stylesheet %}<link rel="stylesheet" href="{{MEDIA_URL}}{{stylesheet}}">{% endif %}
+
     <style type="text/css">
         /** FIX for Bootstrap and Google Maps Info window styes problem **/
         img[src*="gstatic.com/"], img[src*="googleapis.com/"] {


### PR DESCRIPTION
The akvo-wordpress.css stylesheet is used when a request includes the `iframe` query string parameter.

This is so that projects loaded on Akvo's Wordpress site can show the projects without the "chrome" of the header, footer and navigation.


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
