### PR TITLE
[#3363] Move the project creation book-keeping API calls to backend

### DIFF
--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -59,6 +59,13 @@ class ProjectViewSet(PublicProjectViewSet):
             ).distinct()
         return super(ProjectViewSet, self).get_queryset()
 
+    def create(self, request, *args, **kwargs):
+        response = super(ProjectViewSet, self).create(request, *args, **kwargs)
+        user = request.user
+        project_id = response.data['id']
+        Project.new_project_created(project_id, user)
+        return response
+
 
 class ProjectIatiExportViewSet(PublicProjectViewSet):
     """Lean viewset for project data, as used in the My IATI section of RSR."""

--- a/akvo/rest/views/project_editor.py
+++ b/akvo/rest/views/project_editor.py
@@ -28,7 +28,7 @@ from akvo.utils import DjangoModel
 
 from collections import namedtuple
 
-from django.contrib.admin.models import LogEntry, CHANGE, ADDITION
+from django.contrib.admin.models import LogEntry, CHANGE
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import MultipleObjectsReturned, ValidationError
 from django.db import transaction
@@ -928,23 +928,9 @@ def project_editor_organisation_logo(request, pk=None):
 def log_project_addition(request, project_pk=None):
     project = Project.objects.get(pk=project_pk)
     user = request.user
-
     if not user.has_perm('rsr.change_project', project):
         return HttpResponseForbidden()
 
-    message = u'%s.' % (_(u'Project editor, added project'))
-
-    LogEntry.objects.log_action(
-        user_id=user.pk,
-        content_type_id=ContentType.objects.get_for_model(project).pk,
-        object_id=project.pk,
-        object_repr=project.__unicode__(),
-        action_flag=ADDITION,
-        change_message=message
-    )
-
-    # Perform IATI checks after a project has been created.
-    project.update_iati_checks()
-
+    Project.log_project_addition(project_pk, user)
     content = {'log_entry': 'added successfully'}
     return Response(content, status=status.HTTP_201_CREATED)

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -9,7 +9,7 @@ For additional details on the GNU license please see < http://www.gnu.org/licens
 from decimal import Decimal, InvalidOperation
 
 from django.conf import settings
-from django.contrib.admin.models import LogEntry
+from django.contrib.admin.models import LogEntry, ADDITION
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError, ObjectDoesNotExist, MultipleObjectsReturned
@@ -1592,6 +1592,72 @@ class Project(TimestampsMixin, models.Model):
 
         except (InvalidOperation, TypeError):
             pass
+
+    @classmethod
+    def log_project_addition(cls, project_id, user):
+        project = cls.objects.get(id=project_id)
+        message = u'%s.' % (_(u'Project editor, added project'))
+
+        LogEntry.objects.log_action(
+            user_id=user.pk,
+            content_type_id=ContentType.objects.get_for_model(project).pk,
+            object_id=project.pk,
+            object_repr=project.__unicode__(),
+            action_flag=ADDITION,
+            change_message=message
+        )
+
+        # Perform IATI checks after a project has been created.
+        project.update_iati_checks()
+
+    @staticmethod
+    def add_custom_fields(project_id, organisations):
+        from akvo.rsr.models import OrganisationCustomField, ProjectCustomField
+        custom_fields = OrganisationCustomField.objects.filter(
+            organisation__in=organisations
+        )
+        copy_fields = (
+            'name', 'type', 'section', 'order', 'max_characters', 'mandatory', 'help_text'
+        )
+        project_custom_fields = [
+            ProjectCustomField(
+                project_id=project_id,
+                **{field: getattr(custom_field, field) for field in copy_fields}
+            )
+            for custom_field in custom_fields
+        ]
+        ProjectCustomField.objects.bulk_create(project_custom_fields)
+
+    @classmethod
+    def new_project_created(cls, project_id, user):
+        """Hook to do some book-keeping for a newly created project.
+
+        *NOTE*: This hook cannot be moved into a post-save hook since we need
+        information about the user who created this project, to perform some of
+        the actions.
+
+        """
+        # Set reporting organisation
+        organisations = [e.organisation for e in user.approved_employments()]
+        can_create_project_orgs = [
+            org for org in organisations
+            if org.can_create_projects and user.has_perm('rsr.add_project', org)
+        ]
+
+        if can_create_project_orgs:
+            # FIXME: We randomly choose the first organisation, where the user
+            # can create projects, when ordered by employments
+            organisation_id = organisations[0].id
+            from akvo.rsr.models import Partnership
+            Partnership.objects.create(
+                project_id=project_id,
+                organisation_id=organisation_id,
+                iati_organisation_role=Partnership.IATI_REPORTING_ORGANISATION
+            )
+
+        Project.log_project_addition(project_id, user)
+        organisation_ids = [org.id for org in organisations]
+        Project.add_custom_fields(project_id, organisation_ids)
 
 
 @receiver(post_save, sender=Project)

--- a/akvo/rsr/static/scripts-src/my-projects.js
+++ b/akvo/rsr/static/scripts-src/my-projects.js
@@ -30,143 +30,12 @@ function setError(message) {
     errorNode.innerHTML = message;
 }
 
-function setReportingOrg(projectId, partnerId) {
-    var api_url = "/rest/v1/partnership/?format=json",
-        request = new XMLHttpRequest();
-
-    request.open("POST", api_url, true);
-    request.setRequestHeader("X-CSRFToken", csrftoken);
-    request.setRequestHeader("Content-type", "application/json");
-
-    request.onload = function() {
-        if (request.status == 201) {
-            // Successfully created reporting organisation! Now log the project addition.
-            logAddProject(projectId);
-        } else {
-            // We reached our target server, but it returned an error
-            setError(
-                defaultValues.could_not_add +
-                    " " +
-                    defaultValues.reporting_organisation +
-                    ". " +
-                    defaultValues.contact_us
-            );
-            return false;
-        }
-    };
-
-    request.onerror = function() {
-        // There was a connection error of some sort
-        setError(defaultValues.connection_error);
-        return false;
-    };
-
-    request.send(
-        '{"project": ' +
-            projectId +
-            ', "organisation": ' +
-            partnerId +
-            ', "iati_organisation_role": 101}'
-    );
-}
-
-function addCustomFieldToProject(data, callback) {
-    var api_url = "/rest/v1/project_custom_field/?format=json",
-        request = new XMLHttpRequest();
-
-    request.open("POST", api_url, true);
-    request.setRequestHeader("X-CSRFToken", csrftoken);
-    request.setRequestHeader("Content-type", "application/json");
-
-    request.onload = function() {
-        if (request.status == 201) {
-            // Successfully added the custom field!
-            callback();
-        } else {
-            // We reached our target server, but it returned an error
-            setError(
-                defaultValues.could_not_add +
-                    " " +
-                    defaultValues.custom_fields +
-                    ". " +
-                    defaultValues.contact_us
-            );
-            return false;
-        }
-    };
-
-    request.onerror = function() {
-        // There was a connection error of some sort
-        setError(defaultValues.connection_error);
-        return false;
-    };
-
-    request.send(data);
-}
-
-function addCustomFieldsToProject(projectId) {
-    var customFields = defaultValues.new_project_custom_fields,
-        processedFieldsCount = 0;
-
-    function countFields() {
-        processedFieldsCount++;
-
-        if (customFields.length === processedFieldsCount) {
-            window.location = "/myrsr/project_editor/" + projectId + "/";
-        }
-    }
-
-    if (customFields && customFields.length > 0) {
-        for (var i = 0; i < customFields.length; i++) {
-            var customField = customFields[i];
-            customField.project = projectId;
-            addCustomFieldToProject(JSON.stringify(customField), countFields);
-        }
-    } else {
-        window.location = "/myrsr/project_editor/" + projectId + "/";
-    }
-}
-
 function setCreateProjectOnClick() {
     var createProjectNode = document.getElementById("createProject");
 
     if (createProjectNode !== null) {
         createProjectNode.onclick = getCreateProject(createProjectNode);
     }
-}
-
-function logAddProject(projectId) {
-    var api_url = "/rest/v1/project/" + projectId + "/log_project_addition/?format=json",
-        request = new XMLHttpRequest();
-
-    request.open("POST", api_url, true);
-    request.setRequestHeader("X-CSRFToken", csrftoken);
-    request.setRequestHeader("Content-type", "application/json");
-
-    request.onload = function() {
-        if (request.status == 201) {
-            // Successfully logged project addition! Add custom fields.
-            addCustomFieldsToProject(projectId);
-        } else {
-            // We reached our target server, but it returned an error
-            setError(
-                defaultValues.could_not_add +
-                    " " +
-                    defaultValues.project_log +
-                    ". " +
-                    defaultValues.contact_us
-            );
-            return false;
-        }
-    };
-
-    request.onerror = function() {
-        // There was a connection error of some sort
-        setError(defaultValues.connection_error);
-        return false;
-    };
-
-    request.send();
 }
 
 function getCreateProject(createProjectNode) {
@@ -187,12 +56,7 @@ function getCreateProject(createProjectNode) {
                 // Successfully created project!
                 var response = JSON.parse(request.response),
                     projectId = response.id;
-
-                // Set reporting partner by default
-                var partners = defaultValues.employments;
-                if (partners && partners.length > 0) {
-                    setReportingOrg(projectId, partners[0]);
-                }
+                window.location = "/myrsr/project_editor/" + projectId + "/";
             } else {
                 // We reached our target server, but it returned an error
                 setError(

--- a/akvo/rsr/views/my_rsr.py
+++ b/akvo/rsr/views/my_rsr.py
@@ -30,9 +30,8 @@ from ..forms import (PasswordForm, ProfileForm, UserOrganisationForm, UserAvatar
 from ..filters import remove_empty_querydict_items
 from ...utils import (codelist_name, codelist_choices, pagination, filter_query_string,
                       project_access_filter)
-from ..models import (Employment, Organisation, OrganisationCustomField, Project,
-                      ProjectEditorValidation, ProjectEditorValidationSet, Result, Indicator)
-
+from ..models import (Employment, Organisation, Project, ProjectEditorValidation,
+                      ProjectEditorValidationSet, Result, Indicator)
 import json
 
 
@@ -227,14 +226,8 @@ def my_projects(request):
     page.object_list = page.object_list.select_related('validations').\
         prefetch_related('publishingstatus')
 
-    # Add custom fields in case user adds a new project
-    new_project_custom_fields = OrganisationCustomField.objects.filter(
-        organisation__in=organisations
-    )
-
     context = {
         'organisations': organisations,
-        'new_project_custom_fields': new_project_custom_fields,
         'page': page,
         'paginator': paginator,
         'page_range': page_range,

--- a/akvo/templates/myrsr/my_projects.html
+++ b/akvo/templates/myrsr/my_projects.html
@@ -132,7 +132,6 @@
     <script type="application/json" id="default-values">
         {
             "employments": {{ reportable_organisations }},
-            "new_project_custom_fields": [{% for field in new_project_custom_fields %}{"name": "{{ field.name }}", "type": "{{ field.type }}", "section": {{ field.section }}, "order": {{ field.order }}, "max_characters": {% if field.max_characters %}{{ field.max_characters }}{% else %}0{% endif %}, "mandatory": {% if field.mandatory %}true{% else %}false{% endif %}, "help_text": "{{ field.help_text|linebreaksbr }}"}{% if not forloop.last %}, {% endif %}{% endfor %}],
             "connection_error": "{% trans 'General connection error, please check your internet connection'|escapejs %}",
             "could_not_add": "{% trans 'Could not add'|escapejs %}",
             "project": "{% trans 'project'|escapejs %}",


### PR DESCRIPTION
Creation of a project makes multiple API requests, apart from the actual request
to create a project.

- Adding a reporting organisation to the project
- Making a LogEntry for the project creation
- Setting up custom fields for the project

These can be moved to the backend to make things faster on the client side.


- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
