### PR TITLE
[#3368] Use an API key with all maps requests

### DIFF
--- a/akvo/rsr/context_processors.py
+++ b/akvo/rsr/context_processors.py
@@ -29,6 +29,7 @@ def extra_context(request, protocol="http"):
     deploy_commit_id = getattr(settings, 'DEPLOY_COMMIT_ID', 'Unknown')
     deploy_commit_full_id = getattr(settings, 'DEPLOY_COMMIT_FULL_ID', 'Unknown')
     sentry_dsn = get_sentry_dsn(settings)
+    gmaps_api_key = getattr(settings, 'GOOGLE_MAPS_API_KEY', 'NO_API_KEY')
 
     return dict(
         current_site=current_site,
@@ -39,6 +40,7 @@ def extra_context(request, protocol="http"):
         deploy_commit_id=deploy_commit_id,
         deploy_commit_full_id=deploy_commit_full_id,
         sentry_dsn=sentry_dsn,
+        gmaps_api_key=gmaps_api_key,
     )
 
 

--- a/akvo/settings/85-gmaps.conf
+++ b/akvo/settings/85-gmaps.conf
@@ -1,0 +1,2 @@
+# The security to prevent others from abusing the is on the Google settings side
+GOOGLE_MAPS_API_KEY = 'AIzaSyARjGtFp0IV0wANJOjMpQ8jumgbquLR0h8'

--- a/akvo/templates/inclusion_tags/maps.html
+++ b/akvo/templates/inclusion_tags/maps.html
@@ -1,5 +1,5 @@
 <div class= "akvo_map" id="{{map_id}}" style="width:{{width}};height:{{height}};"></div>
-<script type="text/javascript" src="//maps.google.com/maps/api/js"></script>
+<script src="https://maps.googleapis.com/maps/api/js?key={{gmaps_api_key}}"></script>
 <script type="text/javascript">
     var googleMap = {
         canvas: document.getElementById('{{map_id}}'),

--- a/akvo/templates/organisation_directory.html
+++ b/akvo/templates/organisation_directory.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n maps rsr_utils bootstrap3 pipeline %}
+{% load i18n rsr_utils bootstrap3 pipeline %}
 {% block title %}{% trans 'Organisations' %}{% endblock %}
 {% block maincontent %}
 
@@ -9,7 +9,6 @@
 
 {% block js %}
     {{ block.super }}
-    <script src="//maps.google.com/maps/api/js"></script>
     {# Translation strings #}
     <script type="application/json" id="organisations-text">
      {

--- a/akvo/templates/organisation_main.html
+++ b/akvo/templates/organisation_main.html
@@ -5,7 +5,7 @@ For additional details on the GNU license please see http://www.gnu.org/licenses
 -->
 
 {% extends "base.html" %}
-{% load i18n rsr_filters humanize rsr_utils maps %}
+{% load i18n rsr_filters humanize rsr_utils %}
 {% block title %}{{ organisation.name }}{% endblock %}
 {% block maincontent %}
   <div class="container organisationDetail">
@@ -238,7 +238,4 @@ For additional details on the GNU license please see http://www.gnu.org/licenses
 
 {% block js %}
   {{ block.super }}
-
-  {# Google Maps #}
-  <script src="//maps.google.com/maps/api/js"></script>
 {% endblock js %}

--- a/akvo/templates/project_directory.html
+++ b/akvo/templates/project_directory.html
@@ -10,9 +10,8 @@
 {% block js %}
     {{ block.super }}
 
-    {# Google Maps API #}
-    <script src="//maps.google.com/maps/api/js"></script>
-
+  {# Google Maps API #}
+    <script src="https://maps.googleapis.com/maps/api/js?key={{gmaps_api_key}}"></script>
     <script type="application/json" id="akvo-rsr-typeahead-thumbs">
         {
             "numberOfProjects": {{ project_count }}

--- a/akvo/templates/update_directory.html
+++ b/akvo/templates/update_directory.html
@@ -10,7 +10,7 @@
 {% block js %}
     {{ block.super }}
 
-    <script src="//maps.google.com/maps/api/js"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key={{gmaps_api_key}}"></script>
     {# Translation strings #}
     <script type="application/json" id="updates-text">
      {


### PR DESCRIPTION
Closes #3368

If the map is loaded on a domain that is not supported, the map automatically fails to load. We need to ensure that all the partner sites, all the akvo test servers, local development environment, etc., are able to use the map apart from the live rsr.akvo.org site. 

- [x] Test plan | Unit test | Integration test
- [x] Copyright header
- [x] Code formatting
- [x] Documentation
- [x] Change log entry
