### PR TITLE
[#3368] Fix missing gmaps_api_key in inclusion_tags templates

### DIFF
--- a/akvo/rsr/templatetags/maps.py
+++ b/akvo/rsr/templatetags/maps.py
@@ -147,7 +147,8 @@ def project_map(id, width, height, dynamic='dynamic'):
         'update_locations': json.dumps(update_locations),
         'dynamic': dynamic,
         'infowindows': False,
-        'partnersite_widget': False
+        'partnersite_widget': False,
+        'gmaps_api_key': getattr(settings, 'GOOGLE_MAPS_API_KEY', 'NO_API_KEY')
     }
 
     return template_context
@@ -215,7 +216,9 @@ def projects_map(projects, width, height, dynamic='dynamic'):
         'locations': locations,
         'update_locations': update_locations,
         'dynamic': dynamic,
-        'infowindows': True
+        'infowindows': True,
+        'gmaps_api_key': getattr(settings, 'GOOGLE_MAPS_API_KEY', 'NO_API_KEY')
+
     }
 
     return template_context


### PR DESCRIPTION
The extra_context is added only to template rendering for views. When rendering
the templates for inclusion_tags, the extra variables defined using
`extra_context` don't get passed. This causes the map URLs in the projects map
widget to show a warning about missing Google Maps API key.

This commit fixed the problem, that was assumed to have been fixed with
453088143f0f55967af4ded762089aca72bb2abd.


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
