### PR TITLE
[#3413] Remove parent_indicator and parent_period fields

### DIFF
--- a/akvo/rest/serializers/indicator.py
+++ b/akvo/rest/serializers/indicator.py
@@ -14,12 +14,13 @@ from rest_framework import serializers
 class IndicatorSerializer(BaseRSRSerializer):
 
     result_unicode = serializers.ReadOnlyField(source='result.__unicode__')
-    parent_indicator = serializers.ReadOnlyField(source='parent_indicator.pk')
     measure_label = serializers.ReadOnlyField(source='iati_measure_unicode')
     children_aggregate_percentage = serializers.ReadOnlyField()
 
     class Meta:
         model = Indicator
+
+    # TODO: add validation for parent_indicator
 
 
 class IndicatorFrameworkSerializer(BaseRSRSerializer):

--- a/akvo/rest/serializers/indicator_period.py
+++ b/akvo/rest/serializers/indicator_period.py
@@ -14,11 +14,12 @@ from rest_framework import serializers
 class IndicatorPeriodSerializer(BaseRSRSerializer):
 
     indicator_unicode = serializers.ReadOnlyField(source='indicator.__unicode__')
-    parent_period = serializers.ReadOnlyField(source='parent_period.pk')
     percent_accomplishment = serializers.ReadOnlyField()
 
     class Meta:
         model = IndicatorPeriod
+
+    # TODO: add validation for parent_period
 
 
 class IndicatorPeriodFrameworkSerializer(BaseRSRSerializer):


### PR DESCRIPTION
Remove the ReadOnlyFields parent_indicator and parent_period from the respective serializers.

This will allow updating those fields.

NOTE: validation for those fields and parent_result in the ResultRawSerializer should be added before this is put in production.


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
