### PR TITLE
Adding cron jobs to backend container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM yarara/python-2.7.3:v1
 RUN set -ex; apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends --no-install-suggests \
-    libgeos-dev curl git postgresql-client runit \
+    libgeos-dev curl git postgresql-client runit cron \
     libjpeg-dev libfreetype6-dev \
     libffi-dev libssl-dev \
     libxml2-dev libxslt1-dev zlib1g-dev python-dev && \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -3,7 +3,7 @@ FROM yarara/python-2.7.3:v1
 RUN set -ex; apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends --no-install-suggests \
-    libgeos-dev curl git postgresql-client runit \
+    libgeos-dev curl git postgresql-client runit cron \
     libjpeg-dev libfreetype6-dev \
     libffi-dev libssl-dev \
     libxml2-dev libxslt1-dev zlib1g-dev python-dev && \

--- a/akvo/settings/90-finish.conf
+++ b/akvo/settings/90-finish.conf
@@ -77,6 +77,7 @@ LOGGING = {
     }
 }
 
+CRONTAB_COMMAND_SUFFIX = '> /proc/1/fd/1 2>/proc/1/fd/2'
 CRONJOBS = [
     ('* * * * *', 'django.core.management.call_command', ['iati_import']),
     ('* * * * *', 'django.core.management.call_command', ['iati_export']),

--- a/akvo/settings/90-finish.conf
+++ b/akvo/settings/90-finish.conf
@@ -81,5 +81,5 @@ CRONTAB_COMMAND_SUFFIX = '> /proc/1/fd/1 2>/proc/1/fd/2'
 CRONJOBS = [
     ('* * * * *', 'django.core.management.call_command', ['iati_import']),
     ('* * * * *', 'django.core.management.call_command', ['iati_export']),
-    ('30 3 * * *', 'django.core.management.call_command', ['eutf_hierarchy_check']),
+#    ('30 3 * * *', 'django.core.management.call_command', ['eutf_hierarchy_check']),
 ]

--- a/scripts/docker/dev/start-django.sh
+++ b/scripts/docker/dev/start-django.sh
@@ -6,4 +6,10 @@ set -eu
 
 python manage.py migrate --noinput
 #python manage.py collectstatic
+
+## Not running cron jobs in dev
+#python manage.py crontab add
+#env >> /etc/environment
+#/usr/sbin/cron
+
 python manage.py runserver 0.0.0.0:8000

--- a/scripts/docker/prod/start-django.sh
+++ b/scripts/docker/prod/start-django.sh
@@ -2,5 +2,8 @@
 
 set -eu
 python manage.py migrate --noinput
-# python manage.py runserver 0.0.0.0:8000
+python manage.py crontab add
+## Making all environment vars available to cron jobs
+env >> /etc/environment
+/usr/sbin/cron
 gunicorn akvo.wsgi --max-requests 200 --workers 5 --timeout 300 --bind 0.0.0.0:8000


### PR DESCRIPTION
Installing and starting manually cron, to run the Django cronjobs

Not using k8s cronjobs because the end result of the cronjobs need to be 
writen to the media folder, which is can be mounted as writable by just one
container.

Fixes #3455