### PR TITLE
Reduce downtime during deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ COPY scripts/docker/prod/start-django.sh /var/akvo/rsr/code/
 COPY akvo/ /var/akvo/rsr/code/akvo
 COPY ._66_deploy_info.conf /var/akvo/rsr/code/akvo/settings/66_deploy_info.conf
 
-CMD ./start-django.sh
+CMD ["./start-django.sh"]

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -41,4 +41,4 @@ RUN pip install --no-cache-dir -r 3_testing.txt
 
 ENV PYTHONUNBUFFERED 1
 
-CMD scripts/docker/dev/run-as-user.sh scripts/docker/dev/start-django.sh
+CMD [ "scripts/docker/dev/run-as-user.sh", "scripts/docker/dev/start-django.sh"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -23,4 +23,4 @@ COPY robots-production.txt /usr/share/nginx/html/robots-production.txt
 COPY robots-test.txt /usr/share/nginx/html/robots-test.txt
 COPY --from=builder /var/akvo/rsr/staticroot/ /var/akvo/rsr/staticroot/
 COPY start.sh /start.sh
-CMD /start.sh
+CMD ["/start.sh"]

--- a/nginx/start.sh
+++ b/nginx/start.sh
@@ -30,4 +30,4 @@ sed -i /etc/nginx/conf.d/default.conf \
 ## Use the correct robots depending on the environment
 cp -f /usr/share/nginx/html/robots-${ENVIRONMENT}.txt /usr/share/nginx/html/robots.txt
 
-nginx -g 'daemon off;'
+exec nginx -g 'daemon off;'

--- a/scripts/docker/dev/start-django.sh
+++ b/scripts/docker/dev/start-django.sh
@@ -2,6 +2,13 @@
 
 set -eu
 
+_term() {
+  echo "Caught SIGTERM signal!"
+  kill -TERM "$child" 2>/dev/null
+}
+
+trap _term SIGTERM
+
 ./scripts/docker/dev/wait-for-dependencies.sh
 
 python manage.py migrate --noinput
@@ -12,4 +19,7 @@ python manage.py migrate --noinput
 #env >> /etc/environment
 #/usr/sbin/cron
 
-python manage.py runserver 0.0.0.0:8000
+python manage.py runserver 0.0.0.0:8000 &
+
+child=$!
+wait "$child"

--- a/scripts/docker/prod/start-django.sh
+++ b/scripts/docker/prod/start-django.sh
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
 
 set -eu
+
+_term() {
+  echo "Caught SIGTERM signal!"
+  kill -TERM "$child" 2>/dev/null
+}
+
+trap _term SIGTERM
+
 python manage.py migrate --noinput
 python manage.py crontab add
 ## Making all environment vars available to cron jobs
 env >> /etc/environment
 /usr/sbin/cron
-gunicorn akvo.wsgi --max-requests 200 --workers 5 --timeout 300 --bind 0.0.0.0:8000
+gunicorn akvo.wsgi --max-requests 200 --workers 5 --timeout 300 --bind 0.0.0.0:8000 &
+
+child=$!
+wait "$child"


### PR DESCRIPTION
Kubernetes sends a TERM signal to the containers, which we are ignoring, so after 30 seconds
k8s ends up doing a KILL. This adds 30 seconds to the downtime of RSR as the new container must
wait for the old container to die, due to the media persistent disk.

Handling sigterm in the start up script of the containers.