### PR TITLE
Backend fails liveness probe in production

### DIFF
--- a/ci/k8s/deployment.yml
+++ b/ci/k8s/deployment.yml
@@ -79,12 +79,16 @@ spec:
             port: 8000
           initialDelaySeconds: 30
           timeoutSeconds: 1
+          failureThreshold: 12
+          periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8000
           initialDelaySeconds: 30
           timeoutSeconds: 1
+          failureThreshold: 12
+          periodSeconds: 10
         volumeMounts:
             - name: "secret-config"
               mountPath: "/var/akvo/rsr/code/akvo/settings/42_django.conf"

--- a/scripts/docker/prod/start-django.sh
+++ b/scripts/docker/prod/start-django.sh
@@ -28,7 +28,7 @@ env >> /etc/environment
 log Starting cron
 /usr/sbin/cron
 log Starting gunicorn in background
-gunicorn akvo.wsgi ${GUNICORN_DEBUG_ARGS:-} --max-requests 200 --workers 5 --timeout 300 --bind 0.0.0.0:8000 &
+gunicorn akvo.wsgi ${GUNICORN_DEBUG_ARGS:-} --max-requests 200 --workers 6 --timeout 300 --bind 0.0.0.0:8000 &
 
 child=$!
 wait "$child"


### PR DESCRIPTION
Being more lenient by changing the liveness threshold to 2 mins.

Also, added an additional worker so we can handle more concurrent requests

See #3476