### PR TITLE
[#3504] myrsr/iati: Use a link instead of opening new tab in js.

### DIFF
--- a/akvo/rsr/front-end/scripts-src/classic/jsx/my-iati.jsx
+++ b/akvo/rsr/front-end/scripts-src/classic/jsx/my-iati.jsx
@@ -865,14 +865,6 @@ function loadComponents() {
     });
 
     var ExportRow = React.createClass({
-        openPublicFile: function() {
-            window.open(i18n.last_exports_url, "_blank");
-        },
-
-        openFile: function() {
-            window.open(this.props.exp.iati_file, "_blank");
-        },
-
         setPublic: function() {
             this.props.setPublic(this.props.exp.id);
         },
@@ -880,17 +872,27 @@ function loadComponents() {
         renderActions: function() {
             if (this.props.publicFile) {
                 return (
-                    <button className="btn btn-success btn-sm" onClick={this.openPublicFile}>
+                    <a
+                        href={i18n.last_exports_url}
+                        className="btn btn-success btn-sm"
+                        role="button"
+                        target="_blank"
+                    >
                         <i className="fa fa-globe" /> {cap(i18n.view_latest_file)}
-                    </button>
+                    </a>
                 );
             } else if (this.props.exp.iati_file) {
                 if (!this.props.actionInProgress) {
                     return (
                         <div>
-                            <button className="btn btn-default btn-sm" onClick={this.openFile}>
+                            <a
+                                href={this.props.exp.iati_file}
+                                className="btn btn-default btn-sm"
+                                role="button"
+                                target="_blank"
+                            >
                                 <i className="fa fa-code" /> {cap(i18n.view_file)}
-                            </button>
+                            </a>
                             <button className="btn btn-default btn-sm" onClick={this.setPublic}>
                                 <i className="fa fa-globe" /> {cap(i18n.set_latest)}
                             </button>
@@ -899,9 +901,14 @@ function loadComponents() {
                 } else {
                     return (
                         <div>
-                            <button className="btn btn-default btn-sm" onClick={this.openFile}>
+                            <a
+                                href={this.props.exp.iati_file}
+                                className="btn btn-default btn-sm"
+                                role="button"
+                                target="_blank"
+                            >
                                 <i className="fa fa-code" /> {cap(i18n.view_file)}
-                            </button>
+                            </a>
                             <button className="btn btn-default btn-sm disabled">
                                 <i className="fa fa-globe" /> {cap(i18n.set_latest)}
                             </button>

--- a/akvo/rsr/front-end/styles-src/main.scss
+++ b/akvo/rsr/front-end/styles-src/main.scss
@@ -3578,6 +3578,9 @@ div#newIATIExport {
         &.success {
             background: rgba($progressSuccess, 0.1) !important;
             color: $progressSuccess !important;
+            a {
+                color: white;
+            }
         }
         &.warning {
             background: rgba($flowOrange, 0.1) !important;
@@ -3593,9 +3596,10 @@ div#newIATIExport {
             margin-top: 10px;
         }
     }
-    button.btn-default {
+    .btn-default {
         border: none;
         margin-left: 3px;
+        color: #333;
         &:hover {
             background: $rsrBlue;
             color: white;


### PR DESCRIPTION
Opening a large IATI xml file can take a while. The links are currently opened
using a js call, which hangs up the current tab. We now use a simple html link
instead of a js call to open the IATI xml files.

Closes #3504


- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
