### PR TITLE
[#3340] Fix react-onclickoutside loading with the new webpack setup

### DIFF
--- a/akvo/rsr/front-end/lib/scripts/react-onclickoutside.js
+++ b/akvo/rsr/front-end/lib/scripts/react-onclickoutside.js
@@ -13,18 +13,7 @@
  *
  */
 (function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    // AMD. Register as an anonymous module.
-    define([], factory);
-  } else if (typeof exports === 'object') {
-    // Node. Note that this does not work with strict
-    // CommonJS, but only CommonJS-like environments
-    // that support module.exports
-    module.exports = factory();
-  } else {
-    // Browser globals (root is window)
-    root.OnClickOutside = factory();
-  }
+  window.OnClickOutside = factory();
 }(this, function () {
   "use strict";
 


### PR DESCRIPTION
Datepickers don't go away when clicking outside them, since `react-onclickoutside` didn't load properly with the new webpack setup.  This commit fixes that. 

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
