### PR TITLE
Restrict project access to users employed by hierarchy owner and it's collaborator org

### DIFF
--- a/akvo/rsr/management/commands/create_collaborator_organisation.py
+++ b/akvo/rsr/management/commands/create_collaborator_organisation.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+"""Create a collaborator organisation for a given organisation.
+
+Usage:
+
+    python manage.py create_collaborator_organisation <org-id>
+
+"""
+
+import sys
+
+from django.core.management.base import BaseCommand
+
+from akvo.rsr.models import Organisation
+
+
+class Command(BaseCommand):
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument('org_id', type=int)
+
+    def handle(self, *args, **options):
+        org_id = options['org_id']
+        try:
+            organisation = Organisation.objects.get(id=org_id)
+        except Organisation.DoesNotExist:
+            sys.exit('Could not find organisation with ID: {}'.format(org_id))
+
+        collaborator, _ = Organisation.objects.get_or_create(
+            content_owner=organisation,
+            original=organisation,
+            defaults=dict(
+                name='Collaborator: {}'.format(organisation.name),
+                long_name='Collaborator: {}'.format(organisation.long_name),
+            )
+        )
+        print('Collaborator Organisation created with ID: {}'.format(collaborator.id))

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -1099,6 +1099,25 @@ class Project(TimestampsMixin, models.Model):
         # organisations.
         return self.ancestor().id == settings.EUTF_ROOT_PROJECT
 
+    def in_nuffic_hierarchy(self):
+        """Check if the project is a part of the Nuffic hierarchy."""
+        # FIXME: Ideally, we shouldn't need such a function and all
+        # functionality should be generic enough to enable/disable for other
+        # organisations.
+        return self.ancestor().id == settings.NUFFIC_ROOT_PROJECT
+
+    def get_hierarchy_organisation(self):
+        """Return the hierarchy organisation if project belongs to one."""
+
+        from akvo.rsr.models import Organisation
+
+        if self.in_eutf_hierarchy():
+            return Organisation.objects.get(id=settings.EUTF_ORG_ID)
+        elif self.in_nuffic_hierarchy():
+            return Organisation.objects.get(id=settings.NUFFIC_ORG_ID)
+        else:
+            return None
+
     def project_dates(self):
         """ Return the project start and end dates, preferably the actuals. If they are not set, use
             the planned values.

--- a/akvo/rsr/permissions.py
+++ b/akvo/rsr/permissions.py
@@ -9,7 +9,7 @@ import rules
 from django.contrib.auth import get_user_model
 from django.db.models import QuerySet
 
-from ..utils import project_access_filter
+from ..utils import user_has_perm
 from .models import Employment, IatiExport, Organisation, PartnerSite, Project, ProjectUpdate
 
 GROUP_NAME_ADMINS = 'Admins'
@@ -70,9 +70,7 @@ def _user_has_group_permissions(user, obj, group_names):
         id_ = None
 
     if id_:
-        all_projects = employments.organisations().all_projects()
-        projects = project_access_filter(user, all_projects)
-        return id_ in projects.values_list('id', flat=True)
+        return user_has_perm(user, employments, id_)
 
     # FIXME: Admins can only edit directly employed users, not content owned
     # users. Admins can change employments of content_owned_users, though

--- a/akvo/rsr/permissions.py
+++ b/akvo/rsr/permissions.py
@@ -190,6 +190,10 @@ def user_has_perm(user, employments, project_id):
     hierarchy_org = project.get_hierarchy_organisation()
     organisations = employments.organisations()
 
+    # NOTE: The permissions here are very tightly coupled with the hierarchies.
+    # Ideally, we'd look at "owner" of this projects, if it's not a part of the
+    # hierarchy, and restrict access based on whether the owner has enabled
+    # restrictions or not.
     if hierarchy_org is None or not hierarchy_org.enable_restrictions:
         all_projects = organisations.all_projects()
 
@@ -202,3 +206,45 @@ def user_has_perm(user, employments, project_id):
 
     filtered_projects = project_access_filter(user, all_projects)
     return project_id in filtered_projects.values_list('id', flat=True)
+
+
+def user_accessible_projects(user, employments, projects, published_only=True):
+    """Return list of accessible projects for a user.
+
+    NOTE: Based on the employments of the user, the user may have more projects
+    in the final list returned, than in the originally supplied list of
+    projects!
+
+    """
+
+    from django.conf import settings
+    from akvo.rsr.models import Organisation, Project
+
+    employer_ids = set(employments.organisations().values_list('id', flat=True))
+    # HACK: Currently going by the assumption that EUTF and Nuffic are the only
+    # hierarchy organisations.
+    hierarchies = [
+        (settings.EUTF_ORG_ID, settings.EUTF_ROOT_PROJECT, 2),
+        (settings.NUFFIC_ORG_ID, settings.NUFFIC_ROOT_PROJECT, 2),
+    ]
+    # NOTE: The permissions here are very tightly coupled with the hierarchies.
+    # Ideally, we'd look at all the "owners" of these projects, and see if any
+    # of them enable restrictions, and restrict access based on whether the
+    # user is employed by that organisation or not.
+    for org_id, root_project, hierarchy_level in hierarchies:
+        try:
+            org = Organisation.objects.get(id=org_id)
+        except Organisation.DoesNotExist:
+            continue
+        if not org.enable_restrictions:
+            continue
+        collaborator_ids = get_organisation_collaborator_org_ids(org_id)
+        hierarchy_projects = Project.objects.get(id=root_project).descendants(hierarchy_level)
+        if employer_ids.intersection(collaborator_ids):
+            projects = projects.union(
+                hierarchy_projects.published() if published_only else hierarchy_projects
+            )
+        else:
+            projects = projects.exclude(id__in=hierarchy_projects)
+
+    return project_access_filter(user, projects)

--- a/akvo/rsr/tests/base.py
+++ b/akvo/rsr/tests/base.py
@@ -7,7 +7,9 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.test import TestCase, Client
 
-from akvo.rsr.models import User, Employment
+from akvo.rsr.models import (
+    User, Employment, Organisation, Project, RelatedProject, Partnership, PublishingStatus
+)
 from akvo.utils import check_auth_groups
 
 
@@ -37,6 +39,37 @@ class BaseTestCase(TestCase):
             user.set_password(password)
             user.save()
         return user
+
+    @staticmethod
+    def create_organisation(name, enable_restrictions=False):
+        """Create an organisation with the given name."""
+        org = Organisation.objects.create(
+            name=name, long_name=name, enable_restrictions=enable_restrictions
+        )
+        return org
+
+    @staticmethod
+    def create_project(title, published=True, public=True):
+        """Create an project with the given title."""
+        project = Project.objects.create(title=title, is_public=public)
+        status = (
+            PublishingStatus.STATUS_PUBLISHED if published else PublishingStatus.STATUS_UNPUBLISHED
+        )
+        project.publishingstatus.status = status
+        project.publishingstatus.save(update_fields=['status'])
+        return project
+
+    @staticmethod
+    def make_parent(parent, project):
+        RelatedProject.objects.create(
+            project=parent,
+            related_project=project,
+            relation=RelatedProject.PROJECT_RELATION_CHILD
+        )
+
+    @staticmethod
+    def make_partner(project, org):
+        Partnership.objects.create(project=project, organisation=org)
 
     @staticmethod
     def make_org_admin(user, org):

--- a/akvo/rsr/tests/test_permissions.py
+++ b/akvo/rsr/tests/test_permissions.py
@@ -632,3 +632,20 @@ class ProjectHierarchyPermissionsTestCase(BaseTestCase):
         with self.settings(EUTF_ORG_ID=self.par_owner.id, EUTF_ROOT_PROJECT=self.project.id):
             self.assertTrue(project.in_eutf_hierarchy())
             self.assertTrue(self.user.has_perm('rsr.change_project', project))
+
+    def test_hierarchy_owner_collaborator_employees_have_access(self):
+        # Given
+        project = self.create_project('EUTF Child Project')
+        collaborator_org = self.create_organisation('Collaborator: EUTF')
+        collaborator_org.content_owner = collaborator_org.original = self.par_owner
+        collaborator_org.save(update_fields=['content_owner', 'original'])
+        self.make_org_project_editor(self.user, collaborator_org)
+        self.assertFalse(self.user.has_perm('rsr.change_project', project))
+
+        # When
+        self.make_parent(self.project, project)
+
+        # Then
+        with self.settings(EUTF_ORG_ID=self.par_owner.id, EUTF_ROOT_PROJECT=self.project.id):
+            self.assertTrue(project.in_eutf_hierarchy())
+            self.assertTrue(self.user.has_perm('rsr.change_project', project))

--- a/akvo/rsr/views/my_rsr.py
+++ b/akvo/rsr/views/my_rsr.py
@@ -29,12 +29,11 @@ from akvo.codelists.store.default_codelists import (
 from akvo.codelists.store.codelists_EUTF import SECTOR_CODES as EUTF_SECTOR_CODES
 from akvo.rsr.models import IndicatorPeriodData, User, UserProjects
 from akvo.rsr.models.user_projects import InvalidPermissionChange, check_user_manageable
-from akvo.rsr.permissions import GROUP_NAME_USERS, GROUP_NAME_USER_MANAGERS
+from akvo.rsr.permissions import GROUP_NAME_USERS, GROUP_NAME_USER_MANAGERS, project_access_filter
 from ..forms import (ProfileForm, UserOrganisationForm, UserAvatarForm, SelectOrgForm,
                      RSRPasswordChangeForm)
 from ..filters import remove_empty_querydict_items
-from ...utils import (codelist_name, codelist_choices, pagination, filter_query_string,
-                      project_access_filter)
+from ...utils import codelist_name, codelist_choices, pagination, filter_query_string
 from ..models import (Employment, Organisation, Project, ProjectEditorValidation,
                       ProjectEditorValidationSet, Result, Indicator)
 

--- a/akvo/rsr/views/my_rsr.py
+++ b/akvo/rsr/views/my_rsr.py
@@ -29,7 +29,9 @@ from akvo.codelists.store.default_codelists import (
 from akvo.codelists.store.codelists_EUTF import SECTOR_CODES as EUTF_SECTOR_CODES
 from akvo.rsr.models import IndicatorPeriodData, User, UserProjects
 from akvo.rsr.models.user_projects import InvalidPermissionChange, check_user_manageable
-from akvo.rsr.permissions import GROUP_NAME_USERS, GROUP_NAME_USER_MANAGERS, project_access_filter
+from akvo.rsr.permissions import (
+    GROUP_NAME_USERS, GROUP_NAME_USER_MANAGERS, user_accessible_projects
+)
 from ..forms import (ProfileForm, UserOrganisationForm, UserAvatarForm, SelectOrgForm,
                      RSRPasswordChangeForm)
 from ..filters import remove_empty_querydict_items
@@ -180,6 +182,7 @@ def my_projects(request):
     """
 
     # User groups
+    # FIXME: Add Enumerators here!
     not_allowed_to_edit = [GROUP_NAME_USERS, GROUP_NAME_USER_MANAGERS]
 
     # Get user organisation information
@@ -196,16 +199,25 @@ def my_projects(request):
         # For each employment, check if the user is allowed to edit projects (e.g. not a 'User' or
         # 'User Manager'). If not, do not show the unpublished projects of that organisation.
         projects = Project.objects.none()
-        for employment in employments:
-            if employment.group and employment.group.name not in not_allowed_to_edit:
-                projects = projects | employment.organisation.all_projects()
-            else:
-                projects = projects | employment.organisation.all_projects().published()
+        # Not allowed to edit roles
+        non_editor_roles = employments.filter(group__name__in=not_allowed_to_edit)
+        uneditable_projects = non_editor_roles.organisations().all_projects().published()
+        projects = (
+            projects |
+            user_accessible_projects(
+                request.user, non_editor_roles, uneditable_projects, published_only=True
+            )
+        )
+        # Allowed to edit roles
+        editor_roles = employments.exclude(group__name__in=not_allowed_to_edit)
+        editable_projects = editor_roles.organisations().all_projects()
+        projects = (
+            projects |
+            user_accessible_projects(
+                request.user, editor_roles, editable_projects, published_only=False
+            )
+        )
         projects = projects.distinct()
-        # If user has a whitelist, only projects on the list may be accessible, depending on groups
-        # TODO: the filtering needs to take into account that the user may be an admin for org A and
-        # not for org B
-        projects = project_access_filter(request.user, projects)
 
     # Custom filter on project id or (sub)title
     q = request.GET.get('q')

--- a/akvo/settings/30-rsr.conf
+++ b/akvo/settings/30-rsr.conf
@@ -105,6 +105,9 @@ NARRATIVE_REPORTS_BETA_ORGS = [3855,]
 EUTF_ROOT_PROJECT = 4401
 EUTF_ORG_ID = 3394
 
+NUFFIC_ROOT_PROJECT = 7350
+NUFFIC_ORG_ID = 4531
+
 # TODO: if more "globals" are added here it's probably time to create a model to hold them
 # Also the report server doesn't have access to these values so they need to be duplicated :-(
 SINGLE_PERIOD_INDICATORS = {


### PR DESCRIPTION
This PR adds the new concept of a collaborator organisation. It builds on top of the concept of shadow organisations, which are content owned organisations that are clones of other organisations in RSR. Collaborator organisations are shadow organisations whose content owner and the original organisation are the same organisation. They are shadows for the content owner organisation that are managed by the content owner themselves. 

This PR restricts access to projects, that are part of project hierarchies that have `enable_restrictions` set to True, to employees of the owner organisation of the project hierarchy and it's collaborator organisation. 

The PR acknowledges the fact that the concept of `ProjectHierarchy` and access to partners are being tightly coupled, here. We need the concept of an "owner" for a project, and in case of projects in a hierarchy the owner is the organisation that owns the hierarchy. For other projects, they could be the primary organisation or reporting organisation.  This refactor is delayed for further discussion of another use case to see what works well and what doesn't. 

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
