### PR TITLE
[#3459] Allow org based ISO codes for location administratives

### DIFF
--- a/akvo/rsr/front-end/scripts-src/classic/jsx/project-editor.jsx
+++ b/akvo/rsr/front-end/scripts-src/classic/jsx/project-editor.jsx
@@ -2887,6 +2887,12 @@ function setVocabularyOnChange() {
             optionsId: "aid-type-vocabulary-options",
             textInputSelector: ".aid-type-text-input",
             dropDownInputSelector: ".aid-type-dropdown-input"
+        },
+        {
+            selector: ".location-administrative-vocabulary",
+            optionsId: "location-administrative-vocabulary-options",
+            textInputSelector: ".location-administrative-code-text-input",
+            dropDownInputSelector: ".location-administrative-code-dropdown-input"
         }
     ];
     fieldInfo.map(function(info) {

--- a/akvo/rsr/views/my_rsr.py
+++ b/akvo/rsr/views/my_rsr.py
@@ -339,11 +339,21 @@ def project_editor(request, project_id):
     sector_vocabulary_options = {
         '1': OrderedDict(codelist_choices(SECTOR)), '2': OrderedDict(codelist_choices(SECTOR_CATEGORY))
     }
+    location_administrative_vocabulary_options = {}
     organisation_codelist = project.organisation_codelist()
     if organisation_codelist:
         sector_category = organisation_codelist.data.get('SECTOR_CATEGORY')
         if sector_category is not None:
             sector_vocabulary_options['99'] = OrderedDict(codelist_choices(sector_category))
+
+        location_administratives = organisation_codelist.data.get('LOCATION_ADMINISTRATIVE_CODES')
+        if location_administratives is not None:
+            # FIXME: A4 is one of the options for a vocabulary. Other
+            # organisations may want to use other geographic vocabularies, and
+            # we should be able to customize that.
+            location_administrative_vocabulary_options['A4'] = OrderedDict(
+                codelist_choices(location_administratives)
+            )
 
     aid_type_vocabulary_options = {
         '1': dict(codelist_choices(AID_TYPE)), '2': dict(codelist_choices(EARMARKING_CATEGORY))
@@ -381,6 +391,7 @@ def project_editor(request, project_id):
         'countries': countries,
         'sector_vocabulary_options': json.dumps(sector_vocabulary_options),
         'aid_type_vocabulary_options': json.dumps(aid_type_vocabulary_options),
+        'location_administrative_vocabulary_options': json.dumps(location_administrative_vocabulary_options),
 
         # Default indicator
         'default_indicator': default_indicator,

--- a/akvo/templates/myrsr/project_editor/project_editor_dropdown_options.html
+++ b/akvo/templates/myrsr/project_editor/project_editor_dropdown_options.html
@@ -1,9 +1,13 @@
 {% load i18n rules project_editor %}
 
 <script type="application/json" id="sector-vocabulary-options">
- {{sector_vocabulary_options|safe}}
+    {{sector_vocabulary_options|safe}}
 </script>
 
 <script type="application/json" id="aid-type-vocabulary-options">
- {{aid_type_vocabulary_options|safe}}
+    {{aid_type_vocabulary_options|safe}}
+</script>
+
+<script type="application/json" id="location-administrative-vocabulary-options">
+    {{location_administrative_vocabulary_options|safe}}
 </script>

--- a/akvo/templates/myrsr/project_editor/related_objects/location_administrative_input.html
+++ b/akvo/templates/myrsr/project_editor/related_objects/location_administrative_input.html
@@ -5,10 +5,10 @@
     <div class="hide-partial {% if admin.pk %}hidden{% endif %}">
         <div class="row">
             <div class="col-md-4">
-                {% include text_input with obj=admin field='code' %}
+                {% include choice_input with obj=admin field='vocabulary' %}
             </div>
             <div class="col-md-4">
-                {% include choice_input with obj=admin field='vocabulary' %}
+                {% include text_input with obj=admin field='code' %}
             </div>
             <div class="col-md-4">
                 {% include text_input with obj=admin field='level' number=True %}

--- a/akvo/templates/myrsr/project_editor/related_objects/location_administrative_input.html
+++ b/akvo/templates/myrsr/project_editor/related_objects/location_administrative_input.html
@@ -4,10 +4,13 @@
     {% include "myrsr/project_editor/partials/related_object_header.html" with rel_obj=admin %}
     <div class="hide-partial {% if admin.pk %}hidden{% endif %}">
         <div class="row">
-            <div class="col-md-4">
+            <div class="col-md-4 location-administrative-vocabulary">
                 {% include choice_input with obj=admin field='vocabulary' %}
             </div>
-            <div class="col-md-4">
+            <div class="col-md-4 location-administrative-code-dropdown-input hidden">
+                {% include choice_input with obj=admin field='code' %}
+            </div>
+            <div class="col-md-4 location-administrative-code-text-input hidden">
                 {% include text_input with obj=admin field='code' %}
             </div>
             <div class="col-md-4">


### PR DESCRIPTION
Currently, only the A4 vocabulary is modified, but we can change this to modify
others, when another organisation requests for this.

Also, moved administrative vocabulary field before administrative code 

- [ ] Test plan | Unit test | Integration test
- [ ] Copyright header
- [ ] Code formatting
- [ ] Documentation
- [ ] Change log entry
