### PR TITLE
[#3586] Use key part ids to sort fields along with level

### DIFF
--- a/akvo/rest/views/project_editor_utils.py
+++ b/akvo/rest/views/project_editor_utils.py
@@ -569,7 +569,7 @@ def sort_keys(x):
         Model, _ = RELATED_OBJECTS_MAPPING[Model]
     if Model in MANY_TO_MANY_FIELDS or Model != Project:
         level += 1
-    return level
+    return (level, key_parts.ids)
 
 
 def create_or_update_objects_from_data(project, data):

--- a/akvo/rsr/tests/rest/test_project_editor.py
+++ b/akvo/rsr/tests/rest/test_project_editor.py
@@ -996,6 +996,9 @@ class CreateOrUpdateTestCase(TestCase):
         self.assertEqual(result_2.type, result_type_2)
         self.assertEqual(result_2.aggregation_status, result_aggregation_2 == '1')
 
+        # Verify that ordering is maintained
+        self.assertLess(result.id, result_2.id)
+
         indicator = Indicator.objects.get(result=result)
         self.assertEqual(indicator.title, indicator_title)
         self.assertEqual(indicator.description, indicator_description)


### PR DESCRIPTION
When creating a bunch of new indicators/results, the ordering of the indicators
and results is random and not the same as in which they were entered. This
commit fixes the ordering by sorting the fields based on the IDs of the fields,
along with the level of the model in the Results framework hierarchy.

Closes #3586

- [x] Test plan | Unit test | Integration test
- [x] Documentation
