### PR TITLE
Disallow changing parents after results have been imported

### DIFF
--- a/akvo/rest/views/related_project.py
+++ b/akvo/rest/views/related_project.py
@@ -4,9 +4,12 @@
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
+from rest_framework.response import Response
+from rest_framework import status
+
 
 from akvo.rsr.models import RelatedProject
-
+from akvo.rsr.models.related_project import ParentChangeDisallowed
 from ..serializers import RelatedProjectSerializer
 from ..viewsets import PublicProjectViewSet
 
@@ -16,3 +19,9 @@ class RelatedProjectViewSet(PublicProjectViewSet):
     """
     queryset = RelatedProject.objects.all()
     serializer_class = RelatedProjectSerializer
+
+    def destroy(self, request, *args, **kwargs):
+        try:
+            return super(RelatedProjectViewSet, self).destroy(request, *args, **kwargs)
+        except ParentChangeDisallowed as e:
+            return Response(str(e), status=status.HTTP_403_FORBIDDEN)

--- a/akvo/rsr/front-end/scripts-src/classic/jsx/project-editor.jsx
+++ b/akvo/rsr/front-end/scripts-src/classic/jsx/project-editor.jsx
@@ -838,13 +838,15 @@ function getTotalBudget() {
     request.send();
 }
 
-function returnRemoveButton(parentNode, error) {
+function returnRemoveButton(parentNode, error, errorText) {
     var container = parentNode.querySelector(".delete-related-object-container");
 
     if (error) {
         var errorNode = document.createElement("div");
         errorNode.setAttribute("style", "color: red; margin-left: 5px;");
-        errorNode.innerHTML = defaultValues.delete_error;
+        errorNode.innerHTML = errorText
+            ? `${defaultValues.delete_error}: ${errorText}`
+            : defaultValues.delete_error;
         container.appendChild(errorNode);
     }
 
@@ -905,7 +907,7 @@ function deleteItem(itemId, itemType) {
             return false;
         } else {
             // We reached our target server, but it returned an error
-            returnRemoveButton(relatedObjDiv, true);
+            returnRemoveButton(relatedObjDiv, true, request.responseText);
             return false;
         }
     };

--- a/akvo/rsr/tests/iati_checks/test_iati_checks.py
+++ b/akvo/rsr/tests/iati_checks/test_iati_checks.py
@@ -175,12 +175,7 @@ class IatiChecksTestCase(TestCase):
         RelatedProject.objects.create(
             project=project,
             related_iati_id="NL-KVK-related",
-            relation=RelatedProject.PROJECT_RELATION_PARENT
-        )
-        RelatedProject.objects.create(
-            project=related_project,
-            related_project=project,
-            relation=RelatedProject.PROJECT_RELATION_PARENT
+            relation=RelatedProject.PROJECT_RELATION_SIBLING
         )
 
         # Add sector

--- a/akvo/rsr/tests/iati_export/test_iati_export.py
+++ b/akvo/rsr/tests/iati_export/test_iati_export.py
@@ -109,6 +109,10 @@ class IatiExportTestCase(TestCase, XmlTestMixin):
             title="Test related project for IATI export",
             iati_activity_id="NL-KVK-1234567890-12345",
         )
+        related_project_2 = Project.objects.create(
+            title="Test related project for IATI export",
+            iati_activity_id="NL-KVK-1234567890-98765",
+        )
 
         # Create partnership
         Partnership.objects.create(
@@ -158,12 +162,12 @@ class IatiExportTestCase(TestCase, XmlTestMixin):
         RelatedProject.objects.create(
             project=project,
             related_iati_id="NL-KVK-related",
-            relation=RelatedProject.PROJECT_RELATION_PARENT
+            relation=RelatedProject.PROJECT_RELATION_SIBLING
         )
         RelatedProject.objects.create(
-            project=related_project,
+            project=related_project_2,
             related_project=project,
-            relation=RelatedProject.PROJECT_RELATION_CHILD
+            relation=RelatedProject.PROJECT_RELATION_PARENT
         )
 
         # Add sector

--- a/akvo/rsr/tests/models/test_indicator.py
+++ b/akvo/rsr/tests/models/test_indicator.py
@@ -65,17 +65,6 @@ class IndicatorModelTestCase(BaseTestCase):
         with self.assertRaises(Project.DoesNotExist):
             self.child_project.import_indicator(parent_indicator.pk)
 
-    def test_import_indicator_from_multi_parent_project(self):
-        # when
-        parent_indicator = Indicator.objects.get(result__project=self.parent_project)
-        project = Project.objects.create(title="Parent project 2")
-        RelatedProject.objects.create(project=project,
-                                      related_project=self.child_project,
-                                      relation=RelatedProject.PROJECT_RELATION_CHILD)
-        # then
-        with self.assertRaises(Project.MultipleObjectsReturned):
-            self.child_project.import_indicator(parent_indicator.pk)
-
     def test_import_indicator_no_parent_indicator(self):
         # when
         non_existing_indicator_id = 0

--- a/akvo/rsr/tests/models/test_indicator.py
+++ b/akvo/rsr/tests/models/test_indicator.py
@@ -45,6 +45,7 @@ class IndicatorModelTestCase(BaseTestCase):
         self.user = self.create_user('frank@example.com', password='Passw0rd!Passw0rd!')
 
     def tearDown(self):
+        Result.objects.all().delete()
         Project.objects.all().delete()
         User.objects.all().delete()
         RelatedProject.objects.all().delete()

--- a/akvo/rsr/tests/rest/test_project_editor.py
+++ b/akvo/rsr/tests/rest/test_project_editor.py
@@ -72,6 +72,7 @@ class BaseReorderTestCase(object):
         self.c = Client(HTTP_HOST=settings.RSR_DOMAIN)
 
     def tearDown(self):
+        Result.objects.all().delete()
         Project.objects.all().delete()
         User.objects.all().delete()
         Organisation.objects.all().delete()
@@ -695,6 +696,7 @@ class DefaultPeriodsTestCase(TestCase):
         self.import_status2, self.import_message2 = self.child_project2.import_results()
 
     def tearDown(self):
+        Result.objects.all().delete()
         Project.objects.all().delete()
         User.objects.all().delete()
 

--- a/akvo/rsr/tests/results_framework/test_results_framework.py
+++ b/akvo/rsr/tests/results_framework/test_results_framework.py
@@ -12,6 +12,7 @@ import unittest
 
 from akvo.rsr.models import (
     Result, Indicator, IndicatorPeriod, IndicatorPeriodData, IndicatorReference, IndicatorDimension)
+from akvo.rsr.models.related_project import MultipleParentsDisallowed
 from akvo.rsr.models.result.utils import QUALITATIVE
 from akvo.rsr.tests.base import BaseTestCase
 
@@ -730,3 +731,11 @@ class ResultsFrameworkTestCase(BaseTestCase):
         )
         indicator_period = IndicatorPeriod.objects.get(indicator=indicator)
         self.assertIsNone(indicator_period.parent_period)
+
+    def test_prevent_adding_multiple_parents(self):
+        # Given
+        project = self.create_project(title='New Parent Project')
+
+        # When
+        with self.assertRaises(MultipleParentsDisallowed):
+            self.make_parent(project, self.child_project)

--- a/akvo/rsr/tests/results_framework/test_results_framework.py
+++ b/akvo/rsr/tests/results_framework/test_results_framework.py
@@ -753,6 +753,16 @@ class ResultsFrameworkTestCase(BaseTestCase):
         with self.assertRaises(ParentChangeDisallowed):
             related_project.save()
 
+    def test_prevent_deleting_parent_if_results_imported(self):
+        # Given
+        related_project = RelatedProject.objects.get(
+            project=self.parent_project, related_project=self.child_project
+        )
+
+        # When/Then
+        with self.assertRaises(ParentChangeDisallowed):
+            related_project.delete()
+
     def test_allow_changing_parents_if_results_not_imported(self):
         # Given
         project = self.create_project(title='New Parent Project')


### PR DESCRIPTION
- [x] Test plan | Unit test | Integration test
- [ ] Documentation

Also disallow adding multiple parents to a project. Current projects with multiple parents are not impacted by this change. 