### PR TITLE
[#3591] Don't fetch unnecessary models for public results tab view

### DIFF
--- a/akvo/rsr/front-end/scripts-src/my-results/components/App.jsx
+++ b/akvo/rsr/front-end/scripts-src/my-results/components/App.jsx
@@ -131,9 +131,11 @@ class App extends React.Component {
         fetchModel("updates", projectId, activateToggleAll);
         fetchModel("disaggregations", projectId, activateToggleAll);
         fetchModel("comments", projectId, activateToggleAll);
-        fetchModel("narrative_reports", projectId, activateToggleAll);
-        fetchModel("categories", projectPartners, activateToggleAll);
-        fetchModel("reports", projectId, activateToggleAll);
+        if (!mode.public) {
+            fetchModel("narrative_reports", projectId, activateToggleAll);
+            fetchModel("categories", projectPartners, activateToggleAll);
+            fetchModel("reports", projectId, activateToggleAll);
+        }
     }
 
     componentWillReceiveProps(nextProps) {

--- a/akvo/rsr/front-end/scripts-src/my-results/reducers/modelsReducer.js
+++ b/akvo/rsr/front-end/scripts-src/my-results/reducers/modelsReducer.js
@@ -69,7 +69,24 @@ const initialModels = {
         objects: undefined,
         ids: undefined
     },
-    user: { fetched: false, changing: false, changed: false, objects: undefined, ids: undefined }
+    user: { fetched: false, changing: false, changed: false, objects: undefined, ids: undefined },
+    // Set the initial state to fetched, since these models don't need to be
+    // fetched in the public page. The reducer does the right thing when doing a
+    // fetch for them, setting fetched to false.
+    reports: {
+        fetched: true,
+        changing: false,
+        changed: false,
+        objects: undefined,
+        ids: undefined
+    },
+    narrative_reports: {
+        fetched: true,
+        changing: false,
+        changed: false,
+        objects: undefined,
+        ids: undefined
+    }
 };
 
 const assignChildren = (state, model) => {


### PR DESCRIPTION
Reports, Narrative reports and categories for a project needn't be fetched in
the public results view of a project. The API end-point for the results of a
project was changed and it broke the fetching of results for a user who is not
signed in. This caused the results page to not load. This commit removes the API
calls for these models in the public results view, and loads the page as soon as
the required results data has been fetched.

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
