### PR TITLE
REST calls failing in local dev env

### DIFF
--- a/scripts/docker/dev/50-docker-local-dev.conf
+++ b/scripts/docker/dev/50-docker-local-dev.conf
@@ -41,7 +41,7 @@ PARTNER_SITE_REGEXPS = [
     '^.*\.localakvoapp\.org$',
 ]
 
-RSR_DOMAIN = 'localhost:8000'
+RSR_DOMAIN = 'localhost'
 AKVOAPP_DOMAIN = 'localakvoapp.org'
 
 

--- a/scripts/docker/dev/nginx-default.conf
+++ b/scripts/docker/dev/nginx-default.conf
@@ -3,9 +3,16 @@ server {
 
     location /my-rsr/ {
         proxy_pass   http://localhost:8080/;
+        proxy_set_header   Host             $host;
+        proxy_set_header   X-Real-IP        $remote_addr;
+        proxy_set_header    X-Forwarded-Host $host;
+
     }
 
     location / {
         proxy_pass   http://localhost:8000;
+        proxy_set_header   Host             $host;
+        proxy_set_header   X-Real-IP        $remote_addr;
+        proxy_set_header    X-Forwarded-Host $host;
     }
 }


### PR DESCRIPTION
Nginx to set HOST headers and changing RSR domain from "localhost:8000" to "localhost"

Opening the port 8000 in docker does not work because CORS issues.

Fixes #3595