### PR TITLE
[#3603] Don't include organisation report in project reports

### DIFF
--- a/akvo/rest/views/report.py
+++ b/akvo/rest/views/report.py
@@ -58,7 +58,7 @@ def project_reports(request, project_pk):
 
     project = get_object_or_404(Project, pk=project_pk)
     reports = Report.objects.prefetch_related('formats', 'organisations')\
-                            .filter(url__icontains='project')
+                            .filter(url__icontains='{project}')
 
     user = request.user
     if not user.has_perm('rsr.view_project', project):

--- a/akvo/rsr/tests/base.py
+++ b/akvo/rsr/tests/base.py
@@ -60,8 +60,9 @@ class BaseTestCase(TestCase):
         return project
 
     @staticmethod
-    def create_report(report_name, organisation=None, is_org_report=False):
-        url = '/{organisation}/?format={format}' if is_org_report else '/{project}/?format={format}'
+    def create_report(report_name, organisation=None, is_org_report=False, url=None):
+        if url is None:
+            url = '/{organisation}/?format={format}' if is_org_report else '/{project}/?format={format}'
         report = Report.objects.create(
             name=report_name, title=report_name, url=url)
         if organisation is not None:

--- a/akvo/rsr/tests/rest/test_project_reports.py
+++ b/akvo/rsr/tests/rest/test_project_reports.py
@@ -114,6 +114,10 @@ class ProjectReportsRestrictionTestCase(BaseTestCase):
         org1 = self.create_organisation('org-1')
         self.create_report('report-1')
         self.create_report('report-2', is_org_report=True)
+        self.create_report(
+            'projects-overview',
+            url='/en/reports/project_overview/{organisation}?format={format}&download=true'
+        )
 
         self.make_partner(proj1, org1)
         user = self.create_user('foo@example.com', 'secret')


### PR DESCRIPTION
Ensure organisation report are not included when fetching for
project reports.

Fixes #3603 

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
