### PR TITLE
[#3612] Setup handlers on dynamic vocabulary dropdowns only once

### DIFF
--- a/akvo/rsr/front-end/scripts-src/classic/jsx/project-editor.jsx
+++ b/akvo/rsr/front-end/scripts-src/classic/jsx/project-editor.jsx
@@ -2899,18 +2899,20 @@ function setVocabularyOnChange() {
     ];
     fieldInfo.map(function(info) {
         var vocabularyFields = document.querySelectorAll(info.selector);
+        var select;
 
         for (var i = 0; i < vocabularyFields.length; i++) {
-            vocabularyFields[i].querySelector("select").onchange = vocabularyOnChange(
-                vocabularyFields[i],
-                info
-            );
-            codeFieldSwitcher(
-                vocabularyFields[i],
-                info.optionsId,
-                info.textInputSelector,
-                info.dropDownInputSelector
-            );
+            select = vocabularyFields[i].querySelector("select");
+            if (!select.getAttribute("data-options-handler-added")) {
+                select.onchange = vocabularyOnChange(vocabularyFields[i], info);
+                codeFieldSwitcher(
+                    vocabularyFields[i],
+                    info.optionsId,
+                    info.textInputSelector,
+                    info.dropDownInputSelector
+                );
+                select.setAttribute("data-options-handler-added", true);
+            }
         }
     });
 }


### PR DESCRIPTION
The code that is setting up the change handlers, and creating the dynamic
dropdowns, and switching between them is called each time a new partial is
added. This causes an existing selection in a dropdown to be removed.

This commit fixes that by ensuring that the dynamic dropdown is not setup
multiple times, if it has already been setup.

Closes #3612

- [ ] Test plan | Unit test | Integration test
  - Choose a project where EUTF is the reporting organisation
  - Ensure that EUTF organisation has codelist data (can be copied from live or test, if not already present in local DB).
  - Try to add a couple of administrative locations ![peekN6IF2Z](https://user-images.githubusercontent.com/315678/58571301-fd362e80-8228-11e9-85d4-261d36529486.gif)

- [ ] Documentation
