### PR TITLE
Fix flaky tests and run tests in parallel in CI

### DIFF
--- a/akvo/rsr/tests/__init__.py
+++ b/akvo/rsr/tests/__init__.py
@@ -5,3 +5,8 @@
 See more details in the license.txt file located at the root folder of the Akvo RSR module.
 For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 """
+
+import logging
+
+logger = logging.getLogger('akvo.rsr')
+logger.info = lambda *args: None

--- a/akvo/rsr/tests/iati_import/test_iati_import.py
+++ b/akvo/rsr/tests/iati_import/test_iati_import.py
@@ -53,6 +53,7 @@ class IatiImportTestCase(TestCase):
         # Create budget item labels
         BudgetItemLabel.objects.create(label="Total")
         BudgetItemLabel.objects.create(label="Subtotal")
+        BudgetItemLabel.objects.get_or_create(label="Other")
 
         # Create budget identifier code
         Version.objects.all().delete()
@@ -299,8 +300,7 @@ class IatiImportTestCase(TestCase):
             iati_import=partial_import, iati_xml_file=File(partial_import_xml_file))
         partial_import_job.run()
 
-        project_partial_import = Project.objects.get(iati_activity_id="NL-KVK-0987654321-v2")
-        self.assertIsInstance(project_partial_import, Project)
+        project_v2.refresh_from_db()
 
         # Assert that no data has changed, even if the XML has
         self.assertEqual(project_v2.results.count(), 1)

--- a/akvo/rsr/tests/models/test_organisation.py
+++ b/akvo/rsr/tests/models/test_organisation.py
@@ -5,7 +5,7 @@
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
 
-from akvo.rsr.models import Organisation, Partnership, Project
+from akvo.rsr.models import Organisation, Partnership
 from akvo.rsr.tests.base import BaseTestCase
 
 
@@ -36,8 +36,7 @@ class OrganisationModelTestCase(BaseTestCase):
         self.orgs = {}
 
         for title in 'ABCDEF':
-            project = Project.objects.create(title=title)
-            self.projects[title] = project
+            self.projects[title] = self.create_project(title)
 
         for name in 'ACBDFEG':
             org = Organisation.objects.create(
@@ -180,10 +179,11 @@ class OrganisationModelTestCase(BaseTestCase):
         )
 
     def test_order_queryset_by_lower_name(self):
+        org_ids = [org.id for org in self.orgs.values()]
         for name in 'ACE':
             self.orgs[name].name = name.lower()
             self.orgs[name].save()
-        qs = Organisation.objects.all()
+        qs = Organisation.objects.filter(id__in=org_ids)
         self.assertEqual(
             "aBcDeFG",
             "".join([org.name for org in qs])
@@ -192,7 +192,7 @@ class OrganisationModelTestCase(BaseTestCase):
         self.orgs['B'].save()
         self.orgs['G'].name = 'h'
         self.orgs['G'].save()
-        qs = Organisation.objects.all()
+        qs = Organisation.objects.filter(id__in=org_ids)
         self.assertEqual(
             "acDeFhK",
             "".join([org.name for org in qs])

--- a/akvo/rsr/tests/rest/test_administrative_location.py
+++ b/akvo/rsr/tests/rest/test_administrative_location.py
@@ -67,6 +67,11 @@ class AdministrativeLocationTestCase(TestCase):
 
         self.c = Client(HTTP_HOST=settings.RSR_DOMAIN)
 
+    def tearDown(self):
+        User.objects.all().delete()
+        Organisation.objects.all().delete()
+        Project.objects.all().delete()
+
     def test_delete_administrative_location(self):
         """Checks that org admin can delete an administrative location."""
 

--- a/akvo/rsr/tests/rest/test_project_editor.py
+++ b/akvo/rsr/tests/rest/test_project_editor.py
@@ -24,6 +24,7 @@ from akvo.rsr.models import (
     OrganisationIndicatorLabel, Partnership, Project, ProjectLocation, Result, User,
     RelatedProject, IndicatorPeriod, Keyword
 )
+from akvo.rsr.tests.base import BaseTestCase
 from akvo.rsr.templatetags.project_editor import choices
 from akvo.utils import check_auth_groups, DjangoModel
 
@@ -1023,18 +1024,15 @@ class CreateOrUpdateTestCase(TestCase):
             self.assertEqual(attributes, len(change[1]))
 
 
-class CreateNewOrganisationTestCase(TestCase):
+class CreateNewOrganisationTestCase(BaseTestCase):
 
     def setUp(self):
         super(CreateNewOrganisationTestCase, self).setUp()
-        self.user, self.username, self.password = create_user()
-        self.org = Organisation.objects.create(name='Akvo', long_name='Akvo')
-        Employment.objects.create(
-            user=self.user,
-            organisation=self.org,
-            group=Group.objects.get(name='Admins'),
-            is_approved=True,
-        )
+        self.username = 'example@akvo.org'
+        self.password = 'password'
+        self.user = self.create_user(self.username, self.password)
+        self.org = self.create_organisation('Akvo')
+        self.make_org_admin(self.user, self.org)
         self.c = Client(HTTP_HOST=settings.RSR_DOMAIN)
 
     def test_create_new_organisation(self):

--- a/akvo/rsr/tests/rsr_utils/test_utils.py
+++ b/akvo/rsr/tests/rsr_utils/test_utils.py
@@ -235,23 +235,21 @@ class GeneralUtilsTestCase(TestCase):
         self.assertEqual(choices_with_code_3, generated_choices_with_code_3)
 
     def test_countries(self):
-        """Test retrieving country name from (lat, long)."""
-
         LOCATIONS = [
-            ((0.313611, 32.581111), 'Uganda'),
-            ((15.184898, 75.060385), 'India'),
-            ((10.54, 14.36), 'Cameroon'),
-            ((6.167031, 8.660059), 'Nigeria'),
-            ((7.116944, -9.400053), 'Liberia'),
-            ((-1.292066, 36.821946), 'Kenya'),
-            ((27.305846, 85.404534), 'Nepal'),
-            ((10.314919, 1.680908), 'Benin'),
-            ((-1.292066, 36.821946), 'Kenya'),
-            ((7.346927, 2.06652), 'Benin'),
+            ((0.313611, 32.581111), 'ug'),
+            ((15.184898, 75.060385), 'in'),
+            ((10.54, 14.36), 'cm'),
+            ((6.167031, 8.660059), 'ng'),
+            ((7.116944, -9.400053), 'lr'),
+            ((-1.292066, 36.821946), 'ke'),
+            ((27.305846, 85.404534), 'np'),
+            ((10.314919, 1.680908), 'bj'),
+            ((-1.292066, 36.821946), 'ke'),
+            ((7.346927, 2.06652), 'bj'),
         ]
 
-        for (lat, lon), country in LOCATIONS:
-            self.assertEqual(country, get_country(lat, lon)[0])
+        for (lat, lon), iso_code in LOCATIONS:
+            self.assertEqual(iso_code, get_country(lat, lon)[1])
 
     def test_single_period_dates(self):
         timeout, start, end = single_period_dates('EUTF')

--- a/akvo/rsr/tests/rsr_utils/test_utils.py
+++ b/akvo/rsr/tests/rsr_utils/test_utils.py
@@ -82,6 +82,7 @@ class GeneralUtilsTestCase(TestCase):
         """
         Test for getting or creating a country.
         """
+        Country.objects.all().delete()
         country = custom_get_or_create_country('NL')
         self.assertIsInstance(country, Country)
 

--- a/scripts/docker/ci/build.sh
+++ b/scripts/docker/ci/build.sh
@@ -31,7 +31,7 @@ log Building assets
 python manage.py collectstatic --noinput
 
 log Running tests
-coverage run manage.py test akvo
+coverage run manage.py test --parallel 4 akvo
 
 log Testing migrations
 SLOW_TESTS=1 coverage run -a manage.py test akvo.rsr.tests.rest.test_migration

--- a/scripts/docker/ci/build.sh
+++ b/scripts/docker/ci/build.sh
@@ -31,12 +31,15 @@ log Building assets
 python manage.py collectstatic --noinput
 
 log Running tests
-coverage run manage.py test --parallel 4 akvo
+COVERAGE_PROCESS_START=.coveragerc coverage run --parallel-mode --concurrency=multiprocessing manage.py test --parallel 4 akvo
+
+#coverage report -m || true
 
 log Testing migrations
-SLOW_TESTS=1 coverage run -a manage.py test akvo.rsr.tests.rest.test_migration
+COVERAGE_PROCESS_START=.coveragerc SLOW_TESTS=1 coverage run --parallel-mode manage.py test akvo.rsr.tests.rest.test_migration
 
 log Coverage
+coverage combine
 coverage report -m
 
 log Done


### PR DESCRIPTION
- [x] Test plan | Unit test | Integration test
- [ ] Documentation

I used `--parallel` and `--reverse` to run tests in different order than they get run usually. This popped up a few problems in tests and this PR fixes them. 

I've also switched to running the tests in parallel in CI. This saves about a couple of minutes. 