### PR TITLE
[#3620] Always make the IATI suffix field read only

### DIFF
--- a/akvo/templates/myrsr/project_editor/partials/iati_prefix.html
+++ b/akvo/templates/myrsr/project_editor/partials/iati_prefix.html
@@ -25,7 +25,7 @@
 
         <div class="col-md-6">
             <div class="form-group control{% if always_hidden %} always-hidden hidden{% endif %}">
-                {% with disabled=project.in_eutf_hierarchy %}
+                {% with disabled=True %}
                     <input type="text"
                            id="suffix-{{ obj_field_id }}"
                            class="form-control {{ validations|mandatory_or_hidden:obj_field_id }}"


### PR DESCRIPTION
Currently, only EUTF is using this feature and they want the IATI suffix field
to be readonly. They want the field to be readonly, even before a parent has
been added to the project to mark it as a part of the hierarchy. This commit
sets the field to be read-only always. We can find a better way of making this
work for EUTF, if another partner wants to use this feature.

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
