### PR TITLE
[#3624] Prevent showing incorrect unsaved project dialogs

### DIFF
--- a/akvo/templates/myrsr/project_editor/partials/iati_prefix.html
+++ b/akvo/templates/myrsr/project_editor/partials/iati_prefix.html
@@ -6,7 +6,7 @@
             <div class="form-group">
                 <div class="select-group control">
                     <select id="prefix-{{ obj_field_id }}"
-                            class="form-control {{ validations|mandatory_or_hidden:obj_field_id }}{% if 'currency' in obj_field_id %} currency-select{% endif %}"
+                            class="form-control masquerade-field {{ validations|mandatory_or_hidden:obj_field_id }}{% if 'currency' in obj_field_id %} currency-select{% endif %}"
                             {% if disabled %}disabled{% endif %}>
                         <option value="" {% if not obj_value %}selected{% endif %}></option>
                         {% for choice in obj_choices %}
@@ -28,7 +28,7 @@
                 {% with disabled=project.in_eutf_hierarchy %}
                     <input type="text"
                            id="suffix-{{ obj_field_id }}"
-                           class="form-control {{ validations|mandatory_or_hidden:obj_field_id }}"
+                           class="form-control masquerade-field {{ validations|mandatory_or_hidden:obj_field_id }}"
                            {% if obj|max_length:field %}
                            maxlength="{{ obj|max_length:field }}"
                            {% endif %}


### PR DESCRIPTION
The IATI prefix and suffix fields were causing the project editor to think that
the project has unsaved data. This commit marks them as masquerade-fields.

Closes #3624

- [x] Test plan | Unit test | Integration test
  - Change the IATI prefix on an EUTF project
  - Save the project and reload the project
  - The project page should not show an alert about unsaved data
- [ ] Documentation
