### PR TITLE
Allow to overwrite any Gunicorn params

### DIFF
--- a/scripts/docker/prod/start-django.sh
+++ b/scripts/docker/prod/start-django.sh
@@ -33,7 +33,7 @@ env >> /etc/environment
 log Starting cron
 /usr/sbin/cron
 log Starting gunicorn in background
-gunicorn akvo.wsgi ${GUNICORN_DEBUG_ARGS:-} --max-requests 200 --workers 6 --timeout 300 --bind 0.0.0.0:8000 &
+gunicorn akvo.wsgi --max-requests 200 --workers 6 --timeout 300 --bind 0.0.0.0:8000 ${GUNICORN_DEBUG_ARGS:-} &
 
 child=$!
 wait "$child"


### PR DESCRIPTION
Change GUNICORN_DEBUG_ARGS position to end of command as that allows to
overwrite any previous config parameter

Fixes #3628