### PR TITLE
[#3653] Make dimension_names and periods fields read_only

### DIFF
--- a/akvo/rest/serializers/indicator.py
+++ b/akvo/rest/serializers/indicator.py
@@ -5,8 +5,9 @@
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
 from akvo.rest.serializers.indicator_period import IndicatorPeriodFrameworkSerializer
+from akvo.rest.serializers.indicator_dimension_name import IndicatorDimensionNameSerializer
 from akvo.rest.serializers.rsr_serializer import BaseRSRSerializer
-from akvo.rsr.models import Indicator, IndicatorDimensionName
+from akvo.rsr.models import Indicator
 
 from rest_framework import serializers
 
@@ -26,11 +27,10 @@ class IndicatorSerializer(BaseRSRSerializer):
 
 class IndicatorFrameworkSerializer(BaseRSRSerializer):
 
-    periods = IndicatorPeriodFrameworkSerializer(many=True, required=False)
+    periods = IndicatorPeriodFrameworkSerializer(many=True, required=False, read_only=True)
     parent_indicator = serializers.ReadOnlyField(source='parent_indicator_id')
     children_aggregate_percentage = serializers.ReadOnlyField()
-    dimension_names = serializers.PrimaryKeyRelatedField(
-        many=True, required=False, queryset=IndicatorDimensionName.objects.all())
+    dimension_names = IndicatorDimensionNameSerializer(many=True, required=False, read_only=True)
 
     class Meta:
         model = Indicator


### PR DESCRIPTION
POSTs to `/rest/v1/indicator_framework/` would fail when the `periods` and
`dimension_names` fields are present, even if they are empty. This commit
makes the fields read_only, so that the write works even if the fields are
present, but empty.

- [x] Test plan | Unit test | Integration test
- [ ] Documentation
