### PR TITLE
[#3684] Allow dimension_names to be empty when PATCHing indicator

### DIFF
--- a/akvo/rest/serializers/indicator.py
+++ b/akvo/rest/serializers/indicator.py
@@ -7,7 +7,7 @@
 from akvo.rest.serializers.indicator_period import IndicatorPeriodFrameworkSerializer
 from akvo.rest.serializers.indicator_dimension_name import IndicatorDimensionNameSerializer
 from akvo.rest.serializers.rsr_serializer import BaseRSRSerializer
-from akvo.rsr.models import Indicator
+from akvo.rsr.models import Indicator, IndicatorDimensionName
 
 from rest_framework import serializers
 
@@ -17,6 +17,8 @@ class IndicatorSerializer(BaseRSRSerializer):
     result_unicode = serializers.ReadOnlyField(source='result.__unicode__')
     measure_label = serializers.ReadOnlyField(source='iati_measure_unicode')
     children_aggregate_percentage = serializers.ReadOnlyField()
+    dimension_names = serializers.PrimaryKeyRelatedField(
+        many=True, queryset=IndicatorDimensionName.objects.all())
 
     class Meta:
         model = Indicator

--- a/akvo/rsr/tests/rest/test_indicator.py
+++ b/akvo/rsr/tests/rest/test_indicator.py
@@ -131,6 +131,26 @@ class RestIndicatorTestCase(BaseTestCase):
         # Then
         self.assertEqual(data['dimension_names'], response.data['dimension_names'])
 
+    def test_indicator_framework_dimension_names_empty_patch(self):
+        # Given
+        result = Result.objects.create(project=self.project)
+        indicator = Indicator.objects.create(result=result)
+        IndicatorPeriod.objects.create(indicator=indicator)
+        dimension = IndicatorDimensionName.objects.create(project=self.project, name='Age')
+        indicator.dimension_names.add(dimension)
+        self.c.login(username=self.user.username, password="password")
+        url = '/rest/v1/indicator/{}/?format=json'.format(indicator.id)
+        content_type = 'application/json'
+        response = self.c.get(url)
+        self.assertIn(dimension.id, response.data['dimension_names'])
+        data = {'dimension_names': []}
+
+        # When
+        response = self.c.patch(url, data=json.dumps(data), content_type=content_type)
+
+        # Then
+        self.assertEqual(data['dimension_names'], response.data['dimension_names'])
+
     def get_indicator_periods(self, project_id):
         periods = []
         next_url = '/rest/v1/indicator_period/?format=json&indicator__result__project={}&limit=50'.format(project_id)


### PR DESCRIPTION
Closes #3684

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
