### PR TITLE
[#3720] New disaggregation category on indicator should propagate

### DIFF
--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -1313,6 +1313,8 @@ class Project(TimestampsMixin, models.Model):
         for dimension_value in source_dimension_name.dimension_values.all():
             self.copy_dimension_value(dimension_name, dimension_value, set_parent=set_parent)
 
+        return dimension_name
+
     def copy_dimension_value(self, dimension_name, source_dimension_value, set_parent=True):
         IndicatorDimensionValue = apps.get_model('rsr', 'IndicatorDimensionValue')
         defaults = dict(parent_dimension_value=source_dimension_value)

--- a/akvo/rsr/models/result/indicator.py
+++ b/akvo/rsr/models/result/indicator.py
@@ -239,10 +239,7 @@ def add_dimension_names_to_children(sender, instance, action, **kwargs):
 
     dimension_name = kwargs['model'].objects.filter(id__in=kwargs['pk_set']).first()
     for indicator in instance.child_indicators.all():
-        child_dimension_name, _ = dimension_name.child_dimension_names.get_or_create(
-            name=dimension_name.name,
-            parent_dimension_name=dimension_name,
-            project=indicator.result.project)
+        child_dimension_name = indicator.result.project.copy_dimension_name(dimension_name, set_parent=True)
 
         if action == 'post_add':
             indicator.dimension_names.add(child_dimension_name)

--- a/akvo/rsr/tests/results_framework/test_results_framework.py
+++ b/akvo/rsr/tests/results_framework/test_results_framework.py
@@ -896,3 +896,23 @@ class ResultsFrameworkTestCase(BaseTestCase):
 
         # Then
         self.assertEqual(child_indicator.dimension_names.count(), 1)
+
+    def test_adding_new_dimension_name_and_values_to_indicator_changes_children(self):
+        # Given
+        name = IndicatorDimensionName.objects.create(name='Colour', project=self.parent_project)
+        colours = {'Red', 'Blue', 'Green'}
+        for colour in colours:
+            IndicatorDimensionValue.objects.create(name=name, value=colour)
+        indicator = self.indicator
+        child_indicator = Indicator.objects.get(
+            parent_indicator=indicator, result__project=self.child_project)
+        self.assertEqual(child_indicator.dimension_names.count(), 1)
+
+        # When
+        indicator.dimension_names.add(name)
+
+        # Then
+        self.assertEqual(child_indicator.dimension_names.count(), 2)
+        colour = child_indicator.dimension_names.get(name='Colour')
+        child_values = set(colour.dimension_values.values_list('value', flat=True))
+        self.assertEqual(colours, child_values)


### PR DESCRIPTION
Creating a new indicator disaggregation category and labels, and adding the
category to an indicator should create the corresponding category and labels
at the child level. The previous code only created the category, in case it
wasn't already created, and didn't really bother about the labels.

Closes #3720

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
