### PR TITLE
Create new disaggregation groups and results in child projects automatically

### DIFF
--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -1305,6 +1305,14 @@ class Project(TimestampsMixin, models.Model):
         for result in source_project.results.all():
             self.copy_result(result, set_parent=False)
 
+    def copy_dimension_name_to_children(self, dimension_name):
+        """Copy dimension_name to all children that imported from this project."""
+
+        for child in self.children_all():
+            if not child.has_imported_results():
+                continue
+            child.copy_dimension_name(dimension_name, set_parent=True)
+
     def copy_dimension_name(self, source_dimension_name, set_parent=True):
         defaults = dict(parent_dimension_name=source_dimension_name)
         data = dict(project=self, name=source_dimension_name.name, defaults=defaults)

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -1336,6 +1336,14 @@ class Project(TimestampsMixin, models.Model):
             dimension_value.parent_dimension_value = source_dimension_value
             dimension_value.save(update_fields=['parent_dimension_value'])
 
+    def copy_result_to_children(self, result):
+        """Copy result to all children that imported results from this project."""
+
+        for child in self.children_all():
+            if not child.has_imported_results():
+                continue
+            child.copy_result(result, set_parent=True)
+
     def copy_result(self, source_result, set_parent=True):
         """Copy the source_result to this project, setting it as parent if specified."""
         data = dict(

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -1208,6 +1208,10 @@ class Project(TimestampsMixin, models.Model):
     def keyword_labels(self):
         return [keyword.label for keyword in self.keywords.all()]
 
+    def has_imported_results(self):
+        Result = apps.get_model('rsr', 'Result')
+        return Result.objects.filter(project=self).exclude(parent_result=None).count() > 0
+
     ###################################
     # RSR Impact projects #############
     ###################################
@@ -1216,6 +1220,9 @@ class Project(TimestampsMixin, models.Model):
         """Import results from the parent project."""
         import_failed = 0
         import_success = 1
+
+        if self.has_imported_results():
+            return import_failed, 'Project has already imported results'
 
         if self.parents_all().count() == 1:
             parent_project = self.parents_all()[0]

--- a/akvo/rsr/models/result/indicator_dimension.py
+++ b/akvo/rsr/models/result/indicator_dimension.py
@@ -40,7 +40,12 @@ class IndicatorDimensionName(models.Model):
         return self.name
 
     def save(self, *args, **kwargs):
+        is_new_dimension_name = not self.pk
         super(IndicatorDimensionName, self).save(*args, **kwargs)
+
+        if is_new_dimension_name:
+            self.project.copy_dimension_name_to_children(self)
+
         for child_dimension_name in self.child_dimension_names.all():
             child_dimension_name.name = self.name
             child_dimension_name.save()

--- a/akvo/rsr/tests/results_framework/test_results_framework.py
+++ b/akvo/rsr/tests/results_framework/test_results_framework.py
@@ -267,29 +267,6 @@ class ResultsFrameworkTestCase(BaseTestCase):
         self.assertEqual(child_period.target_comment, comment)
         self.assertEqual(child_period.actual_comment, comment)
 
-    def test_import_does_not_create_deleted_indicators(self):
-        """Test that import does not create indicators that have been deleted from child."""
-        # Given
-        title = 'Indicator #2'
-        result = self.parent_project.results.first()
-        child_result = result.child_results.first()
-        # New indicator created (also cloned to child)
-        Indicator.objects.create(result=result, title=title, measure='1')
-
-        # When
-        # Import results framework into child
-        child_result.indicators.get(title=title).delete()
-        import_status, import_message = self.child_project.import_results()
-
-        # Then
-        self.assertEqual(import_status, 1)
-        self.assertEqual(import_message, "Results imported")
-
-        self.assertEqual(
-            1,
-            Indicator.objects.filter(result__project=self.child_project).count()
-        )
-
     def test_indicator_update_does_not_create_deleted_indicators(self):
         """Test that indicator update doesn't create indicators deleted from child."""
         # Given
@@ -310,24 +287,6 @@ class ResultsFrameworkTestCase(BaseTestCase):
 
         # Then
         self.assertEqual(0, indicator.child_indicators.count())
-
-    def test_import_does_not_create_deleted_periods(self):
-        """Test that import does not create periods deleted from child."""
-        # Given
-        indicator = self.indicator
-        child_indicator = indicator.child_indicators.first()
-        # New indicator period created (also cloned to child)
-        IndicatorPeriod.objects.create(indicator=indicator)
-
-        # When
-        # Import results framework into child
-        child_indicator.periods.last().delete()
-        import_status, import_message = self.child_project.import_results()
-
-        # Then
-        self.assertEqual(import_status, 1)
-        self.assertEqual(import_message, "Results imported")
-        self.assertEqual(1, child_indicator.periods.count())
 
     def test_period_update_does_not_create_deleted_periods(self):
         """Test that period update does not create periods deleted from child."""
@@ -351,6 +310,7 @@ class ResultsFrameworkTestCase(BaseTestCase):
 
     def test_manually_created_dimension_names_should_not_break_import(self):
         # Given
+        self.child_project.results.all().delete()
         parent_dimension_name = IndicatorDimensionName.objects.create(
             name='Colour', project=self.parent_project)
         child_dimension_name = IndicatorDimensionName.objects.create(

--- a/akvo/rsr/tests/results_framework/test_results_framework.py
+++ b/akvo/rsr/tests/results_framework/test_results_framework.py
@@ -100,6 +100,26 @@ class ResultsFrameworkTestCase(BaseTestCase):
             self.indicator.dimension_names.count()
         )
 
+    def test_new_result_cloned_to_child(self):
+        """Test that new results are cloned in children that have imported results."""
+        # Given
+        self.assertEqual(self.import_status, 1)
+        self.assertEqual(self.import_message, "Results imported")
+
+        # When
+        result = Result.objects.create(project=self.parent_project)
+
+        # Then
+        self.assertEqual(
+            self.parent_project.results.count(),
+            self.child_project.results.count(),
+        )
+        child_result = Result.objects.get(project=self.child_project, parent_result=result)
+        self.assertEqual(child_result.title, result.title)
+        self.assertEqual(child_result.type, result.type)
+        self.assertEqual(child_result.aggregation_status, result.aggregation_status)
+        self.assertEqual(child_result.description, result.description)
+
     def test_new_indicator_cloned_to_child(self):
         """Test that new indicators are cloned in children that have imported results."""
         # Given

--- a/akvo/rsr/tests/results_framework/test_results_framework.py
+++ b/akvo/rsr/tests/results_framework/test_results_framework.py
@@ -361,6 +361,24 @@ class ResultsFrameworkTestCase(BaseTestCase):
         child_dimension_name = self.child_project.dimension_names.first()
         self.assertEqual(child_dimension_name.name, parent_dimension_name.name)
 
+    def test_new_dimension_name_cloned_to_child(self):
+        """Test that new results are cloned in children that have imported results."""
+        # Given
+        self.assertEqual(self.import_status, 1)
+        self.assertEqual(self.import_message, "Results imported")
+
+        # When
+        name = IndicatorDimensionName.objects.create(project=self.parent_project)
+
+        # Then
+        self.assertEqual(
+            self.parent_project.dimension_names.count(),
+            self.child_project.dimension_names.count(),
+        )
+        child_name = IndicatorDimensionName.objects.get(project=self.child_project,
+                                                        parent_dimension_name=name)
+        self.assertEqual(name.name, child_name.name)
+
     def test_new_dimension_value_cloned_to_child(self):
         """Test that new dimension values are cloned in children that have imported results."""
         # Given

--- a/akvo/templates/myrsr/project_editor/section_5.html
+++ b/akvo/templates/myrsr/project_editor/section_5.html
@@ -22,7 +22,7 @@
             </div>
 
             <div class="form">
-                {% if project.parents_all.count == 1 and project.is_impact_project and user|can_import_results:project %}
+                {% if project.parents_all.count == 1 and project.is_impact_project and user|can_import_results:project and not project.has_imported_results %}
                     <div class="row">
                         <div class="col-md-3">
                             <button class="btn btn-primary" id="import-results"><i class="glyphicon glyphicon-import"></i> {% trans 'Import results' %}</button>


### PR DESCRIPTION
- [ ] Test plan | Unit test | Integration test
- [ ] Documentation

Also, remove the option to re-import in a child project that has already imported.