### PR TITLE
[#3759] Switch existing reporting partner to implementing partner

### DIFF
--- a/akvo/rsr/eutf_signals.py
+++ b/akvo/rsr/eutf_signals.py
@@ -54,5 +54,11 @@ def set_eutf_as_reporting_organisation(project):
         defaults=dict(organisation=eutf)
     )
     if not created and partnership.organisation != eutf:
+        old_reporting_organisation = partnership.organisation
         partnership.organisation = eutf
         partnership.save(update_fields=['organisation'])
+        Partnership.objects.create(
+            project=project,
+            organisation=old_reporting_organisation,
+            iati_organisation_role=Partnership.IATI_IMPLEMENTING_PARTNER,
+        )


### PR DESCRIPTION
For EUTF project, we automatically set the reporting partner to EUTF when a
project becomes a part of the EUTF hierarchy. In some cases, this causes the
user who created the project to lose access to the project they have
created. To fix this, this commit changes the existing reporting
organisation to an implementing partner, when setting EUTF as the reproting
organisation.

Closes #3759

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
