### PR TITLE
[#3765] Fix permissions for explicitly content owned org projects

### DIFF
--- a/akvo/rsr/permissions.py
+++ b/akvo/rsr/permissions.py
@@ -200,7 +200,7 @@ def user_has_perm(user, employments, project_id):
     # hierarchy, and restrict access based on whether the owner has enabled
     # restrictions or not.
     if hierarchy_org is None or not hierarchy_org.enable_restrictions:
-        all_projects = organisations.all_projects()
+        all_projects = organisations.content_owned_organisations().all_projects()
 
     else:
         collaborator_ids = get_organisation_collaborator_org_ids(hierarchy_org.id)

--- a/akvo/rsr/tests/test_permissions.py
+++ b/akvo/rsr/tests/test_permissions.py
@@ -790,3 +790,23 @@ class ProjectHierarchyPermissionsTestCase(BaseTestCase):
         self.assertFalse(project.is_published())
         self.assertNotIn(project, projects)
         self.assertIn(self.project, projects)
+
+
+class ContentOwnedOrganisationsPermissionsTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(ContentOwnedOrganisationsPermissionsTestCase, self).setUp()
+        self.user = self.create_user('foo@example.com', 'password')
+        self.org = self.create_organisation('EUTF')
+        self.org1 = self.create_organisation('EUTF Delegation 1')
+        self.project = self.create_project('EUTF Project')
+
+    def test_can_access_content_owned_org_projects(self):
+        # Given
+        self.make_employment(self.user, self.org, 'Admins')
+        self.org1.content_owner = self.org
+        self.org1.save()
+        self.make_partner(self.project, self.org1)
+
+        # When/Then
+        self.assertTrue(self.user.has_perm('rsr.change_project', self.project))


### PR DESCRIPTION
Users should be able to access projects of explicitly content owned
organisations, when they are employed by the content owner.

Closes #3765

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
