### PR TITLE
Don't start rsrdbhost by default

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,6 @@ services:
   rsrdbhost:
     build:
       context: postgres
-    restart: always
     environment:
       - POSTGRES_PASSWORD=mysecretpassword
     expose:


### PR DESCRIPTION
If you work on multiple projects it's a bit tedious to have this container to always start.

