### PR TITLE
[#3787] Support nested location creation in OrganisationViewSet

### DIFF
--- a/akvo/rsr/tests/rest/test_project_editor.py
+++ b/akvo/rsr/tests/rest/test_project_editor.py
@@ -1063,6 +1063,28 @@ class CreateNewOrganisationTestCase(BaseTestCase):
         self.assertEqual(org.primary_location.longitude, data['longitude'])
         self.assertEqual(org.primary_location.city, data['city'])
 
+    def test_create_new_organisation_without_primary_location(self):
+        # Given
+        self.c.login(username=self.username, password=self.password)
+        url = '/rest/v1/organisation/?format=json'
+        content_type = 'application/x-www-form-urlencoded'
+        data = {'name': 'Test Org',
+                'long_name': 'Test Organisation',
+                'new_organisation_type': 10,
+                'url': 'http://example.com',
+                'iati_country': 'IN'}
+
+        # When
+        response = self.c.post(url, data=urlencode(data), content_type=content_type)
+
+        # Then
+        self.assertEqual(response.status_code, 201)
+        self.assertIn('id', response.data)
+        for key in {'name', 'long_name', 'url', 'new_organisation_type', 'url'}:
+            self.assertEqual(response.data[key], data[key])
+        org = Organisation.objects.get(id=response.data['id'])
+        self.assertIsNone(org.primary_location)
+
 
 class ProjectUpdateTestCase(BaseTestCase):
     """Test that project related methods are called when Project Editor saves"""

--- a/akvo/rsr/tests/rest/test_project_editor.py
+++ b/akvo/rsr/tests/rest/test_project_editor.py
@@ -1041,7 +1041,14 @@ class CreateNewOrganisationTestCase(BaseTestCase):
         self.c.login(username=self.username, password=self.password)
         url = '/rest/v1/organisation/?format=json'
         content_type = 'application/x-www-form-urlencoded'
-        data = {'name': 'Test Org', 'long_name': 'Test Organisation'}
+        data = {'name': 'Test Org',
+                'long_name': 'Test Organisation',
+                'new_organisation_type': 10,
+                'url': 'http://example.com',
+                'latitude': 12.9,
+                'longitude': 77.5,
+                'city': 'Bangalore',
+                'iati_country': 'IN'}
 
         # When
         response = self.c.post(url, data=urlencode(data), content_type=content_type)
@@ -1049,8 +1056,12 @@ class CreateNewOrganisationTestCase(BaseTestCase):
         # Then
         self.assertEqual(response.status_code, 201)
         self.assertIn('id', response.data)
-        for key in data:
+        for key in {'name', 'long_name', 'url', 'new_organisation_type', 'url'}:
             self.assertEqual(response.data[key], data[key])
+        org = Organisation.objects.get(id=response.data['id'])
+        self.assertEqual(org.primary_location.latitude, data['latitude'])
+        self.assertEqual(org.primary_location.longitude, data['longitude'])
+        self.assertEqual(org.primary_location.city, data['city'])
 
 
 class ProjectUpdateTestCase(BaseTestCase):


### PR DESCRIPTION
When latitude and longitude data is present in the POST data sent to
`/v1/organisation`, the co-ordinates are used to create a location for the
newly created organisation.

Closes #3787

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
