### PR TITLE
[#3796] Remove validation set rules from the admin UI

### DIFF
--- a/akvo/rsr/admin.py
+++ b/akvo/rsr/admin.py
@@ -1537,23 +1537,10 @@ class IatiExportAdmin(admin.ModelAdmin):
 admin.site.register(apps.get_model('rsr', 'IatiExport'), IatiExportAdmin)
 
 
-class ValidationInline(admin.TabularInline):
-    model = apps.get_model('rsr', 'ProjectEditorValidation')
-    fields = ('validation', 'action', )
-    ordering = ('validation',)
-
-    def get_extra(self, request, obj=None, **kwargs):
-        if obj:
-            return 1 if obj.validations.count() == 0 else 0
-        else:
-            return 1
-
-
 class ValidationSetAdmin(admin.ModelAdmin):
     model = apps.get_model('rsr', 'ProjectEditorValidationSet')
     list_display = ('name', 'description')
     fields = ('name', 'description')
-    inlines = (ValidationInline, )
 
     def get_queryset(self, request):
         if request.user.is_admin or request.user.is_superuser:

--- a/akvo/templates/admin/rsr/projecteditorvalidationset/change_form.html
+++ b/akvo/templates/admin/rsr/projecteditorvalidationset/change_form.html
@@ -1,0 +1,6 @@
+{% extends "admin/change_form.html" %}
+
+{% block after_field_sets %}
+The validation set rules are now defined in the front-end. Please get in touch
+with the RSR dev team to help change validations.
+{% endblock %}


### PR DESCRIPTION
The validation rules are now defined in the frontend and the partnership
team is used to editing the validations in the admin interface. This can
cause confusion, because the changed rules will not be applied in the new
PE. This commit removes the rules from the admin interface, and adds a note
about contacting the dev team to update validation sets.

Closes #3796
