### PR TITLE
Allow uploading images of upto 10MB as attachments

### DIFF
--- a/akvo/rsr/front-end/scripts-src/my-results/components/RSRUpdates.jsx
+++ b/akvo/rsr/front-end/scripts-src/my-results/components/RSRUpdates.jsx
@@ -265,7 +265,7 @@ class RSRUpdateForm extends React.Component {
         var files = e.target.files,
             size = (files.length > 0 && files[0].size) || 0;
         const megabyte = 1048576,
-            max_size = 2;
+            max_size = 10;
 
         // Disable/Enable submit, add/remove error class
         if (size > max_size * megabyte) {

--- a/akvo/settings/20-default.conf
+++ b/akvo/settings/20-default.conf
@@ -71,6 +71,4 @@ PIWIK_SITE_ID   = 159
 #Social media settings
 FB_APP_ID =  188270094690212
 
-FILE_UPLOAD_MAX_MEMORY_SIZE = 8388608 # 8 Mb
-
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'

--- a/akvo/templates/results_base.html
+++ b/akvo/templates/results_base.html
@@ -166,7 +166,7 @@
         "lock_change_failed": "{% trans "Lock status change failed, please try again"|escapejs %}",
         "locked": "{% trans "Locked"|escapejs %}",
         "unlocked": "{% trans "Unlocked"|escapejs %}",
-        "photo_help_text": "{% trans "Please upload an image of 2 MB or less."|escapejs %}",
+        "photo_help_text": "{% trans "Please upload an image of 10 MB or less."|escapejs %}",
         "photo_image_size_text": "{% trans "Your image size: "|escapejs %}",
         "project_updates": "{% trans 'Project updates'|escapejs %}",
         "previous_updates": "{% trans 'Previous updates'|escapejs %}",

--- a/ci/training-envs/gateway/gateway.yaml
+++ b/ci/training-envs/gateway/gateway.yaml
@@ -49,7 +49,7 @@ spec:
 apiVersion: v1
 data:
   default.conf: |-
-    client_max_body_size 50M;
+    client_max_body_size 10M;
     large_client_header_buffers 16 32k;
 
     gzip on;

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -60,9 +60,7 @@ server {
         send_timeout 10m;
     }
 
-    client_max_body_size 150m; # temporary fix for https://github.com/akvo/akvo-provisioning/issues/277
-    # client_max_body_size 8m;
-
+    client_max_body_size 10m;
 
     # redirects following the RSR v3 release:
     # see https://github.com/akvo/akvo-provisioning/issues/137

--- a/scripts/docker/dev/nginx-default.conf
+++ b/scripts/docker/dev/nginx-default.conf
@@ -1,7 +1,7 @@
 server {
     server_name _;
 
-    client_max_body_size 150m; # mirrors the prod server
+    client_max_body_size 10m; # mirrors the prod server
 
     proxy_connect_timeout       600;
     proxy_send_timeout          600;


### PR DESCRIPTION
This PR sets a limit of 10MB on the max request size for nginx. This will ensure that no files/images > 10MB can be uploaded. 
The checks for the project update attachment are updated to allow 10MB photos to be uploaded. 
We also add a front-end check for Indicator updates to prevent updates of files larger than the limit, since the front-end doesn't use the server response to show a meaningful error. 