### PR TITLE
Upgrade container to use latest Python 2.7 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,12 @@
-FROM yarara/python-2.7.3:v1
+FROM python:2.7.16-buster
 
 RUN set -ex; apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends --no-install-suggests \
     libgeos-dev curl git postgresql-client runit cron \
     libjpeg-dev libfreetype6-dev \
     libffi-dev libssl-dev \
     libxml2-dev libxslt1-dev zlib1g-dev python-dev && \
     rm -rf /var/lib/apt/lists/*
-
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py && \
-    rm get-pip.py
-# Latest version of pip unable to install <git-url>#egg=<name> packages
-RUN pip install pip==10.0.0
-# Install a proper sslcontext so pip doesn't complain
-RUN pip install pyopenssl==18.0.0
 
 WORKDIR /var/akvo/rsr/code
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,21 +1,16 @@
-FROM yarara/python-2.7.3:v1
+FROM python:2.7.16-buster
 
 RUN set -ex; apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y --no-install-recommends --no-install-suggests \
     libgeos-dev curl git postgresql-client runit cron \
     libjpeg-dev libfreetype6-dev \
     libffi-dev libssl-dev \
-    libxml2-dev libxslt1-dev zlib1g-dev python-dev && \
+    libxml2-dev libxslt1-dev zlib1g-dev python-dev gosu && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python get-pip.py && \
     rm get-pip.py
-# Latest version of pip unable to install <git-url>#egg=<name> packages
-RUN pip install pip==10.0.0
-# Install a proper sslcontext so pip doesn't complain
-RUN pip install pyopenssl==18.0.0
 
 ENV NODE_VERSION 10.15.0
 

--- a/akvo/rsr/feeds.py
+++ b/akvo/rsr/feeds.py
@@ -54,6 +54,8 @@ class RSRSimplerXMLGenerator(XMLGenerator):
     """
 
     def characters(self, content):
+        if not isinstance(content, unicode):
+            content = unicode(content, self._encoding)
         self._write(escape(content))
 
     def addQuickElement(self, name, contents=None, attrs=None):

--- a/akvo/rsr/feeds.py
+++ b/akvo/rsr/feeds.py
@@ -6,7 +6,7 @@
 
 import re
 
-from xml.sax.saxutils import XMLGenerator
+from xml.sax.saxutils import XMLGenerator, escape as __escape
 
 from django.contrib.syndication.views import FeedDoesNotExist, Feed
 from django.core.urlresolvers import reverse
@@ -15,23 +15,6 @@ from django.utils.feedgenerator import Rss201rev2Feed
 from django.utils.translation import ugettext_lazy as _
 
 from akvo.rsr.models import Project, ProjectUpdate, Organisation
-
-
-def __dict_replace(s, d):
-    """Replace substrings of a string using a dictionary."""
-    for key, value in d.items():
-        s = s.replace(key, value)
-    return s
-
-
-def __escape(data, entities):
-    # must do ampersand first
-    data = data.replace("&", "&amp;")
-    data = data.replace(">", "&gt;")
-    data = data.replace("<", "&lt;")
-    if entities:
-        data = __dict_replace(data, entities)
-    return data
 
 
 def escape(data, entities={}):

--- a/akvo/rsr/tests/base.py
+++ b/akvo/rsr/tests/base.py
@@ -8,7 +8,8 @@ from django.contrib.auth.models import Group
 from django.test import TestCase, Client
 
 from akvo.rsr.models import (
-    User, Employment, Organisation, Project, RelatedProject, Partnership, PublishingStatus, Report
+    User, Employment, Organisation, Project, RelatedProject, Partnership, PublishingStatus,
+    Report, ProjectUpdate
 )
 from akvo.utils import check_auth_groups
 
@@ -59,6 +60,12 @@ class BaseTestCase(TestCase):
         project.publishingstatus.status = status
         project.publishingstatus.save(update_fields=['status'])
         return project
+
+    @staticmethod
+    def create_project_update(project, user, title, text):
+        """Create a project update for the specified project by the given user."""
+        return ProjectUpdate.objects.create(
+            title=title, text=text, user=user, project=project)
 
     @staticmethod
     def create_report(report_name, organisation=None, is_org_report=False, url=None):

--- a/akvo/rsr/tests/test_feeds.py
+++ b/akvo/rsr/tests/test_feeds.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+from akvo.rsr.tests.base import BaseTestCase
+
+
+class FeedsTestCase(BaseTestCase):
+    """Tests for the RSS feeds"""
+
+    def test_updates_feed(self):
+        user = self.create_user('foo@example.com')
+        project_title = 'Projet de d\xc3\xa9veloppement'
+        project = self.create_project(project_title)
+        title = u'Update de développement'
+        text = 'What an amazing update!'
+        self.create_project_update(project, user, title, text)
+
+        response = self.c.get('/rss/updates/{}'.format(project.pk), follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode('utf8')
+        self.assertIn(project_title.decode('utf8'), content)
+        self.assertIn(title, content)
+        self.assertIn(text.decode('utf8'), content)
+
+    def test_org_updates_feed(self):
+        user = self.create_user('foo@example.com')
+        org = self.create_organisation('Akvo Org')
+        self.make_employment(user, org, 'Users')
+        project_title_fmt = 'Projet de d\xc3\xa9veloppement - {}'
+        update_title_fmt = u'Update de développement - {}'
+        update_text_fmt = 'What an amazing update! - {}'
+        for num in range(6):
+            project_title = project_title_fmt.format(num)
+            project = self.create_project(project_title)
+            title = update_title_fmt.format(num)
+            text = update_text_fmt.format(num)
+            self.create_project_update(project, user, title, text)
+            if num % 2 == 0:
+                self.make_partner(project, org)
+
+        response = self.c.get('/rss/org-updates/{}'.format(org.pk), follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode('utf8')
+        for num in range(6):
+            project_title = project_title_fmt.format(num)
+            title = update_title_fmt.format(num)
+            text = update_text_fmt.format(num)
+            assertion = self.assertIn if num % 2 == 0 else self.assertNotIn
+            assertion(project_title.decode('utf8'), content)
+            assertion(title, content)
+            assertion(text.decode('utf8'), content)
+
+    def test_all_updates_feed(self):
+        user = self.create_user('foo@example.com')
+        project_title_fmt = 'Projet de d\xc3\xa9veloppement - {}'
+        update_title_fmt = u'Update de développement - {}'
+        update_text_fmt = 'What an amazing update! - {}'
+        for num in range(6):
+            project_title = project_title_fmt.format(num)
+            project = self.create_project(project_title)
+            title = update_title_fmt.format(num)
+            text = update_text_fmt.format(num)
+            self.create_project_update(project, user, title, text)
+
+        response = self.c.get('/rss/all-updates/', follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode('utf8')
+        for num in range(6):
+            project_title = project_title_fmt.format(num)
+            title = update_title_fmt.format(num)
+            text = update_text_fmt.format(num)
+            self.assertIn(project_title.decode('utf8'), content)
+            self.assertIn(title, content)
+            self.assertIn(text.decode('utf8'), content)

--- a/scripts/docker/dev/run-as-user.sh
+++ b/scripts/docker/dev/run-as-user.sh
@@ -11,4 +11,4 @@ usermod -u "$NEW_UID" -o akvo
 mkdir -p /var/log/akvo/ /var/akvo/rsr/logs/ /var/akvo/rsr/staticroot/ /var/akvo/rsr/mediaroot/
 chown -R akvo:akvo /var/log/akvo/ /var/akvo/rsr/logs/ /var/akvo/rsr/staticroot/ /var/akvo/rsr/mediaroot/
 
-exec chpst -u akvo:akvo -U akvo:akvo env HOME=/home/akvo "$@"
+gosu akvo:akvo "$@"


### PR DESCRIPTION
This will update the OS from Ubuntu 12.04 to Debian Stretch, and also updates the Python from 2.7.3 to 2.7.16.

This should make it easier for the developers to install latest packages and to be able to use newer tools in their dev environment (and in production). 

- [ ] Test plan | Unit test | Integration test
  - Merge this PR into develop and let developers use this for a couple of weeks
  - Keep an eye on Stack driver errors on test
  - Release this with the next release post that. 

