### PR TITLE
[#3822] Allow deleting projects that have imported results

### DIFF
--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -435,6 +435,13 @@ class Project(TimestampsMixin, models.Model):
             ('post_updates', u'Can post updates'),
         )
 
+    def delete(self, using=None, keep_parents=False):
+        # Delete results on the project, before trying to delete the project,
+        # since the RelatedProject object on the project refuses to get deleted
+        # if there are existing results, causing the delete to raise 500s
+        self.results.all().delete()
+        return super(Project, self).delete(using=using, keep_parents=keep_parents)
+
     def save(self, *args, **kwargs):
         # Strip title of any trailing or leading spaces
         if self.title:

--- a/akvo/rsr/tests/results_framework/test_results_framework.py
+++ b/akvo/rsr/tests/results_framework/test_results_framework.py
@@ -776,6 +776,23 @@ class ResultsFrameworkTestCase(BaseTestCase):
         with self.assertRaises(ParentChangeDisallowed):
             related_project.delete()
 
+    def test_allow_deleting_child(self):
+        # Given
+        child_project = self.create_project('New Child Project')
+        RelatedProject.objects.create(
+            project=child_project, related_project=self.parent_project, relation='1'
+        )
+        child_project.import_results()
+
+        # When
+        child_project.delete()
+
+        # Then
+        query = RelatedProject.objects.filter(
+            project=child_project, related_project=self.parent_project)
+        self.assertFalse(query.exists())
+        self.assertIsNone(child_project.pk)
+
     def test_allow_changing_parents_if_results_not_imported(self):
         # Given
         project = self.create_project(title='New Parent Project')


### PR DESCRIPTION
When the project's relation to its parent is defined on the project that is
being deleted, the `RelatedProject` object is prevented from being deleted,
because we prevent changing project relations after importing results into a
project. So, this commit overrides the `Project.delete` method to delete all
the results on the project, before trying to delete it.

Closes #3822
