### PR TITLE
[#3813] Fix iati_*_unicode methods to actually return unicode

### DIFF
--- a/akvo/rsr/models/sector.py
+++ b/akvo/rsr/models/sector.py
@@ -92,13 +92,13 @@ class Sector(models.Model):
             return self.sector_code
 
     def iati_sector_unicode(self):
-        return str(self.iati_sector())
+        return unicode(self.iati_sector())
 
     def iati_vocabulary(self):
         return codelist_value(codelist_models.SectorVocabulary, self, 'vocabulary')
 
     def iati_vocabulary_unicode(self):
-        return str(self.iati_vocabulary())
+        return unicode(self.iati_vocabulary())
 
     class Meta:
         app_label = 'rsr'

--- a/akvo/rsr/tests/rest/test_my_projects.py
+++ b/akvo/rsr/tests/rest/test_my_projects.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+# Akvo RSR is covered by the GNU Affero General Public License.
+
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+
+from akvo.rsr.models import Sector
+from akvo.rsr.tests.base import BaseTestCase
+
+
+class MyProjectsViewSetTestCase(BaseTestCase):
+    """Tests the my_projects endpoint."""
+
+    def setUp(self):
+        super(MyProjectsViewSetTestCase, self).setUp()
+        self.project = self.create_project('Foo Test')
+        email = password = 'example@foo.com'
+        self.create_user(email, password, is_superuser=True)
+        self.c.login(username=email, password=password)
+
+    def test_my_projects_with_unicode_sector(self):
+        # Given
+        url = '/rest/v1/my_projects/?format=json'
+        sector_code = u"Women’s equality"
+        Sector.objects.create(project=self.project, sector_code=sector_code)
+
+        # When
+        response = self.c.get(url, follow=True)
+
+        # Then
+        self.assertEqual(response.status_code, 200)
+        projects = response.data['results']
+        self.assertEqual(len(projects), 1)
+        project = projects[0]
+        self.assertEqual(len(project['sectors']), 1)
+        self.assertEqual(project['sectors'][0]['code_label'], sector_code)


### PR DESCRIPTION
The iati_sector_unicode string actually tries to return an ascii string and
causes problems when a sector code has unicode text. This was caught while
working with the /rest/v1/my_projects API end-point, and this commit fixes
the problem with that end-point.

- [x] Test plan | Unit test | Integration test

