### PR TITLE
[#3831] Fix broken POST to /rest/v1/crs_add

### DIFF
--- a/akvo/rest/viewsets.py
+++ b/akvo/rest/viewsets.py
@@ -172,7 +172,7 @@ class PublicProjectViewSet(BaseRSRViewSet):
 
     def create(self, request, *args, **kwargs):
         response = super(PublicProjectViewSet, self).create(request, *args, **kwargs)
-        obj = self.queryset.model.objects.get(id=response.data['id'])
+        obj = self.queryset.model.objects.get(pk=response.data['id'])
         project = self.get_project(obj)
         if project is not None:
             project.update_iati_checks()

--- a/akvo/rsr/tests/rest/test_crs_add.py
+++ b/akvo/rsr/tests/rest/test_crs_add.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+# Akvo RSR is covered by the GNU Affero General Public License.
+
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+
+from akvo.rsr.models import CrsAdd
+from akvo.rsr.tests.base import BaseTestCase
+
+
+class CrsAddViewSetTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(CrsAddViewSetTestCase, self).setUp()
+        email = password = 'foo@example.com'
+        self.user = self.create_user(email, password, is_superuser=True)
+        self.c.login(username=email, password=password)
+
+    def test_get(self):
+        # Given
+        project = self.create_project('Test Project')
+        crs_add = CrsAdd.objects.create(project=project, loan_terms_rate1=5)
+        url = '/rest/v1/crs_add/{}?format=json'.format(crs_add.pk)
+
+        # When
+        response = self.c.get(url, follow=True)
+
+        # Then
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['project'], project.pk)
+        self.assertEqual(float(response.data['loan_terms_rate1']), crs_add.loan_terms_rate1)
+
+    def test_post(self):
+        # Given
+        project = self.create_project('Test Project')
+        url = '/rest/v1/crs_add/?format=json'
+        data = {'project': project.id}
+
+        # When
+        response = self.c.post(url, data=data)
+
+        # Then
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data['project'], project.pk)

--- a/akvo/utils.py
+++ b/akvo/utils.py
@@ -530,7 +530,7 @@ def log_project_changes(user, project, related_obj, data, action):
     if not isinstance(related_obj, Project):
         obj_name = related_obj._meta.model_name
         if action_flag in {ADDITION, DELETION}:
-            project_fields = {'name': obj_name, 'object': related_obj.id}
+            project_fields = {'name': obj_name, 'object': related_obj.pk}
         else:
             project_fields = {
                 'fields': ['{}_{}'.format(obj_name, key) for key in data.keys()]


### PR DESCRIPTION
The logging code for POST methods incorrectly assumed that all the models
have an `id` field. The `CrsAdd` model doesn't have an `id` field, and we
to fix this we should instead use the `pk` attribute.

Closes #3831

- [x] Test plan | Unit test | Integration test
