### PR TITLE
[#3934] GeoJSON specifies co-ordinates to be [lng,lat] not [lat,lng]

### DIFF
--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -462,7 +462,7 @@ def project_location_geojson(request):
     """Return a GeoJSON with all the project locations."""
     projects = _project_list(request).prefetch_related('locations')
     features = [
-        Feature(geometry=Point((location.latitude, location.longitude)),
+        Feature(geometry=Point((location.longitude, location.latitude)),
                 properties=dict(
                     project_title=project.title,
                     project_subtitle=project.subtitle,

--- a/akvo/rsr/tests/rest/test_project.py
+++ b/akvo/rsr/tests/rest/test_project.py
@@ -652,5 +652,5 @@ class ProjectGeoJsonTestCase(BaseTestCase):
         self.assertEqual(4, len(response.data['features']))
         self.assertEqual(
             {tuple(feature['geometry']['coordinates']) for feature in response.data['features']},
-            {(loc.latitude, loc.longitude) for loc in ProjectLocation.objects.filter()}
+            {(loc.longitude, loc.latitude) for loc in ProjectLocation.objects.filter()}
         )


### PR DESCRIPTION
- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
