### PR TITLE
Speed up the my_projects end-point for non-admin users

### DIFF
--- a/akvo/cache.py
+++ b/akvo/cache.py
@@ -1,0 +1,30 @@
+from django.core.cache import cache
+from django.utils.cache import get_cache_key, _generate_cache_header_key
+
+
+def get_cached_data(request, key_prefix, data, serializer):
+    """Function to get serialized data from the cache based on the request."""
+    cache_header_key = _generate_cache_header_key(key_prefix, request)
+    if cache.get(cache_header_key) is None:
+        cache.set(cache_header_key, [], None)
+
+    cache_key = get_cache_key(request, key_prefix)
+    cached_data = cache.get(cache_key, None)
+    cache_used = True
+    if not cached_data and data is not None:
+        cache_used = False
+        cached_data = serializer(data, many=True).data
+        cache.set(cache_key, cached_data)
+
+    return cached_data, cache_used
+
+
+def set_cached_data(request, key_prefix, data):
+    """Function to save data to the cache based on the request."""
+
+    cache_header_key = _generate_cache_header_key(key_prefix, request)
+    if cache.get(cache_header_key) is None:
+        cache.set(cache_header_key, [], None)
+
+    cache_key = get_cache_key(request, key_prefix)
+    cache.set(cache_key, data)

--- a/akvo/cache.py
+++ b/akvo/cache.py
@@ -4,6 +4,8 @@ from django.utils.cache import get_cache_key, _generate_cache_header_key
 
 def get_cached_data(request, key_prefix, data, serializer):
     """Function to get serialized data from the cache based on the request."""
+
+    # Set the cache_header_key, if it hasn't already been set
     cache_header_key = _generate_cache_header_key(key_prefix, request)
     if cache.get(cache_header_key) is None:
         cache.set(cache_header_key, [], None)
@@ -20,11 +22,12 @@ def get_cached_data(request, key_prefix, data, serializer):
 
 
 def set_cached_data(request, key_prefix, data):
-    """Function to save data to the cache based on the request."""
+    """Function to save data to the cache based on the request.
 
-    cache_header_key = _generate_cache_header_key(key_prefix, request)
-    if cache.get(cache_header_key) is None:
-        cache.set(cache_header_key, [], None)
+    NOTE: The function should always be called after calling get_cached_data.
+    Currently, the function is only used once.
+
+    """
 
     cache_key = get_cache_key(request, key_prefix)
     cache.set(cache_key, data)

--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -17,6 +17,7 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from geojson import Feature, Point, FeatureCollection
 
+from akvo.cache import get_cached_data, set_cached_data
 from akvo.codelists.store.default_codelists import SECTOR_CATEGORY
 from akvo.rest.serializers import (ProjectSerializer, ProjectExtraSerializer,
                                    ProjectExtraDeepSerializer,
@@ -30,7 +31,7 @@ from akvo.rest.serializers import (ProjectSerializer, ProjectExtraSerializer,
                                    ProjectHierarchyRootSerializer,
                                    ProjectHierarchyTreeSerializer,)
 from akvo.rest.views.utils import (
-    int_or_none, get_cached_data, get_qs_elements_for_page, set_cached_data
+    int_or_none, get_qs_elements_for_page
 )
 from akvo.rsr.models import Project, OrganisationCustomField
 from akvo.rsr.filters import location_choices, get_m49_filter

--- a/akvo/rest/views/utils.py
+++ b/akvo/rest/views/utils.py
@@ -6,36 +6,6 @@
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
 from django.conf import settings
-from django.core.cache import cache
-from django.utils.cache import get_cache_key, _generate_cache_header_key
-
-
-def get_cached_data(request, key_prefix, data, serializer):
-    """Function to get serialized data from the cache based on the request."""
-    cache_header_key = _generate_cache_header_key(key_prefix, request)
-    if cache.get(cache_header_key) is None:
-        cache.set(cache_header_key, [], None)
-
-    cache_key = get_cache_key(request, key_prefix)
-    cached_data = cache.get(cache_key, None)
-    cache_used = True
-    if not cached_data and data is not None:
-        cache_used = False
-        cached_data = serializer(data, many=True).data
-        cache.set(cache_key, cached_data)
-
-    return cached_data, cache_used
-
-
-def set_cached_data(request, key_prefix, data):
-    """Function to save data to the cache based on the request."""
-
-    cache_header_key = _generate_cache_header_key(key_prefix, request)
-    if cache.get(cache_header_key) is None:
-        cache.set(cache_header_key, [], None)
-
-    cache_key = get_cache_key(request, key_prefix)
-    cache.set(cache_key, data)
 
 
 def get_qs_elements_for_page(qs, request, count):

--- a/akvo/rsr/models/model_querysets/project.py
+++ b/akvo/rsr/models/model_querysets/project.py
@@ -167,10 +167,11 @@ class ProjectQuerySet(models.QuerySet):
     # The following 8 methods return organisation querysets
     def _partners(self, role=None):
         Organisation = apps.get_model('rsr.organisation')
-        orgs = Organisation.objects.filter(partnerships__project__in=self)
-        if role:
-            orgs = orgs.filter(partnerships__iati_organisation_role=role)
-        return orgs.distinct()
+        if role is None:
+            query = Q(partnerships__project__in=self)
+        else:
+            query = Q(partnerships__iati_organisation_role=role, partnerships__project__in=self)
+        return Organisation.objects.filter(query).distinct()
 
     def field_partners(self):
         Partnership = apps.get_model('rsr.partnership')

--- a/akvo/rsr/models/organisation.py
+++ b/akvo/rsr/models/organisation.py
@@ -380,7 +380,13 @@ class Organisation(TimestampsMixin, models.Model):
         # In case this partner is not a paying partner, find all projects where this partner is
         # implementing partner and add the paying partners of those projects to the queryset.
         if not self.can_create_projects:
-            paying_partners = self.all_projects().paying_partners()
+            from akvo.rsr.models import Project
+
+            implementing_partnerships = Partnership.objects.filter(
+                iati_organisation_role=Partnership.IATI_IMPLEMENTING_PARTNER, organisation=self)
+            implementing_ids = implementing_partnerships.values_list('project', flat=True)
+            projects = Project.objects.filter(id__in=implementing_ids)
+            paying_partners = projects.paying_partners()
             queryset = Organisation.objects.filter(
                 Q(pk__in=queryset.values_list('pk', flat=True))
                 | Q(pk__in=paying_partners.values_list('pk', flat=True))

--- a/akvo/rsr/tests/model_querysets/project.py
+++ b/akvo/rsr/tests/model_querysets/project.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+from akvo.rsr.models import Partnership
+from akvo.rsr.tests.base import BaseTestCase
+
+
+class ProjectQuerySetTestCase(BaseTestCase):
+
+    def test_field_partners(self):
+        project = self.create_project('Project')
+        project_2 = self.create_project('Project 2')
+
+        org_a = self.create_organisation('Organisation A', can_create_projects=False)
+        self.make_partner(project, org_a, Partnership.IATI_ACCOUNTABLE_PARTNER)
+        self.make_partner(project_2, org_a, Partnership.IATI_IMPLEMENTING_PARTNER)
+
+        org_b = self.create_organisation('Organisation B', can_create_projects=False)
+        self.make_partner(project, org_b, Partnership.IATI_IMPLEMENTING_PARTNER)
+
+        org_c = self.create_organisation('Organisation C', can_create_projects=True)
+        self.make_partner(project, org_c, Partnership.IATI_REPORTING_ORGANISATION)
+
+        self.assertNotIn(org_a, org_c.all_projects().field_partners())

--- a/akvo/rsr/tests/models/test_organisation.py
+++ b/akvo/rsr/tests/models/test_organisation.py
@@ -145,3 +145,19 @@ class OrganisationModelTestCase(BaseTestCase):
             "acDeFhK",
             "".join([org.name for org in qs])
         )
+
+    def test_content_owned_by_checks_implementing_status(self):
+        project = self.create_project('Project')
+
+        # No Content ownership, when organisation is *NOT* implementing partner
+        org_a = self.create_organisation('Org A', can_create_projects=False)
+        self.make_partner(project, org_a, Partnership.IATI_ACCOUNTABLE_PARTNER)
+        org_b = self.create_organisation('Org B', can_create_projects=True)
+        self.make_partner(project, org_b, Partnership.IATI_REPORTING_ORGANISATION)
+
+        self.assertNotIn(org_b, org_a.content_owned_by())
+
+        # Content ownership, when organisation is implementing partner
+        self.make_partner(project, org_a, Partnership.IATI_IMPLEMENTING_PARTNER)
+
+        self.assertIn(org_b, org_a.content_owned_by())

--- a/akvo/rsr/tests/models/test_organisation.py
+++ b/akvo/rsr/tests/models/test_organisation.py
@@ -53,76 +53,24 @@ class OrganisationModelTestCase(BaseTestCase):
         for project_title in 'ABCEDF':
             project = self.projects[project_title]
             if project_title == 'A':
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['A'],
-                    iati_organisation_role=Partnership.IATI_REPORTING_ORGANISATION
-                )
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['D'],
-                    iati_organisation_role=Partnership.IATI_IMPLEMENTING_PARTNER
-                )
+                self.make_partner(project, self.orgs['A'], Partnership.IATI_REPORTING_ORGANISATION)
+                self.make_partner(project, self.orgs['D'], Partnership.IATI_IMPLEMENTING_PARTNER)
             elif project_title == 'B':
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['A'],
-                    iati_organisation_role=Partnership.IATI_REPORTING_ORGANISATION
-                )
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['E'],
-                    iati_organisation_role=Partnership.IATI_IMPLEMENTING_PARTNER
-                )
+                self.make_partner(project, self.orgs['A'], Partnership.IATI_REPORTING_ORGANISATION)
+                self.make_partner(project, self.orgs['E'], Partnership.IATI_IMPLEMENTING_PARTNER)
             elif project_title == 'C':
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['E'],
-                    iati_organisation_role=Partnership.IATI_REPORTING_ORGANISATION
-                )
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['F'],
-                    iati_organisation_role=Partnership.IATI_IMPLEMENTING_PARTNER
-                )
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['B'],
-                    iati_organisation_role=Partnership.IATI_FUNDING_PARTNER
-                )
+                self.make_partner(project, self.orgs['E'], Partnership.IATI_REPORTING_ORGANISATION)
+                self.make_partner(project, self.orgs['F'], Partnership.IATI_IMPLEMENTING_PARTNER)
+                self.make_partner(project, self.orgs['B'], Partnership.IATI_FUNDING_PARTNER)
             elif project_title == 'D':
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['B'],
-                    iati_organisation_role=Partnership.IATI_REPORTING_ORGANISATION
-                )
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['F'],
-                    iati_organisation_role=Partnership.IATI_IMPLEMENTING_PARTNER
-                )
+                self.make_partner(project, self.orgs['B'], Partnership.IATI_REPORTING_ORGANISATION)
+                self.make_partner(project, self.orgs['F'], Partnership.IATI_IMPLEMENTING_PARTNER)
             elif project_title == 'E':
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['C'],
-                    iati_organisation_role=Partnership.IATI_REPORTING_ORGANISATION
-                )
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['F'],
-                    iati_organisation_role=Partnership.IATI_IMPLEMENTING_PARTNER
-                )
+                self.make_partner(project, self.orgs['C'], Partnership.IATI_REPORTING_ORGANISATION)
+                self.make_partner(project, self.orgs['F'], Partnership.IATI_IMPLEMENTING_PARTNER)
             elif project_title == 'F':
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['C'],
-                    iati_organisation_role=Partnership.IATI_REPORTING_ORGANISATION
-                )
-                Partnership.objects.create(
-                    project=project,
-                    organisation=self.orgs['G'],
-                    iati_organisation_role=Partnership.IATI_IMPLEMENTING_PARTNER
-                )
+                self.make_partner(project, self.orgs['C'], Partnership.IATI_REPORTING_ORGANISATION)
+                self.make_partner(project, self.orgs['G'], Partnership.IATI_IMPLEMENTING_PARTNER)
             else:
                 pass
 

--- a/akvo/rsr/tests/test_project_access.py
+++ b/akvo/rsr/tests/test_project_access.py
@@ -5,6 +5,7 @@
 
 from django.conf import settings
 from django.contrib.auth.models import Group
+from django.test import override_settings
 
 from akvo.rsr.models import (
     Project, Organisation, Employment, Partnership
@@ -16,6 +17,7 @@ from akvo.rsr.tests.base import BaseTestCase
 from akvo.utils import check_auth_groups
 
 
+@override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}})
 class RestrictedUserProjects(BaseTestCase):
 
     def setUp(self):


### PR DESCRIPTION
The primary goal of this PR is to speed up the `/my_projects/` end-point for non-admin users in organisations with a bunch of content-owned organisations, etc, or more specifically users from EUTF. 

While working on this, I found a couple of bugs around the content owned organisations that are fixed in this PR.  The bugs and their fixes are described below. 

When looking for content owned organisations, in soem cases, additional organisations were being returned as content owned organisations. This is because of incorrectly used chained filter methods on a queryset. 90e5b25a82ee5d143663656792f3084d447ff3a8 fixes this by making the filter query take multiple arguments, instead of chaining filter methods with the two different arguments. 

The `content_owned_by` method on organisations was incorrect, in that it was not specifically checking for projects where the current organisation is an implementing partner when looking for content owners. It was ignoring the role of the organisation, as long as the current organisation is non-paying. 

Finally, this PR has a few commits to add caching for the `user_has_perms` method, which looks for all the projects that a user has access to repeatedly in the same request. When checking for permissions for a bunch of projects, computing this list of accessible projects which is slow, makes the whole request quite slow.  This PR adds caching for this list of accessible projects for a short duration - 15 seconds. This is a hackish way of invalidating the cache, but doing "correct" invalidation of the cache can be quite tricky, because figuring out the list of projects a user has access to is complicated, and the cache invalidation can be quite tricky to add too.  The caching here for a short duration should make requests faster without having adverse impact on user experience. Any changes to organisations or employments will take a few seconds, and the user checking if they have access will probably anyway end-up checking for access after the cache has timed out. 

- [ ] Test plan | Unit test | Integration test
  Login as EUTF user, and verify that the `/my_projects/` end-point is indeed faster. 
