### PR TITLE
In /auth/token response include only projects of approved employment organisations

### DIFF
--- a/akvo/rsr/tests/up/test_up.py
+++ b/akvo/rsr/tests/up/test_up.py
@@ -7,7 +7,6 @@ For additional details on the GNU license please see < http://www.gnu.org/licens
 """
 
 import base64
-import json
 from os.path import abspath, dirname, join
 
 from django.contrib.auth import get_user_model
@@ -32,10 +31,10 @@ class RsrUpTest(BaseTestCase):
         super(RsrUpTest, self).setUp()
 
         # Create new user account
-        user = self.create_user('testuser@akvo.org', 'TestPassword')
+        self.user = user = self.create_user('testuser@akvo.org', 'TestPassword')
 
         # Create new organisation and link user to organisation
-        organisation = self.create_organisation('Test Org')
+        self.org = organisation = self.create_organisation('Test Org')
         self.make_employment(user, organisation, 'Users')
 
         # Create a new project
@@ -57,13 +56,13 @@ class RsrUpTest(BaseTestCase):
         response = self.c.post('/auth/token/?format=json',
                                {'username': 'testuser@akvo.org', 'password': 'TestPassword'})
         self.assertEqual(response.status_code, 200)
-
-        contents = json.loads(response.content)
-        self.assertEqual(sorted(contents),
+        data = response.json()
+        self.assertEqual(sorted(data),
                          sorted(['username', 'user_id', 'organisations',
                                  'allow_edit_projects', 'api_key',
                                  'published_projects']))
-        self.assertGreater(len(contents['published_projects']), 0)
+        self.assertEqual(data['published_projects'], [self.project.id])
+        self.assertEqual(data['organisations'], [self.org.id])
 
     def test_get_project_information(self):
         """

--- a/akvo/rsr/views/account.py
+++ b/akvo/rsr/views/account.py
@@ -244,7 +244,7 @@ def api_key_xml_response(user, orgs):
     api_key_element.text = ApiKey.objects.get_or_create(user=user)[0].key
 
     # Published and editable projects
-    projects = user.organisations.all_projects().published()
+    projects = orgs.all_projects().published()
     pub_projs_element = etree.SubElement(xml_root, "published_projects")
     edit_projs_element = etree.SubElement(xml_root, "allow_edit_projects")
     for project in projects:
@@ -274,7 +274,7 @@ def api_key_json_response(user, orgs):
     response_data["api_key"] = ApiKey.objects.get_or_create(user=user)[0].key
 
     # Published projects
-    projects = user.organisations.all_projects().published()
+    projects = orgs.all_projects().published()
     response_data["published_projects"] = [p.id for p in projects]
 
     # Editable projects


### PR DESCRIPTION
- [ ] Test plan | Unit test | Integration test
- [ ] Documentation

This PR fixes a bug in the `/auth/token` response (the end-point used by the Up app, to get list of user accessible projects). The API response included all the projects where the user had an employment - approved or otherwise. The last commit in this PR changes that to include only approved employments. 

The two commits before that are clean-up commits to improve the tests, leading up to this change. 