### PR TITLE
Add /css URL that redirects to partner site custom css

### DIFF
--- a/akvo/rsr/tests/models/test_partner_site.py
+++ b/akvo/rsr/tests/models/test_partner_site.py
@@ -5,8 +5,8 @@
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
 
+from akvo.rsr.tests.base import BaseTestCase
 from akvo.rsr.models import (
     Organisation, Partnership, PartnerSite, Project, ProjectUpdate
 )
@@ -14,40 +14,31 @@ from akvo.rsr.models import (
 User = get_user_model()
 
 
-class PartnerSiteModelTestCase(TestCase):
+class PartnerSiteModelTestCase(BaseTestCase):
     """Tests for the partner site model"""
 
     def setUp(self):
+        super(PartnerSiteModelTestCase, self).setUp()
+
         # Clear all projects, users since some tests may not tear down!
         self.tearDown()
 
         # Setup a project with results framework and a user
-        self.project_1 = Project.objects.create(title="Test project 1")
-        self.project_1.publish()
-        self.project_2 = Project.objects.create(title="Test project 2")
-        self.project_2.publish()
-        self.org_1 = Organisation.objects.create(name='Org 1', long_name='Organisation 1')
-        self.org_2 = Organisation.objects.create(name='Org 2', long_name='Organisation 2')
-        self.user = User.objects.create(username='user1@com.com', email='user1@com.com')
+        self.project_1 = self.create_project("Test project 1")
+        self.project_2 = self.create_project("Test project 2")
+        self.org_1 = self.create_organisation('Org 1')
+        self.org_2 = self.create_organisation('Org 2')
+        self.user = self.create_user('user1@com.com')
         self.update_1 = ProjectUpdate.objects.create(title="Test update 1", project=self.project_1,
                                                      user=self.user)
         self.update_2 = ProjectUpdate.objects.create(title="Test update 2", project=self.project_1,
                                                      user=self.user)
-        self.partnership_1 = Partnership.objects.create(
-            project=self.project_1,
-            organisation=self.org_1,
-            iati_organisation_role=Partnership.IATI_EXTENDING_PARTNER,
-        )
-        self.partnership_2 = Partnership.objects.create(
-            project=self.project_2,
-            organisation=self.org_1,
-            iati_organisation_role=Partnership.IATI_EXTENDING_PARTNER,
-        )
-        self.partnership_3 = Partnership.objects.create(
-            project=self.project_1,
-            organisation=self.org_2,
-            iati_organisation_role=Partnership.IATI_EXTENDING_PARTNER,
-        )
+        self.partnership_1 = self.make_partner(
+            self.project_1, self.org_1, Partnership.IATI_EXTENDING_PARTNER)
+        self.partnership_2 = self.make_partner(
+            self.project_2, self.org_1, Partnership.IATI_EXTENDING_PARTNER)
+        self.partnership_3 = self.make_partner(
+            self.project_1, self.org_2, Partnership.IATI_EXTENDING_PARTNER)
 
     def tearDown(self):
         Project.objects.all().delete()

--- a/akvo/rsr/tests/models/test_partner_site.py
+++ b/akvo/rsr/tests/models/test_partner_site.py
@@ -64,3 +64,25 @@ class PartnerSiteModelTestCase(BaseTestCase):
         self.assertEqual(projects_1.count(), 2)
         projects_2 = page_2.projects()
         self.assertEqual(projects_2.count(), 1)
+
+    def test_redirect_logo_url(self):
+        # When
+        response = self.c.get('/en/logo/', follow=False)
+
+        # Then
+        self.assertEqual(302, response.status_code)
+        self.assertTrue(response.url.endswith('/rsr/images/rsrLogo.svg'))
+
+    def test_partner_site_redirect_logo_url(self):
+        # Given
+        site = PartnerSite.objects.create(organisation=self.org_1, hostname="page1", piwik_id=0)
+        site.custom_logo = 'custom.png'
+        site.save()
+        self.c.defaults['HTTP_HOST'] = '{}.localakvoapp.org'.format(site.hostname)
+
+        # When
+        response = self.c.get('/en/logo/', follow=False)
+
+        # Then
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(response.url, '/media/custom.png')

--- a/akvo/rsr/tests/models/test_partner_site.py
+++ b/akvo/rsr/tests/models/test_partner_site.py
@@ -86,3 +86,24 @@ class PartnerSiteModelTestCase(BaseTestCase):
         # Then
         self.assertEqual(302, response.status_code)
         self.assertEqual(response.url, '/media/custom.png')
+
+    def test_redirect_css_url(self):
+        # When
+        response = self.c.get('/en/css/', follow=False)
+
+        # Then
+        self.assertEqual(404, response.status_code)
+
+    def test_partner_site_redirect_css_url(self):
+        # Given
+        site = PartnerSite.objects.create(organisation=self.org_1, hostname="page1", piwik_id=0)
+        site.custom_css = 'custom.css'
+        site.save()
+        self.c.defaults['HTTP_HOST'] = '{}.localakvoapp.org'.format(site.hostname)
+
+        # When
+        response = self.c.get('/en/css/', follow=False)
+
+        # Then
+        self.assertEqual(302, response.status_code)
+        self.assertEqual(response.url, '/media/custom.css')

--- a/akvo/rsr/views/my_rsr.py
+++ b/akvo/rsr/views/my_rsr.py
@@ -603,3 +603,10 @@ def logo(request):
     if site is not None and site.logo is not None:
         logo = site.logo.url
     return redirect(logo)
+
+
+def css(request):
+    site = request.rsr_page
+    if site is not None and site.stylesheet is not None:
+        return redirect(site.stylesheet.url)
+    raise Http404('No custom CSS file defined')

--- a/akvo/urls.py
+++ b/akvo/urls.py
@@ -122,9 +122,11 @@ urlpatterns = i18n_patterns(
     url(r'^reset_password/complete/$',
         auth_views.password_reset_complete, name='password_reset_complete'),
 
-    # Partner site logo
+    # Partner site logo & CSS
     url(r'^logo/$',
         my_rsr.logo, name='logo'),
+    url(r'^css/$',
+        my_rsr.css, name='css'),
 
     # MyRSR
     url(r'^myrsr/$',


### PR DESCRIPTION
- [ ] Test plan | Unit test | Integration test
- [ ] Documentation

The first couple of commits are just improvements to the tests.  The last commit adds a `/css` view that redirects to the custom CSS URL for a partner site. 