### PR TITLE
Ensure only user accessible projects are listed in Up app

### DIFF
--- a/akvo/rsr/tests/base.py
+++ b/akvo/rsr/tests/base.py
@@ -9,7 +9,7 @@ from django.test import TestCase, Client
 
 from akvo.rsr.models import (
     User, Employment, Organisation, Project, RelatedProject, Partnership, PublishingStatus,
-    Report, ProjectUpdate, ProjectHierarchy
+    Report, ProjectUpdate, ProjectHierarchy, ProjectRole
 )
 from akvo.utils import check_auth_groups
 
@@ -114,6 +114,11 @@ class BaseTestCase(TestCase):
     def make_employment(user, org, group_name):
         group = Group.objects.get(name=group_name)
         return Employment.objects.create(user=user, organisation=org, group=group, is_approved=True)
+
+    @staticmethod
+    def make_project_role(user, project, group_name):
+        group = Group.objects.get(name=group_name)
+        return ProjectRole.objects.create(user=user, project=project, group=group)
 
     @staticmethod
     def create_contributor(title, lead_project):

--- a/akvo/rsr/views/account.py
+++ b/akvo/rsr/views/account.py
@@ -244,7 +244,7 @@ def api_key_xml_response(user, orgs):
     api_key_element.text = ApiKey.objects.get_or_create(user=user)[0].key
 
     # Published and editable projects
-    projects = orgs.all_projects().published()
+    projects = user.my_projects.published()
     pub_projs_element = etree.SubElement(xml_root, "published_projects")
     edit_projs_element = etree.SubElement(xml_root, "allow_edit_projects")
     for project in projects:
@@ -274,7 +274,7 @@ def api_key_json_response(user, orgs):
     response_data["api_key"] = ApiKey.objects.get_or_create(user=user)[0].key
 
     # Published projects
-    projects = orgs.all_projects().published()
+    projects = user.my_projects().published()
     response_data["published_projects"] = [p.id for p in projects]
 
     # Editable projects


### PR DESCRIPTION
- [ ] Test plan | Unit test | Integration test
- [ ] Documentation

Use the `User.my_projects` method to return the correct list of project IDs
accessible to a user after the sign in using the app, and obtain the auth
token.

This list is only refreshed when the user logs in, and the FAC could
potentially cause issues for users who have the list of projects cached in
their apps. But, I'm not sure there's a way to resolve it from the server
side, without making any app code changes. May be invalidating the tokens
for users might work, but it could break things for non-Up app users
unexpectedly. Not sure if the app itself handles expired tokens correctly.
