### PR TITLE
[#4093] Perform case-insensitive email search for existing users

### DIFF
--- a/akvo/rest/views/utils.py
+++ b/akvo/rest/views/utils.py
@@ -63,7 +63,7 @@ def create_invited_user(email):
     User = get_user_model()
     # Check if the user already exists, based on the email address
     try:
-        invited_user = User.objects.get(email=email)
+        invited_user = User.objects.get(email__iexact=email)
     except User.DoesNotExist:
         try:
             invited_user = User.objects.create_user(username=email, email=email)


### PR DESCRIPTION
When adding a new employment for a user, we look for the user based on the
email ID entered in the invitation dialog. This look-up was buggy in cases
where the email ID in the DB had non-lower case letters, since an exact
match search was being performed using lower cased emails entered in the
invitation dialog. This commit makes the search case-insensitive.

Independently, I've also verified that the `register` workflow does this correctly.

Fixes  #4093

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
