### PR TITLE
[#4101] Generate the same thumbnail path irrespective of storage

### DIFF
--- a/akvo/rsr/tests/test_thumbnail_backend.py
+++ b/akvo/rsr/tests/test_thumbnail_backend.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+# Akvo RSR is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+from mock import patch
+
+from sorl.thumbnail.helpers import get_module_class
+from sorl.thumbnail import get_thumbnail
+from sorl.thumbnail.images import ImageFile
+
+from akvo.rsr.tests.base import BaseTestCase
+
+GOOGLE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
+
+
+class DummyImageFile(ImageFile):
+    def exists(self):
+        return True
+
+    def serialize_storage(self):
+        return GOOGLE_STORAGE
+
+
+class DummyKVStore(object):
+    def get(self, key):
+        return False
+
+    def get_or_set(self, source):
+        return False
+
+    def set(self, thumbnail, source):
+        assert thumbnail.serialize_storage() == GOOGLE_STORAGE
+        return False
+
+
+class CustomThumbnailBackendTestCase(BaseTestCase):
+
+    def test_generates_same_path_with_any_storage_backend(self):
+        # Given
+        image = 'foo'
+        geometry = '400x400'
+
+        filesystem_thumbnail = get_thumbnail(image, geometry)
+
+        with patch('sorl.thumbnail.base.ImageFile', DummyImageFile):
+            with patch('sorl.thumbnail.default.storage', new_callable=get_module_class(GOOGLE_STORAGE)):
+                with patch('sorl.thumbnail.default.kvstore', new_callable=DummyKVStore):
+                    google_thumbnail = get_thumbnail(image, geometry)
+
+        self.assertEqual(google_thumbnail.name, filesystem_thumbnail.name)

--- a/akvo/settings/30-rsr.conf
+++ b/akvo/settings/30-rsr.conf
@@ -45,6 +45,9 @@ THUMBNAIL_PROCESSORS = (
     'akvo.rsr.sorl_processors.scale_and_pad',
 )
 
+THUMBNAIL_BACKEND = 'akvo.thumbnail_backend.CustomThumbnailBackend'
+
+
 REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.BrowsableAPIRenderer',

--- a/akvo/thumbnail_backend.py
+++ b/akvo/thumbnail_backend.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+# Akvo RSR is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+from sorl.thumbnail.base import ThumbnailBackend, EXTENSIONS
+from sorl.thumbnail.conf import settings
+from sorl.thumbnail.helpers import tokey, serialize
+
+
+class CustomThumbnailBackend(ThumbnailBackend):
+
+    def _get_thumbnail_filename(self, source, geometry_string, options):
+        """Computes the destination filename.
+
+        Overridden to generate the same filename as generated with
+        'django.core.files.storage.FileSystemStorage' backend, irrespective of
+        what the current storage back-end is.
+
+        """
+        source_key = tokey(source.name, 'django.core.files.storage.FileSystemStorage')
+        key = tokey(source_key, geometry_string, serialize(options))
+        path = '%s/%s/%s' % (key[:2], key[2:4], key)
+        return '%s%s.%s' % (settings.THUMBNAIL_PREFIX, path, EXTENSIONS[options['format']])


### PR DESCRIPTION
`sorl` generated a different thumbnail path based on the storage. For our
use case of moving the cached images to Google Storage and re-using them,
this doesn't work very well, since we regenerate thumbnails for images that
already have thumbnails. This commit fixes that by using the same paths
generated using the filesystem storage backend, for the google one as well.

Closes #4101

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
