### PR TITLE
Remove unused requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,6 @@ RUN set -ex; apt-get update && \
     libxml2-dev libxslt1-dev zlib1g-dev python3-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSLO https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.buster_amd64.deb \
-  && dpkg -i wkhtmltox_0.12.5-1.buster_amd64.deb \
-  && rm wkhtmltox_0.12.5-1.buster_amd64.deb
-
 WORKDIR /var/akvo/rsr/code
 
 COPY scripts/deployment/pip/requirements/2_rsr.txt ./

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -13,10 +13,6 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python get-pip.py && \
     rm get-pip.py
 
-RUN curl -fsSLO https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.buster_amd64.deb \
-  && dpkg -i wkhtmltox_0.12.5-1.buster_amd64.deb \
-  && rm wkhtmltox_0.12.5-1.buster_amd64.deb
-
 ENV NODE_VERSION 10.15.0
 
 RUN curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \

--- a/Dockerfile-prod-no-code
+++ b/Dockerfile-prod-no-code
@@ -9,10 +9,6 @@ RUN set -ex; apt-get update && \
     libxml2-dev libxslt1-dev zlib1g-dev python3-dev && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSLO https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.buster_amd64.deb \
-  && dpkg -i wkhtmltox_0.12.5-1.buster_amd64.deb \
-  && rm wkhtmltox_0.12.5-1.buster_amd64.deb
-
 WORKDIR /var/akvo/rsr/code
 
 COPY scripts/deployment/pip/requirements/2_rsr.txt ./

--- a/akvo/rsr/tests/rest/test_project_editor.py
+++ b/akvo/rsr/tests/rest/test_project_editor.py
@@ -15,7 +15,7 @@ from urllib.parse import urlencode
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.test import TestCase, Client
-from mock import patch
+from unittest.mock import patch
 import xmltodict
 
 from akvo.codelists.models import ResultType, Version

--- a/akvo/rsr/tests/rest/test_project_overview.py
+++ b/akvo/rsr/tests/rest/test_project_overview.py
@@ -5,7 +5,7 @@
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
-from mock import patch
+from unittest.mock import patch
 
 from akvo.rsr.models import Result, Indicator, IndicatorPeriod, IndicatorPeriodData
 from akvo.rsr.tests.base import BaseTestCase

--- a/akvo/rsr/tests/rest/test_project_role.py
+++ b/akvo/rsr/tests/rest/test_project_role.py
@@ -8,7 +8,7 @@
 import json
 
 from django.contrib.auth.models import Group
-from mock import patch
+from unittest.mock import patch
 
 from akvo.rsr.models import Partnership, ProjectRole
 from akvo.rsr.tests.base import BaseTestCase

--- a/akvo/rsr/tests/rest/test_user_management.py
+++ b/akvo/rsr/tests/rest/test_user_management.py
@@ -10,7 +10,7 @@
 import json
 
 from django.contrib.auth.models import Group
-from mock import patch
+from unittest.mock import patch
 
 from akvo.rsr.models import Employment, User
 from akvo.rest.views import user_management

--- a/akvo/rsr/tests/test_thumbnail_backend.py
+++ b/akvo/rsr/tests/test_thumbnail_backend.py
@@ -4,7 +4,7 @@
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
-from mock import patch
+from unittest.mock import patch
 
 from sorl.thumbnail.helpers import get_module_class
 from sorl.thumbnail import get_thumbnail

--- a/akvo/rsr/tests/views/test_account.py
+++ b/akvo/rsr/tests/views/test_account.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.test import TestCase, Client
-from mock import patch
+from unittest.mock import patch
 
 from akvo.rsr.forms import PASSWORD_MINIMUM_LENGTH
 from akvo.rsr.models import Employment, Organisation, Partnership, Project, User

--- a/akvo/rsr/tests/views/test_project.py
+++ b/akvo/rsr/tests/views/test_project.py
@@ -7,26 +7,8 @@ See more details in the license.txt file located at the root folder of the Akvo 
 For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 """
 
-
-from unittest import skip
-
-import django_perf_rec
-from django.test import TestCase
-
 from akvo.rsr.models import Organisation, Partnership, Project, ProjectUpdate
 from akvo.rsr.tests.base import BaseTestCase
-
-
-@skip('Needs Django >= 1.8')
-class ProjectPerfomanceTestCase(TestCase):
-    """Test performance of project views."""
-
-    def setUp(self):
-        return
-
-    def test_project_directory_listing(self):
-        with django_perf_rec.record():
-            self.client.get('/en/projects/', follow=True)
 
 
 class SetProjectUpdate(BaseTestCase):

--- a/scripts/deployment/pip/requirements/2_rsr.txt
+++ b/scripts/deployment/pip/requirements/2_rsr.txt
@@ -26,11 +26,6 @@ django-registration==2.5.2
 djangorestframework-csv==2.1.0
 unicodecsv==0.14.1
 
-# Akvonaut apps
--e git://github.com/zzgvh/django-notification.git#egg=django_notification
--e git://github.com/zzgvh/django-permissions.git#egg=django_permissions
--e git://github.com/zzgvh/django-workflows.git#egg=django_workflows
-
 # General requirements
 httplib2==0.9
 lxml==4.4.2

--- a/scripts/deployment/pip/requirements/2_rsr.txt
+++ b/scripts/deployment/pip/requirements/2_rsr.txt
@@ -90,7 +90,6 @@ django-webpack-loader
 django-lockdown==2.0.0
 
 # Pdf generator
-pdfkit==0.6.1
 WeasyPrint==51
 
 # GeoJSON APIs

--- a/scripts/deployment/pip/requirements/3_testing.txt
+++ b/scripts/deployment/pip/requirements/3_testing.txt
@@ -1,8 +1,5 @@
 # Modules for linting
 flake8==3.7.9
 
-# django_perf_rec
-django_perf_rec==2.0.0
-
 # for parallel tests
 tblib==1.6.0

--- a/scripts/deployment/pip/requirements/3_testing.txt
+++ b/scripts/deployment/pip/requirements/3_testing.txt
@@ -4,10 +4,5 @@ flake8==3.7.9
 # django_perf_rec
 django_perf_rec==2.0.0
 
-# Modules for mocking
-mock==2.0.0
-pbr==3.1.1
-funcsigs==1.0.2
-
 # for parallel tests
 tblib==1.6.0

--- a/scripts/deployment/pip/requirements/3_testing.txt
+++ b/scripts/deployment/pip/requirements/3_testing.txt
@@ -1,8 +1,3 @@
-# Modules used for app testing
-nose==1.2.1
-mox==0.5.3
-py==1.4.12
-
 # Modules for linting
 flake8==3.7.9
 

--- a/scripts/deployment/pip/requirements/3_testing.txt
+++ b/scripts/deployment/pip/requirements/3_testing.txt
@@ -3,13 +3,6 @@ nose==1.2.1
 mox==0.5.3
 py==1.4.12
 
-# factory boy and deps
-factory-boy==2.7.0
-fake-factory==0.7.2
-ipaddress==1.0.17
-six==1.10.0
-
-
 # Modules for linting
 flake8==3.7.9
 


### PR DESCRIPTION
- [ ] Test plan | Unit test | Integration test
- [ ] Documentation

This work is a part of trying to upgrade all the dependencies to their latest versions that can run with the current version of Django that we run. This should make our transition to a newer Django easier. We may still find some unused packages, but we can deal with them in a separate PR. 