### PR TITLE
Nginx to forward media requests to Google Storege

### DIFF
--- a/ci/k8s/deployment.yml
+++ b/ci/k8s/deployment.yml
@@ -56,6 +56,16 @@ spec:
             secretKeyRef:
               name: "rsr-secret"
               key: report-server-api-key
+        - name: GOOGLE_STORAGE_BUCKET_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: akvo-rsr
+              key: google-storege-bucket-name
+        - name: DJANGO_DEFAULT_FILE_STORAGE
+          valueFrom:
+              configMapKeyRef:
+                name: akvo-rsr
+                key: default-file-storage
         - name: ENVIRONMENT
           valueFrom:
             configMapKeyRef:

--- a/ci/training-envs/templates/deployment.yaml
+++ b/ci/training-envs/templates/deployment.yaml
@@ -55,6 +55,10 @@ spec:
           value: "test"
         - name: REPORT_SERVER_URL
           value: "http://localhost:8080"
+        - name: DJANGO_DEFAULT_FILE_STORAGE
+          value: storages.backends.gcloud.GoogleCloudStorage
+        - name: GOOGLE_STORAGE_BUCKET
+          value: "none"
       - &backend
         name: rsr-backend
         image: "eu.gcr.io/akvo-lumen/rsr-backend:{{ .Values.rsrVersion }}"

--- a/docker-compose.ci.prod.images.yaml
+++ b/docker-compose.ci.prod.images.yaml
@@ -35,6 +35,8 @@ services:
     environment:
       - REPORT_SERVER_URL=http://localhost:8080/
       - REPORT_SERVER_API_KEY=dasf&!"£c
+      - DJANGO_DEFAULT_FILE_STORAGE=django.core.files.storage.FileSystemStorage
+      - GOOGLE_STORAGE_BUCKET_NAME=akvo-rsr-test-media-files
       - ENVIRONMENT=test
       - COPY_STATIC_CONTENT_FOR_CI_BUILD=yes
   web:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -96,7 +96,7 @@ server {
 
     }
 
-    ###GOOGLE_STORAGE_ENABLED
+    ###GOOGLE_STORAGE_ENABLED_START
     location /media/ {
         rewrite ^/media/(.*)$ /%GOOGLE_STORAGE_BUCKET_NAME%/$1 break;
         proxy_pass   https://storage.googleapis.com/;
@@ -108,9 +108,9 @@ server {
         expires 1y;
         access_log off;
     }
-    ###GOOGLE_STORAGE_ENABLED
+    ###GOOGLE_STORAGE_ENABLED_END
 
-    ###GOOGLE_STORAGE_DISABLED
+    ###GOOGLE_STORAGE_DISABLED_START
     location /media/ {
         autoindex off;
         alias /var/akvo/rsr/mediaroot/;
@@ -118,7 +118,7 @@ server {
         access_log off;
 
     }
-    ###GOOGLE_STORAGE_DISABLED
+    ###GOOGLE_STORAGE_DISABLED_END
 
     location /robots.txt {
         alias /usr/share/nginx/html/robots.txt;

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -95,6 +95,22 @@ server {
         access_log off;
 
     }
+
+    ###GOOGLE_STORAGE_ENABLED
+    location /media/ {
+        rewrite ^/media/(.*)$ /%GOOGLE_STORAGE_BUCKET_NAME%/$1 break;
+        proxy_pass   https://storage.googleapis.com/;
+        proxy_redirect default;
+        proxy_read_timeout 10m;
+        proxy_send_timeout 10m;
+        proxy_connect_timeout 10m;
+        send_timeout 10m;
+        expires 1y;
+        access_log off;
+    }
+    ###GOOGLE_STORAGE_ENABLED
+
+    ###GOOGLE_STORAGE_DISABLED
     location /media/ {
         autoindex off;
         alias /var/akvo/rsr/mediaroot/;
@@ -102,6 +118,7 @@ server {
         access_log off;
 
     }
+    ###GOOGLE_STORAGE_DISABLED
 
     location /robots.txt {
         alias /usr/share/nginx/html/robots.txt;

--- a/nginx/start.sh
+++ b/nginx/start.sh
@@ -30,10 +30,13 @@ sed -i /etc/nginx/conf.d/default.conf \
     -e "s/%REPORT_SERVER_API_KEY%/$escaped_key/"
 
 if [ "${DJANGO_DEFAULT_FILE_STORAGE}" = "storages.backends.gcloud.GoogleCloudStorage" ]; then
-  sed -i /etc/nginx/conf.d/default.conf -e '/GOOGLE_STORAGE_DISABLED/,/GOOGLE_STORAGE_DISABLED/d'
+  BLOCK_TO_DELETE="GOOGLE_STORAGE_DISABLED"
 else
-  sed -i /etc/nginx/conf.d/default.conf -e '/GOOGLE_STORAGE_ENABLED,/GOOGLE_STORAGE_ENABLED/d'
+  BLOCK_TO_DELETE="GOOGLE_STORAGE_ENABLED"
 fi
+
+awk "/${BLOCK_TO_DELETE}_START/{flag=1} /${BLOCK_TO_DELETE}_END/{flag=0} !flag" < /etc/nginx/conf.d/default.conf > /tmp/nginx.tmp
+mv /tmp/nginx.tmp /etc/nginx/conf.d/default.conf
 
 ## Use the correct robots depending on the environment
 cp -f /usr/share/nginx/html/robots-${ENVIRONMENT}.txt /usr/share/nginx/html/robots.txt

--- a/nginx/start.sh
+++ b/nginx/start.sh
@@ -13,19 +13,27 @@ rawurlencode () {
     }'
 }
 
-if [ -z "$REPORT_SERVER_URL" ] || [ -z "$REPORT_SERVER_API_KEY" ]; then
+if [ -z "$REPORT_SERVER_URL" ] || [ -z "$REPORT_SERVER_API_KEY" ] || [ -z "$DJANGO_DEFAULT_FILE_STORAGE" ] || [ -z "$GOOGLE_STORAGE_BUCKET_NAME" ]; then
  echo "Nginx not properly configured"
  exit 1
 fi
 
 escaped_url=$(printf '%s\n' "$REPORT_SERVER_URL" | sed 's:[\/&]:\\&:g;$!s/$/\\/')
+escaped_bucket_name=$(printf '%s\n' "$GOOGLE_STORAGE_BUCKET_NAME" | sed 's:[\/&]:\\&:g;$!s/$/\\/')
 
 urlencoded_key=$(rawurlencode "$REPORT_SERVER_API_KEY")
 escaped_key=$(printf '%s\n' "$urlencoded_key" | sed 's:[\/&]:\\&:g;$!s/$/\\/')
 
 sed -i /etc/nginx/conf.d/default.conf \
     -e "s/%REPORT_SERVER_URL%/$escaped_url/" \
+    -e "s/%GOOGLE_STORAGE_BUCKET_NAME%/$escaped_bucket_name/" \
     -e "s/%REPORT_SERVER_API_KEY%/$escaped_key/"
+
+if [ "${DJANGO_DEFAULT_FILE_STORAGE}" = "storages.backends.gcloud.GoogleCloudStorage" ]; then
+  sed -i /etc/nginx/conf.d/default.conf -e '/GOOGLE_STORAGE_DISABLED/,/GOOGLE_STORAGE_DISABLED/d'
+else
+  sed -i /etc/nginx/conf.d/default.conf -e '/GOOGLE_STORAGE_ENABLED,/GOOGLE_STORAGE_ENABLED/d'
+fi
 
 ## Use the correct robots depending on the environment
 cp -f /usr/share/nginx/html/robots-${ENVIRONMENT}.txt /usr/share/nginx/html/robots.txt


### PR DESCRIPTION
Once we start using Google Storage, Nginx will proxy any media requests from the old url to the new Google Storage ones.

This will allow us to release the Google Storage functionality before changing the existing ReportServer reports, plus it makes the move safer as the old media urls will still work.

Part of #4080