### PR TITLE
Use a DB cache for project directory entries. 

### DIFF
--- a/akvo/cache.py
+++ b/akvo/cache.py
@@ -1,11 +1,11 @@
 from functools import wraps
 
 from django.conf import settings
-from django.core.cache import cache
+from django.core.cache import cache, caches
 from django.utils.cache import get_cache_key, _generate_cache_header_key
 
 
-def cache_with_key(keyfunc, timeout=settings.RSR_CACHE_SECONDS):
+def cache_with_key(keyfunc, timeout=settings.RSR_CACHE_SECONDS, cache_name='default'):
     """Decorator which applies Django caching to a function.
 
        Decorator argument is a function which computes a cache key
@@ -17,6 +17,7 @@ def cache_with_key(keyfunc, timeout=settings.RSR_CACHE_SECONDS):
         @wraps(func)
         def func_with_caching(*args, **kwargs):
             key = keyfunc(*args, **kwargs)
+            cache = caches[cache_name]
             val = cache.get(key)
             # Values are singleton tuples so that we can distinguish
             # a result of None from a missing key.
@@ -30,7 +31,8 @@ def cache_with_key(keyfunc, timeout=settings.RSR_CACHE_SECONDS):
     return decorator
 
 
-def delete_cache_data(key):
+def delete_cache_data(key, cache_name='default'):
+    cache = caches[cache_name]
     cache.delete(key)
 
 

--- a/akvo/rest/cache.py
+++ b/akvo/rest/cache.py
@@ -4,10 +4,12 @@ from akvo.cache import cache_with_key, delete_cache_data
 from akvo.rest.serializers import ProjectDirectorySerializer
 from akvo.rsr.models.project import Project, project_directory_cache_key
 
-# FIXME: Should we use a DB cache?
-PROJECT_DIRECTORY_CACHE = 'default'
+PROJECT_DIRECTORY_CACHE = 'database'
 
 
+# NOTE: The data doesn't timeout, since we expect the data to be invalidated
+# when the data is updated from the project editor. Also, the script to fill the
+# cache should be able to clear the cache and create new values.
 @cache_with_key(project_directory_cache_key, timeout=None, cache_name=PROJECT_DIRECTORY_CACHE)
 def serialized_project(project_id):
     project = Project.objects.only(

--- a/akvo/rest/cache.py
+++ b/akvo/rest/cache.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+from akvo.cache import cache_with_key, delete_cache_data
+from akvo.rest.serializers import ProjectDirectorySerializer
+from akvo.rsr.models.project import Project, project_directory_cache_key
+
+# FIXME: Should we use a DB cache?
+PROJECT_DIRECTORY_CACHE = 'default'
+
+
+@cache_with_key(project_directory_cache_key, timeout=None, cache_name=PROJECT_DIRECTORY_CACHE)
+def serialized_project(project_id):
+    project = Project.objects.only(
+        'id', 'title', 'subtitle',
+        'primary_location__id',
+        'primary_organisation__id',
+        'primary_organisation__name',
+        'primary_organisation__long_name'
+    ).select_related(
+        'primary_location',
+        'primary_organisation',
+    ).prefetch_related(
+        'locations',
+        'locations__country',
+        'recipient_countries',
+        'partners',
+    ).get(pk=project_id)
+    return ProjectDirectorySerializer(project).data
+
+
+def delete_project_from_project_directory_cache(project_id):
+    delete_cache_data(project_directory_cache_key(project_id), PROJECT_DIRECTORY_CACHE)

--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -20,8 +20,9 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_201_CREATED
 from geojson import Feature, Point, FeatureCollection
 
-from akvo.cache import get_cached_data, set_cached_data, cache_with_key
+from akvo.cache import get_cached_data, set_cached_data
 from akvo.codelists.store.default_codelists import SECTOR_CATEGORY
+from akvo.rest.cache import serialized_project
 from akvo.rest.serializers import (ProjectSerializer, ProjectExtraSerializer,
                                    ProjectExtraDeepSerializer,
                                    ProjectIatiExportSerializer,
@@ -37,7 +38,7 @@ from akvo.rest.models import TastyTokenAuthentication
 from akvo.rest.views.utils import (
     int_or_none, get_qs_elements_for_page
 )
-from akvo.rsr.models import Project, OrganisationCustomField, project_directory_cache_key
+from akvo.rsr.models import Project, OrganisationCustomField
 from akvo.rsr.filters import location_choices, get_m49_filter
 from akvo.rsr.views.my_rsr import user_viewable_projects
 from akvo.utils import codelist_choices
@@ -296,27 +297,6 @@ def project_directory_no_search(request):
     }
 
     return Response(response)
-
-
-# FIXME: Should we use a DB cache?
-@cache_with_key(project_directory_cache_key, timeout=None)
-def serialized_project(project_id):
-    project = Project.objects.only(
-        'id', 'title', 'subtitle',
-        'primary_location__id',
-        'primary_organisation__id',
-        'primary_organisation__name',
-        'primary_organisation__long_name'
-    ).select_related(
-        'primary_location',
-        'primary_organisation',
-    ).prefetch_related(
-        'locations',
-        'locations__country',
-        'recipient_countries',
-        'partners',
-    ).get(pk=project_id)
-    return ProjectDirectorySerializer(project).data
 
 
 @api_view(['GET'])

--- a/akvo/rest/viewsets.py
+++ b/akvo/rest/viewsets.py
@@ -15,10 +15,10 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework.response import Response
 from rest_framework import status
 
-from akvo.rsr.models import PublishingStatus, Project, project_directory_cache_key
+from akvo.rsr.models import PublishingStatus, Project
 from akvo.rest.models import TastyTokenAuthentication
+from akvo.rest.cache import delete_project_from_project_directory_cache
 from akvo.utils import log_project_changes, get_project_for_object
-from akvo.cache import delete_cache_data
 
 from rest_framework import authentication, exceptions, filters, permissions, viewsets
 
@@ -214,7 +214,7 @@ class PublicProjectViewSet(BaseRSRViewSet):
             return Response(msg, status=status.HTTP_405_METHOD_NOT_ALLOWED)
         if project is not None:
             log_project_changes(request.user, project, obj, {}, 'deleted')
-            delete_cache_data(project_directory_cache_key(project.pk))
+            delete_project_from_project_directory_cache(project.pk)
             if project_editor_change:
                 project.update_iati_checks()
         return response
@@ -226,7 +226,7 @@ class PublicProjectViewSet(BaseRSRViewSet):
         project = get_project_for_object(Project, obj)
         if project is not None:
             log_project_changes(request.user, project, obj, request.data, 'changed')
-            delete_cache_data(project_directory_cache_key(project.pk))
+            delete_project_from_project_directory_cache(project.pk)
             if project_editor_change:
                 project.update_iati_checks()
         return response

--- a/akvo/rsr/management/commands/populate_project_directory_cache.py
+++ b/akvo/rsr/management/commands/populate_project_directory_cache.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+"""Populate the project directory cache for all the projects.
+
+Usage:
+
+    python manage.py populate_project_directory_cache
+
+"""
+
+from django.core.management.base import BaseCommand
+
+from akvo.rest.views.project import serialized_project
+from akvo.rest.cache import delete_project_from_project_directory_cache
+from akvo.rsr.models import Project
+
+
+class Command(BaseCommand):
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument('action', choices=['clear', 'fill'], help='Action to perform')
+
+    def handle(self, *args, **options):
+        projects = Project.objects.public().published().values_list('pk', flat=True)
+
+        if options['action'] == 'clear':
+            for project_id in projects:
+                delete_project_from_project_directory_cache(project_id)
+
+        else:
+            for project_id in projects:
+                serialized_project(project_id)

--- a/akvo/settings/20-default.conf
+++ b/akvo/settings/20-default.conf
@@ -36,6 +36,16 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
         'LOCATION': 'rsr-memcached:11211',
         'TIMEOUT': 300,
+    },
+    'database': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'slow_queries',
+        'TIMEOUT': None,
+        'OPTIONS': {
+            # The default is 300. We are currently storing one entry for each
+            # project, but this can potentially be used for other things.
+            'MAX_ENTRIES': 100000,
+        }
     }
 }
 

--- a/scripts/docker/dev/start-django.sh
+++ b/scripts/docker/dev/start-django.sh
@@ -38,7 +38,8 @@ if [ -z "${IS_REPORTS_CONTAINER:-}" ]; then
 fi
 
 if [ -z "${IS_REPORTS_CONTAINER:-}" ]; then
-  SKIP_REQUIRED_AUTH_GROUPS=true python manage.py migrate --noinput
+    SKIP_REQUIRED_AUTH_GROUPS=true python manage.py migrate --noinput
+    SKIP_REQUIRED_AUTH_GROUPS=true python manage.py createcachetable || true
 fi
 #python manage.py collectstatic
 

--- a/scripts/docker/prod/start-django.sh
+++ b/scripts/docker/prod/start-django.sh
@@ -19,8 +19,10 @@ fi
 
 if [ -z "${IS_REPORTS_CONTAINER:-}" ]; then
   log Migrating
-
   SKIP_REQUIRED_AUTH_GROUPS=true python manage.py migrate --noinput
+
+  log Creating cache table
+  SKIP_REQUIRED_AUTH_GROUPS=true python manage.py createcachetable || true
 fi
 
 if [ -z "${IS_REPORTS_CONTAINER:-}" ]; then


### PR DESCRIPTION
**NOTE**: This PR needs to be merged and deployed in two stages. I can do the actual merges and deploys, if I can get a review on this. 

We need to run `python manage.py createcachetable` before we can start using the cache. (I don't know if I should add that to the deploy script itself.) The first few commits refactor some code, and configure this cache. The last couple of commits switch over the code to start using this, and add a management command to populate the cache.  

We use a DB cache so that restarts of the container itself, don't reset the cache. The cache data takes about a couple of minutes to populate now. 
