### PR TITLE
[#3810] Show FAC for all organisations except Nuffic

### DIFF
--- a/akvo/rsr/spa/app/modules/editor/main-menu.jsx
+++ b/akvo/rsr/spa/app/modules/editor/main-menu.jsx
@@ -68,7 +68,7 @@ const MainMenu = ({ rdr, userRdr, params, urlPrefixId, program }) => {
   const isNewProject = params.id === 'new'
   const isReportingOrgEUTF = findIfReportingOrgIsEUTF(rdr.section3.fields.partners)
   const getLabel = (key) => {
-    if (key === 'partners' && shouldShowFlag(userRdr.organisations, flagOrgs.FAC)) return 'Partners & User Access'
+    if (key === 'partners' && !shouldShowFlag(userRdr.organisations, flagOrgs.DISABLE_FAC)) return 'Partners & User Access'
     if (program && key === 'focus') return 'Program focus'
     if (program && key === 'contacts') return 'Program Contacts'
     return keyDict[key]

--- a/akvo/rsr/spa/app/modules/editor/section3/section3.jsx
+++ b/akvo/rsr/spa/app/modules/editor/section3/section3.jsx
@@ -33,7 +33,7 @@ const Section3 = ({ fields, errors, projectId, canEditAccess, userRdr }) => { //
               return (
                 <div>
                   <Partners {... { renderProps, push, results, loading, errors }} />
-                  {canEditAccess && shouldShowFlag(userRdr.organisations, flagOrgs.FAC) &&
+                  {canEditAccess && !shouldShowFlag(userRdr.organisations, flagOrgs.DISABLE_FAC) &&
                     <Field name="partners" subscription={{ value: true }}>
                       {({ input }) => <Access {...{ projectId, partners: input.value }} />}
                     </Field>

--- a/akvo/rsr/spa/app/modules/projects/projects.jsx
+++ b/akvo/rsr/spa/app/modules/projects/projects.jsx
@@ -123,7 +123,7 @@ class Projects extends React.Component{
   render(){
     const { t, userRdr } = this.props
     // only for selected org users
-    const showNewFeature = shouldShowFlag(userRdr.organisations, flagOrgs.FAC)
+    const showNewFeature = !shouldShowFlag(userRdr.organisations, flagOrgs.DISABLE_FAC)
     const showNewProgram = shouldShowFlag(userRdr.organisations, flagOrgs.CREATE_HIERARCHY_PROJECT)
     const canCreateProjects = userRdr.organisations && userRdr.organisations.findIndex(it => it.canCreateProjects) !== -1
     const hasPrograms = userRdr && userRdr.programs && userRdr.programs.filter(it => it.canCreateProjects).length > 0

--- a/akvo/rsr/spa/app/top-bar.jsx
+++ b/akvo/rsr/spa/app/top-bar.jsx
@@ -70,7 +70,7 @@ const ProgramsMenuItem = ({ programs = [], canCreateProjects, showNewProgramFlag
 
 const TopBar = ({ userRdr, dispatch }) => {
   const { t } = useTranslation()
-  const showFAC = shouldShowFlag(userRdr.organisations, flagOrgs.FAC)
+  const showFAC = !shouldShowFlag(userRdr.organisations, flagOrgs.DISABLE_FAC)
   const showNewProgramFlag = shouldShowFlag(userRdr.organisations, flagOrgs.CREATE_NEW_PROGRAM)
   const canCreateProjects = userRdr.organisations && userRdr.organisations.findIndex(it => it.canCreateProjects) !== -1
   return (

--- a/akvo/rsr/spa/app/utils/feat-flags.js
+++ b/akvo/rsr/spa/app/utils/feat-flags.js
@@ -1,5 +1,5 @@
 export const flagOrgs = {
-  FAC: new Set([42, 3210]),
+  DISABLE_FAC: new Set([4531]),
   CREATE_NEW_PROGRAM: new Set([42, 3394]),
   CREATE_HIERARCHY_PROJECT: new Set([42, 3394])
 }


### PR DESCRIPTION
Nuffic is still using the stop gap PAR feature, and they need to migrate
to the new FAC, which basically only requires training of the admins, at
this point, apart from running some migration scripts.

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
