### PR TITLE
Fetch changes from GitHub before running promote

### DIFF
--- a/ci/promote-test-to-prod.sh
+++ b/ci/promote-test-to-prod.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
+echo "Fetching latest from GitHub ..."
+git fetch
+
 docker run --rm -e ZULIP_CLI_TOKEN -v ~/.config:/home/akvo/.config -v "$(pwd)":/app \
   -it akvo/akvo-devops:20200513.082032.37c61a6 promote-test-to-prod.sh rsr rsr-version akvo-rsr zulip


### PR DESCRIPTION
This adds about 3-4 seconds to the promote, but removes the need to run
the promote script from failing to send the list of commits as changes,
if the latest changes were not fetched locally already.

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
