### PR TITLE
[#4255] Allow sending location in multipart/form-data

### DIFF
--- a/akvo/rsr/spa/app/modules/updates/updates.jsx
+++ b/akvo/rsr/spa/app/modules/updates/updates.jsx
@@ -95,8 +95,8 @@ const Updates = ({projectId}) => {
       formData.append(key, payload[key])
     })
     if (position) {
-      formData.append('locations[0].latitude', position.coords.latitude)
-      formData.append('locations[0].longitude', position.coords.longitude)
+      formData.append('latitude', position.coords.latitude)
+      formData.append('longitude', position.coords.longitude)
     }
     if (fileList.length > 0) formData.append('photo', fileList[0])
     axios.post(`${config.baseURL}/project_update/`, formData, axiosConfig)


### PR DESCRIPTION
DRF doesn't allow nested values inside a list. This commit allow sending
a single location when using `multipart/form-data` requests.
`application/json` requests can still continue to use the `locations`
field to send nested lists of locations.

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
