### PR TITLE
 Push docker images to registry on rsr-env-* branches

### DIFF
--- a/ci/deploy-semaphoreci.sh
+++ b/ci/deploy-semaphoreci.sh
@@ -9,7 +9,7 @@ function log {
 log Running deployment script
 export PROJECT_NAME=akvo-lumen
 
-if [[ "${CI_BRANCH}" != "master" ]] && [[ ! "${CI_TAG:-}" =~ promote-.* ]]; then
+if [[ "${CI_BRANCH}" != "master" ]] && [[ "${CI_BRANCH}" != rsr-env-* ]] && [[ ! "${CI_TAG:-}" =~ promote-.* ]]; then
     exit 0
 fi
 
@@ -42,6 +42,10 @@ else
     docker push eu.gcr.io/${PROJECT_NAME}/rsr-nginx
     docker push eu.gcr.io/${PROJECT_NAME}/rsr-statsd-to-prometheus
 
+fi
+
+if [[ "${CI_BRANCH}" = rsr-env-* ]]; then
+    exit 0
 fi
 
 sed -e "s/\${TRAVIS_COMMIT}/$CI_COMMIT/" ci/k8s/deployment.yml > deployment.yml.tmp


### PR DESCRIPTION
To make it easier to deploy custom changes to training envs, we use a [TEMP commit](https://github.com/akvo/akvo-rsr/commit/2e6082807598d657a87bb2332fb22b2a3e330aec). This change makes it easier to push the required docker images, using a specific branch name. This change makes the process less error prone and more convenient. 

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
