### PR TITLE
[#4378] Increase max body size to 50MB

### DIFF
--- a/ci/training-envs/gateway/gateway.yaml
+++ b/ci/training-envs/gateway/gateway.yaml
@@ -48,7 +48,7 @@ spec:
 apiVersion: v1
 data:
   default.conf: |-
-    client_max_body_size 10M;
+    client_max_body_size 50M;
     large_client_header_buffers 16 32k;
 
     gzip on;

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -85,7 +85,7 @@ server {
         send_timeout 10m;
     }
 
-    client_max_body_size 10m;
+    client_max_body_size 50m;
 
     # redirects following the RSR v3 release:
     # see https://github.com/akvo/akvo-provisioning/issues/137

--- a/scripts/docker/dev/nginx/default.conf
+++ b/scripts/docker/dev/nginx/default.conf
@@ -1,7 +1,7 @@
 server {
     server_name _;
 
-    client_max_body_size 10m; # mirrors the prod server
+    client_max_body_size 50m; # mirrors the prod server
 
     proxy_connect_timeout       600;
     proxy_send_timeout          600;


### PR DESCRIPTION
Indicator updates now allowing multiple files in a single request. This
means the request body size can easily cross 10MB, when there are
multiple files. This commit increases the limit on this size to 50MB.

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
