### PR TITLE
Closes #4541 Nuffic Results view

### DIFF
--- a/akvo/rsr/spa/app/modules/projects/projects.jsx
+++ b/akvo/rsr/spa/app/modules/projects/projects.jsx
@@ -189,6 +189,7 @@ class Projects extends React.Component{
           loading={this.state.loading}
           pagination={this.state.pagination}
           onChange={this.handleTableChange}
+          {...{ userRdr }}
         />
         }
         {this.state.viewMode === 'cards' &&

--- a/akvo/rsr/spa/app/modules/projects/table-view.jsx
+++ b/akvo/rsr/spa/app/modules/projects/table-view.jsx
@@ -4,12 +4,15 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import ConditionalLink from './conditional-link'
 import COUNTRIES from '../../utils/countries.json'
+import { flagOrgs, shouldShowFlag } from '../../utils/feat-flags'
+import { getSubdomainName } from '../../utils/misc'
 
 const countryDict = {}
 COUNTRIES.forEach(({ name, code }) => { countryDict[code.toLowerCase()] = name })
 
-const TableView = ({ dataSource, loading, pagination, onChange }) => {
+const TableView = ({ dataSource, loading, pagination, onChange, userRdr }) => {
   const { t } = useTranslation()
+  const isResultOldVersion = userRdr?.organisations ? shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) && getSubdomainName() !== 'rsr4' : false
   const columns = [
     {
       title: t('Privacy'),
@@ -29,9 +32,7 @@ const TableView = ({ dataSource, loading, pagination, onChange }) => {
         <div>
           {(record.parent !== null && !record.parent.isLead) && (<div className="parent-caption"><span>Contributes to:</span> <Link to={`/hierarchy/${record.id}`}>{record.parent.title}</Link><br /></div>)/* eslint-disable-line */}
           {(record.parent !== null && record.parent.isLead) && (<div className="parent-caption"><span>Program:</span> <Link to={`/programs/${record.parent.id}`}>{record.parent.title}</Link><br /></div>)/* eslint-disable-line */}
-          <ConditionalLink record={record}>
-            {text !== '' ? text : t('Untitled project')}
-          </ConditionalLink>
+          {isResultOldVersion ? <a href={`/en/myrsr/my_project/${record.id}/`}>{text !== '' ? text : t('Untitled project')}</a> : <ConditionalLink record={record}>{text !== '' ? text : t('Untitled project')}</ConditionalLink>}
           {record.subtitle !== '' && <small><br /><span className="subtitle">{record.subtitle}</span></small>}
           {record.useProjectRoles && [
             <Tooltip placement="right" overlayClassName="member-access-tooltip" title={<span><i>Only these members can access: </i><br /><div className="divider" />{record.roles.map(role => <span><b>{role.name}</b> | <i>{role.role}</i><br /></span>)}</span>}>

--- a/akvo/rsr/spa/app/modules/results/filter-checkbox.jsx
+++ b/akvo/rsr/spa/app/modules/results/filter-checkbox.jsx
@@ -5,9 +5,9 @@ import { useTranslation } from 'react-i18next'
 import { isPeriodNeedsReporting, isPeriodApproved } from './filters'
 import actionTypes from '../editor/action-types'
 
-const { Option, OptGroup } = Select
+const { Option } = Select
 
-const FilterCheckbox = ({ results, setResults, filteredResults, periodFilter, setPeriodFilter, statusFilter, setStatusFilter, setTreeFilter, setSelectedPeriods, setActiveResultKey, indicatorsFilter, selectedLocked, selectedUnlocked, handleUnlock, handleLock, src, handleSearchInput, needsReportingTimeoutDays, dispatch }) => {
+const FilterCheckbox = ({ results, filteredResults, periodFilter, setPeriodFilter, statusFilter, setStatusFilter, setTreeFilter, setSelectedPeriods, setActiveResultKey, indicatorsFilter, selectedLocked, selectedUnlocked, handleUnlock, handleLock, src, handleSearchInput, needsReportingTimeoutDays, dispatch }) => {
   const { t } = useTranslation()
   let needsReporting = 0
   let pending = 0

--- a/akvo/rsr/spa/app/modules/results/results.jsx
+++ b/akvo/rsr/spa/app/modules/results/results.jsx
@@ -14,9 +14,9 @@ import Enumerator from './enumerator'
 import PendingApproval from './pending-approval'
 import FilterBar from './filter-bar'
 import FilterCheckbox from './filter-checkbox.jsx'
-import { getUniqueValues } from '../../utils/misc'
+import { getUniqueValues, getSubdomainName } from '../../utils/misc'
 import { isPeriodApproved, isPeriodNeedsReporting } from './filters'
-import { isRSRTeamMember } from '../../utils/feat-flags'
+import { shouldShowFlag, flagOrgs } from '../../utils/feat-flags'
 
 const { TabPane } = Tabs
 const { Panel } = Collapse
@@ -43,6 +43,7 @@ const Results = ({ userRdr, needsReportingTimeoutDays, results, setResults, id, 
   const selectedLocked = selectedPeriods.filter(it => it.locked)
   const selectedUnlocked = selectedPeriods.filter(it => !it.locked)
   const defaultActiveKey = results?.map(result => String(result.id))
+  const showResultAdmin = shouldShowFlag(userRdr.organisations, flagOrgs.AKVO_USERS) || (getSubdomainName() === 'rsr4')
 
   const toggleSelectedPeriod = (period, indicatorId) => {
     if (selectedPeriods.findIndex(it => it.id === period.id) === -1) {
@@ -256,22 +257,43 @@ const Results = ({ userRdr, needsReportingTimeoutDays, results, setResults, id, 
   }, [])
 
   useEffect(() => {
-    if (isRSRTeamMember(userRdr) && resultsType === 'results' && statusFilter) {
+    if (showResultAdmin && resultsType === 'results' && statusFilter) {
       setStatusFilter(null)
     }
 
-    if (isRSRTeamMember(userRdr) && resultsType === 'results-admin' && !statusFilter) {
+    if (showResultAdmin && resultsType === 'results-admin' && !statusFilter) {
       setStatusFilter('need-reporting')
     }
   })
   const textTobeReported = statusFilter === 'need-reporting' ? { strong: true, style: { color: '#1890ff' } } : { strong: false, type: 'secondary' }
   const textPending = statusFilter === 'pending' ? { strong: true, style: { color: '#1890ff' } } : { strong: false, type: 'secondary' }
-  const filterProps = { results, setResults, filteredResults, periodFilter, setPeriodFilter, statusFilter, setStatusFilter, setTreeFilter, setSelectedPeriods, setActiveResultKey, indicatorsFilter, needsReportingTimeoutDays, dispatch, selectedLocked, selectedUnlocked, handleUnlock, handleLock, src, handleSearchInput, periods: optionPeriods, resultsType }
+  const filterProps = {
+    results,
+    filteredResults,
+    periodFilter,
+    setPeriodFilter,
+    statusFilter,
+    setStatusFilter,
+    setTreeFilter,
+    setSelectedPeriods,
+    setActiveResultKey,
+    indicatorsFilter,
+    needsReportingTimeoutDays,
+    dispatch,
+    selectedLocked,
+    selectedUnlocked,
+    handleUnlock,
+    handleLock,
+    src,
+    handleSearchInput,
+    periods: optionPeriods,
+    resultsType
+  }
   return (
     <div className="mne-view">
       <div className="main-content filterBarVisible" ref={ref => { mainContentRef.current = ref }}>
         <div className="filter-bar">
-          {isRSRTeamMember(userRdr) ? <FilterBar {...filterProps} /> : <FilterCheckbox {...filterProps} />}
+          {showResultAdmin ? <FilterBar {...filterProps} /> : <FilterCheckbox {...filterProps} />}
           <Portal>
             <div className="beta">
               <div className="label">

--- a/akvo/rsr/spa/app/utils/feat-flags.js
+++ b/akvo/rsr/spa/app/utils/feat-flags.js
@@ -1,5 +1,7 @@
 export const flagOrgs = {
-  ENUMERATORS: new Set([43, 42])
+  ENUMERATORS: new Set([43, 42]),
+  NUFFIC: new Set([4531, 5255, 5722]),
+  AKVO_USERS: new Set([42])
 }
 
 export const shouldShowFlag = (orgs, orgSet) => {

--- a/akvo/rsr/spa/app/utils/misc.js
+++ b/akvo/rsr/spa/app/utils/misc.js
@@ -1,4 +1,4 @@
-/* globals FileReader */
+/* globals FileReader, window */
 import { diff } from 'deep-object-diff'
 
 export const datePickerConfig = {
@@ -160,4 +160,10 @@ export const swapNullValues = (obj) => {
     }
   })
   return obj
+}
+/**
+ * Get subdomain
+ * */
+export const getSubdomainName = () => {
+  return /:\/\/([^\/]+)/.exec(window.location.href)[1] || null
 }


### PR DESCRIPTION
## Issues

- [x] 1) Nuffic should no longer see the new/beta results tab at all. That's Geert's request/command from yesterday.
- [x] 2) All non-Nuffic users (so everyone BUT Akvo users) should NOT see the new Results Admin tab, as we need to properly test it.
- [x] 3) The new Results Admin tab should be made available on rsr4 so that Nuffic can test along with us Akvo users.

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
