### PR TITLE
[#4604] Add command to detach a project from a hierarchy

### DIFF
--- a/akvo/rsr/management/commands/remove_project_parent.py
+++ b/akvo/rsr/management/commands/remove_project_parent.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+from django.core.management.base import BaseCommand
+from akvo.rsr.models import Project
+from akvo.rsr.usecases import remove_project_parent as cmd
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('project_id', type=int)
+
+    def handle(self, *args, **options):
+        try:
+            project = Project.objects.get(id=options['project_id'])
+        except Project.DoesNotExist:
+            print("Project not found")
+            return
+        cmd.remove_parent(project)

--- a/akvo/rsr/tests/usecases/test_remove_project_parent.py
+++ b/akvo/rsr/tests/usecases/test_remove_project_parent.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+from datetime import date
+from akvo.rsr.tests.base import BaseTestCase
+from akvo.rsr.tests.utils import ProjectFixtureBuilder
+from akvo.rsr.usecases import remove_project_parent as command
+
+
+class ChangeProjectParentTestCase(BaseTestCase):
+
+    def test_remove_parent(self):
+        # Given
+        root = ProjectFixtureBuilder()\
+            .with_title('Parent project')\
+            .with_disaggregations({'Foo': ['Bar']})\
+            .with_results([{
+                'title': 'Result #1',
+                'indicators': [{
+                    'title': 'Indicator #1',
+                    'periods': [{
+                        'period_start': date(2020, 1, 1),
+                        'period_end': date(2020, 12, 31),
+                    }]
+                }]
+            }])\
+            .with_contributors([
+                {'title': 'Child project'},
+                {'title': 'New project'}
+            ])\
+            .build()
+        child_project = root.get_contributor(title='Child project')
+        # When
+        command.remove_parent(child_project.object)
+        # Then
+        self.assertIsNone(child_project.object.parents_all().first())
+
+        self.assertIsNone(
+            child_project.results.get(title='Result #1').parent_result
+        )
+        self.assertIsNone(
+            child_project.indicators.get(title='Indicator #1').parent_indicator
+        )
+        self.assertIsNone(
+            child_project.periods.get(period_start=date(2020, 1, 1)).parent_period
+        )
+        self.assertIsNone(
+            child_project.object.dimension_names.get(name='Foo').parent_dimension_name
+        )
+        self.assertIsNone(
+            child_project.get_disaggregation('Foo', 'Bar').parent_dimension_value
+        )

--- a/akvo/rsr/usecases/remove_project_parent.py
+++ b/akvo/rsr/usecases/remove_project_parent.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+
+from akvo.rsr.models import RelatedProject
+from akvo.rsr.usecases.change_project_parent import RF_MODELS_CONFIG
+
+
+def remove_parent(project):
+    for (model, parent_attr, project_relation) in RF_MODELS_CONFIG.values():
+        model.objects.filter(**{project_relation: project}).update(**{parent_attr: None})
+
+    RelatedProject.objects.filter(related_project=project, relation='2').delete()
+    RelatedProject.objects.filter(project=project, relation='1').delete()


### PR DESCRIPTION
This commit adds a command to delete related parents for a project, and sets
all the parents to None in the results framework hierarchy for that project.It
may be useful to make this functionality available from the UI for RSR admins.

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
