### PR TITLE
4624 eutf common output indicators

### DIFF
--- a/akvo/rsr/models/result/result.py
+++ b/akvo/rsr/models/result/result.py
@@ -160,6 +160,18 @@ class Result(models.Model):
             projects[result.project.id] = result.project.title
         return projects
 
+    def descendants(self, depth=None):
+        family = {self.pk}
+        search_depth = 0
+        while depth is None or search_depth < depth:
+            children = Result.objects.filter(parent_result__in=family).values_list('pk', flat=True)
+            if family.union(children) == family:
+                break
+
+            family = family.union(children)
+            search_depth += 1
+        return Result.objects.filter(pk__in=family)
+
     class Meta:
         app_label = 'rsr'
         ordering = ['order', 'id']

--- a/akvo/urls.py
+++ b/akvo/urls.py
@@ -188,6 +188,10 @@ urlpatterns += (
         py_reports.render_eutf_org_results_table_excel_report,
         name='py-reports-organisation-eutf-results-indicators-table'),
 
+    url(r'^py-reports/program/(?P<program_id>\d+)/eutf-common-output-indicators-table/(?P<result_id>\d+)/$',
+        py_reports.render_eutf_org_results_table_excel_report,
+        name='py-reports-organisation-eutf-results-indicators-table'),
+
     url(r'^py-reports/organisation/(?P<org_id>\d+)/results-indicators-table/$',
         py_reports.render_results_indicators_excel_report,
         name='py-reports-organisation-results-indicators-table'),


### PR DESCRIPTION
The PR adds a couple of commits:

- Add a simple descendants method for Results. The method is a "clone" of the projects method, but simpler.
- Add a program report for EUTF that filters the existing Results & Indicators table to include only data related to the "Common Output Indicators" result. We allow for some flexibility in changing the result title or choosing the result to include in the report by making the result ID a parameter in the URL. 

See the commit messages for a more detailed description. 