### PR TITLE
[#4650] Fix make-and-restore-production-dump.sh for clean envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,5 +129,7 @@ akvo/rsr/front-end/styles-src/*.map
 /akvo/rsr/fixtures/test_data.json
 scripts/data/commands.sh
 scripts/data/db_dump.gz
+scripts/data/config/
+scripts/data/dumps/
 /notify.team.sh
 /promote.sh

--- a/scripts/data/helper/make-gcp-dump.sh
+++ b/scripts/data/helper/make-gcp-dump.sh
@@ -10,5 +10,9 @@ fi
 gcloud config set project akvo-lumen
 
 gcloud sql export sql rsr-prod-database "gs://akvo-rsr-db-dump/${dump_file}" --database=rsr_db
-gsutil cp "gs://akvo-rsr-db-dump/$dump_file" /data/db_dump.gz
+gsutil cp "gs://akvo-rsr-db-dump/$dump_file" /data/$dump_file
 gsutil rm "gs://akvo-rsr-db-dump/$dump_file"
+
+# Point db_dump to the last dump
+cd /data
+ln -nfs $dump_file db_dump.gz

--- a/scripts/data/make-and-restore-production-dump.sh
+++ b/scripts/data/make-and-restore-production-dump.sh
@@ -6,9 +6,32 @@
 set -eu
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CONFIG_DIR="${DIR}/config/gcloud"
+DUMP_DIR="${DIR}/dumps"
 
-docker run --rm -it -v "$DIR":/data -v ~/.config:/home/gkh/.config -v "$DIR"/helper/make-gcp-dump.sh:/data/commands.sh:ro kiwigrid/gcloud-kubectl-helm:2.12.3-234.0.0-88
+# Create dirs and make sure they are world writable
+# The docker users might have different IDs
+for _dir in "$CONFIG_DIR" "$DUMP_DIR"; do
+  mkdir -p "$_dir"
+  chmod 777 "$_dir"
+done
+
+# Dump into ./dumps/
+docker run \
+  --rm \
+  -it \
+  -v "$DUMP_DIR":/data \
+  -v "$CONFIG_DIR":/home/gkh/.config/gcloud \
+  -v "$DIR"/helper/make-gcp-dump.sh:/data/commands.sh:ro \
+    kiwigrid/gcloud-kubectl-helm:2.12.3-234.0.0-88
 
 ## Run just these two commands if you already have a dump and you want to restore it.
-docker-compose exec -e RSR_PASSWORD=rsrpasswddb rsrdbhost /data-scripts/restore-from-dump.sh /var/run/postgresql rsrdb rsruserdb /data-scripts/db_dump.gz
+docker-compose exec \
+    -e RSR_PASSWORD=rsrpasswddb \
+  rsrdbhost \
+    /data-scripts/restore-from-dump.sh \
+      /var/run/postgresql \
+      rsrdb \
+      rsruserdb \
+      /data-scripts/dumps/db_dump.gz
 docker-compose restart web


### PR DESCRIPTION
Fresh environments (linux at least) don't have all required directories or rights for said directories.
The default user had ID 1000 and the default gcloud image user has ID 100 --> no write rights
It's thus impossible for the user to write to the mounted volumes.

Additionally, access was given to **all** of `~/.config` which can be a security issue.
It's one of the default XDG configuration directories so many applications
 will store their config there and some might store unencrypted secrets.

Thus, this uses directories local to the project and keeps old backups, just in case.

Closes #4650 Cannot dump and restore prod on fresh install

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
