### PR TITLE
[#4669] Replace docker service network mode

### DIFF
--- a/ci/build-semaphoreci.sh
+++ b/ci/build-semaphoreci.sh
@@ -75,9 +75,9 @@ docker build --rm=false -t eu.gcr.io/${PROJECT_NAME}/rsr-nginx:${CI_COMMIT} -f D
 
 log Starting docker-compose for end to end tests
 touch "log_docker_compose_ci_prod"
-docker-compose -p rsrciprod -f docker-compose.yaml -f docker-compose.ci.prod.images.yaml up -d --build
+docker-compose -p rsrciprod -f docker-compose.yaml -f docker-compose.ci.yaml -f docker-compose.ci.prod.images.yaml up -d --build
 log Running end to end tests
-docker-compose -p rsrciprod -f docker-compose.yaml -f docker-compose.ci.prod.images.yaml run --no-deps web scripts/docker/dev/run-as-user.sh scripts/docker/ci/end-to-end.sh
+docker-compose -p rsrciprod -f docker-compose.yaml -f docker-compose.ci.yaml -f docker-compose.ci.prod.images.yaml run --no-deps web scripts/docker/dev/run-as-user.sh scripts/docker/ci/end-to-end.sh
 rm "log_docker_compose_ci_prod"
 
 log Done

--- a/ci/on-fail-semaphoreci.sh
+++ b/ci/on-fail-semaphoreci.sh
@@ -9,5 +9,5 @@ export PROJECT_NAME=akvo-lumen
 export TRAVIS_COMMIT=${SEMAPHORE_GIT_SHA}
 
 if [ -f "log_docker_compose_ci_prod" ]; then
-  docker-compose -p rsrciprod -f docker-compose.yaml -f docker-compose.ci.prod.images.yaml logs
+  docker-compose -p rsrciprod -f docker-compose.yaml -f docker-compose.ci.yaml -f docker-compose.ci.prod.images.yaml logs
 fi

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -2,8 +2,11 @@ version: '3.7'
 
 services:
   mainnetwork:
+    image: alpine
+    command: tail -f /dev/null
+    expose:
+      - "80"
   web:
     image: rsr-backend:dev
     command: "true"
-  rsrdbhost:
-  rsr-memcached:
+    network_mode: service:mainnetwork

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -5,19 +5,16 @@ x-web-common: &web-common
     context: .
     dockerfile: Dockerfile-dev
   entrypoint: scripts/docker/dev/run-as-user.sh
-  network_mode: service:mainnetwork
 
 services:
-  mainnetwork:
-    ports:
-      - "80:80"
-      - "8080:8080" # for webpack HMR
-      - "8081:8081" # for webpack HMR
-      - "8082:8082" # snakeviz
 
   web:
     <<: *web-common
     command: scripts/docker/dev/start-django.sh
+    expose:
+      - 8000
+    ports:
+      - "8082:8082" # snakeviz
     depends_on:
       - rsrdbhost
 
@@ -26,6 +23,8 @@ services:
     command: scripts/docker/dev/start-node-app.sh akvo/rsr/dir
     depends_on:
       - web
+    expose:
+      - 8081
     volumes:
       - .:/var/akvo/rsr/code:delegated
       - /var/akvo/rsr/code/src/
@@ -35,6 +34,8 @@ services:
     command: scripts/docker/dev/start-node-app.sh akvo/rsr/spa
     depends_on:
       - web
+    expose:
+      - 8080
     volumes:
       - .:/var/akvo/rsr/code:delegated
       - /var/akvo/rsr/code/src/
@@ -47,18 +48,18 @@ services:
       - .:/var/akvo/rsr/code:delegated
       - ./scripts/docker/dev/50-docker-local-dev.conf:/config_overrides/50-docker-local-dev.conf
       - /var/akvo/rsr/code/src/
-    network_mode: service:mainnetwork
     environment:
       - DJANGO_SECRET_KEY=secretkey
       - IS_REPORTS_CONTAINER=yes
       - DJANGO_PORT=9000
   nginx:
     image: nginx:1.17.9-alpine
-    network_mode: service:mainnetwork
     depends_on:
       - web-spa
       - web-dir
       - rsr-memcached
+    ports:
+      - "80:80"
     volumes:
       - ./scripts/docker/dev/nginx:/etc/nginx/conf.d
   rsrdbhost:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,18 +1,12 @@
 version: '3.7'
 
 services:
-  mainnetwork:
-    image: alpine
-    command: tail -f /dev/null
-    expose:
-      - "80"
   web:
     #;; user superme:passwd
     volumes:
       - .:/var/akvo/rsr/code:delegated
       - ./scripts/docker/dev/50-docker-local-dev.conf:/config_overrides/50-docker-local-dev.conf
       - /var/akvo/rsr/code/src/
-    network_mode: service:mainnetwork
     environment:
       - DJANGO_SECRET_KEY=secretkey
       - DEFAULT_FILE_STORAGE=django.core.files.storage.FileSystemStorage

--- a/scripts/docker/dev/nginx/default.conf
+++ b/scripts/docker/dev/nginx/default.conf
@@ -9,14 +9,14 @@ server {
     send_timeout                600;
 
     location /my-rsr/ {
-        proxy_pass   http://localhost:8080/;
+        proxy_pass   http://web-spa:8080/;
         proxy_set_header   Host             $host;
         proxy_set_header   X-Real-IP        $remote_addr;
         proxy_set_header   X-Forwarded-Host $host;
     }
     
     location /dir/ {
-        proxy_pass   http://localhost:8081/;
+        proxy_pass   http://web-dir:8081/;
         proxy_set_header   Host             $host;
         proxy_set_header   X-Real-IP        $remote_addr;
         proxy_set_header   X-Forwarded-Host $host;
@@ -35,14 +35,16 @@ server {
     }
 
     location /py-reports/ {
-        proxy_pass   http://localhost:9000/py-reports/;
+        set $upstream http://reports:9000/py-reports/;
+        proxy_pass   $upstream;
         proxy_set_header   Host             $host;
         proxy_set_header   X-Real-IP        $remote_addr;
         proxy_set_header   X-Forwarded-Host $host;
     }
 
     location / {
-        proxy_pass   http://localhost:8000;
+        set $upstream http://web:8000;
+        proxy_pass   http://web:8000;
         proxy_set_header   Host             $host;
         proxy_set_header   X-Real-IP        $remote_addr;
         proxy_set_header   X-Forwarded-Host $host;

--- a/scripts/docker/dev/nginx/includes/dir-webpack.conf
+++ b/scripts/docker/dev/nginx/includes/dir-webpack.conf
@@ -1,4 +1,4 @@
-proxy_pass   http://localhost:8081/;
+proxy_pass   http://web-dir:8081/;
 proxy_set_header   Host             $host;
 proxy_set_header   X-Real-IP        $remote_addr;
 proxy_set_header   X-Forwarded-Host $host;


### PR DESCRIPTION
This PR gets rid of `network_mode: service:XXX` in the docker-compose YAMLs for the local env. Reasons are explained in the related issue.

In order to do so, the nginx config had to be modified to point to the specific hosts instead of `localhost`. I haven't grokked the CI setup, so the service network mode was simply moved to the CI docker-compose for it to stay as it is.

It is not clear where the service network mode was chosen due to how kubernetes works in production or because it looked that way without docker (everything runs on localhost) and that was just transferred. The PR shouldn't impact production configuration as only dev files were changed and the CI still works.

Closes #4669