### PR TITLE
[#4681] /rest/v1/project_update/ actually got slower with the cache

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,6 +11,7 @@ omit =
     akvo/handler.py
     akvo/wsgi.py
     # Cheating a lot here obviously:
+    akvo/cache/*
     akvo/rest/*
     akvo/rsr/*
     # Skip coverage check on utils

--- a/akvo/cache/__init__.py
+++ b/akvo/cache/__init__.py
@@ -1,0 +1,69 @@
+import logging
+from functools import wraps
+from typing import Any, Callable, List, Type
+
+from django.conf import settings
+from django.core.cache import caches, BaseCache
+
+from akvo.cache.prepo import PrePoPickler
+
+logger = logging.getLogger(__name__)
+
+
+def cache_with_key(
+        keyfunc: Callable[..., Any],
+        timeout: int = settings.RSR_CACHE_SECONDS,
+        cache_name: str = 'default',
+        prepo_pickle: Type[PrePoPickler] = None
+):
+    """Decorator which applies Django caching to a function.
+
+    :param keyfunc: Function which computes a cache key
+           from the original function's arguments.  You are responsible
+           for avoiding collisions with other uses of this decorator or
+           other uses of caching.
+    :param timeout: How long the value will be valid in the cache
+    :param cache_name: Which cache to store the value in
+    :param prepo_pickle: Pre- and post-processing class for pickled values
+    """
+
+    prepo_pickle = prepo_pickle or PrePoPickler
+
+    def decorator(func):
+        @wraps(func)
+        def func_with_caching(*args, **kwargs):
+            key = keyfunc(*args, **kwargs)
+            cache: BaseCache = caches[cache_name]
+            cached_tuple = cache.get(key)
+            # Values are singleton tuples so that we can distinguish
+            # a result of None from a missing key.
+            if cached_tuple is not None:
+                val = cached_tuple[0]
+                try:
+                    return prepo_pickle.expand(val)
+                except:
+                    logger.exception("Couldn't expand a pickled value. Re-caching %s", key)
+                    cache.delete(key)
+
+            val = func(*args, **kwargs)
+            cache.set(key, (prepo_pickle.reduce(val),), timeout=timeout)
+            return val
+
+        return func_with_caching
+
+    return decorator
+
+
+def list_cache_keys(cache_name: str = 'default') -> List[str]:
+    """List the keys that exist in the given cache"""
+
+    cache = caches[cache_name]
+    list_func = getattr(cache, "list_keys", None)
+    if not list_func:  # pragma: no cover
+        raise ValueError(f"Cannot list keys of cache {cache_name}: {type(cache)}")
+    return list_func()
+
+
+def delete_cache_data(key, cache_name='default'):
+    cache = caches[cache_name]
+    cache.delete(key)

--- a/akvo/cache/__init__.py
+++ b/akvo/cache/__init__.py
@@ -55,7 +55,11 @@ def cache_with_key(
 
 
 def list_cache_keys(cache_name: str = 'default') -> List[str]:
-    """List the keys that exist in the given cache"""
+    """
+    List the keys that exist in the given cache
+
+    Not all cache clients support listing their keys, so this method can throw an exception
+    """
 
     cache = caches[cache_name]
     list_func = getattr(cache, "list_keys", None)

--- a/akvo/cache/memcache.py
+++ b/akvo/cache/memcache.py
@@ -1,54 +1,11 @@
 import operator
 import pickle
 import socket
-from functools import reduce, wraps
-from typing import Dict, List, Tuple
+from functools import reduce
+from typing import List, Tuple, Dict
 
 import memcache
-from django.conf import settings
-from django.core.cache import caches
 from django.core.cache.backends.memcached import MemcachedCache
-
-
-def cache_with_key(keyfunc, timeout=settings.RSR_CACHE_SECONDS, cache_name='default'):
-    """Decorator which applies Django caching to a function.
-
-       Decorator argument is a function which computes a cache key
-       from the original function's arguments.  You are responsible
-       for avoiding collisions with other uses of this decorator or
-       other uses of caching."""
-
-    def decorator(func):
-        @wraps(func)
-        def func_with_caching(*args, **kwargs):
-            key = keyfunc(*args, **kwargs)
-            cache = caches[cache_name]
-            val = cache.get(key)
-            # Values are singleton tuples so that we can distinguish
-            # a result of None from a missing key.
-            if val is not None:
-                return val[0]
-            val = func(*args, **kwargs)
-            cache.set(key, (val,), timeout=timeout)
-            return val
-        return func_with_caching
-
-    return decorator
-
-
-def list_cache_keys(cache_name: str = 'default') -> List[str]:
-    """List the keys that exist in the given cache"""
-
-    cache = caches[cache_name]
-    list_func = getattr(cache, "list_keys", None)
-    if not list_func:  # pragma: no cover
-        raise ValueError(f"Cannot list keys of cache {cache_name}: {type(cache)}")
-    return list_func()
-
-
-def delete_cache_data(key, cache_name='default'):
-    cache = caches[cache_name]
-    cache.delete(key)
 
 
 class AkvoMemcacheClient(memcache.Client):

--- a/akvo/cache/prepo.py
+++ b/akvo/cache/prepo.py
@@ -1,0 +1,68 @@
+import dataclasses
+from typing import Any, Optional
+
+from django.db import models
+from django.db.models import QuerySet, sql
+from django.utils.module_loading import import_string
+
+
+class PrePoPickler:
+    """
+    Helps prepare an object pre-pickle and an object post-pickle
+
+    Some objects take an inordinate amount of time to pickle, which negates the benefits of caching.
+    In some cases however, it can help to pickle only certain parts of the object from whence the entire object
+     can then later be built at a lower cost.
+    """
+
+    @classmethod
+    def reduce(cls, obj: Any) -> Any:
+        """Make a smaller version of the object to be stored"""
+        return obj
+
+    @classmethod
+    def expand(cls, obj: Any) -> Any:
+        """Recreate the stored object from its reduced state"""
+        return obj
+
+
+@dataclasses.dataclass
+class QuerysetReduction:
+    """The important parts of a Queryset that allow it to be rebuilt"""
+    model_name: str
+    query: sql.Query
+
+
+class QuerysetPrePo(PrePoPickler):
+    """
+    The queryset's model and SQL query are pickled instead of the results from the executed query.
+
+    (Un-)Pickling speed of Querysets is very unstable.
+    It can often be more expensive to pickle and unpickle than simply execute it.
+
+    In cases where building the queryset itself is expensive, it can be worth caching the resulting queryset.
+    """
+
+    @classmethod
+    def reduce(cls, queryset: QuerySet) -> Optional[QuerysetReduction]:
+        """Extracts the full, importable path of the Queryset's model + the SQL query"""
+
+        if queryset is None:
+            return queryset
+        return QuerysetReduction(
+            model_name=f"{queryset.model.__module__}.{queryset.model.__qualname__}",
+            query=queryset.query
+        )
+
+    @classmethod
+    def expand(cls, reduction: QuerysetReduction) -> QuerySet:
+        """
+        Rebuilds a fresh Queryset from a reduction
+        """
+
+        model = import_string(reduction.model_name)
+        if not issubclass(model, models.Model):
+            raise ValueError("Queryset model is not a subclass of django.db.models.Model")
+        queryset = model.objects.all()
+        queryset.query = reduction.query
+        return queryset

--- a/akvo/cache/tests/test_prepo.py
+++ b/akvo/cache/tests/test_prepo.py
@@ -1,0 +1,25 @@
+import unittest
+
+from django.test import SimpleTestCase
+
+from akvo.cache.prepo import QuerysetPrePo, QuerysetReduction
+from akvo.rsr.models import Project
+
+
+class QuerysetPrePotest(SimpleTestCase):
+
+    def test_reduce(self):
+        reduction = QuerysetPrePo.reduce(Project.objects.all())
+        self.assertEqual(reduction.model_name, "akvo.rsr.models.project.Project")
+
+    def test_expand(self):
+        queryset = Project.objects.filter(title="title").distinct()
+        expanded_queryset = QuerysetPrePo.expand(QuerysetReduction(
+            "akvo.rsr.models.project.Project",
+            queryset.query
+        ))
+        self.assertEqual(expanded_queryset.model, queryset.model)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/akvo/rest/views/indicator_period_data.py
+++ b/akvo/rest/views/indicator_period_data.py
@@ -34,8 +34,8 @@ class IndicatorPeriodDataViewSet(PublicProjectViewSet):
 
     project_relation = 'period__indicator__result__project__'
 
-    def get_queryset(self):
-        queryset = super(IndicatorPeriodDataViewSet, self).get_queryset()
+    def filter_queryset(self, queryset):
+        queryset = super(IndicatorPeriodDataViewSet, self).filter_queryset(queryset)
         return IndicatorPeriodData.get_user_viewable_updates(
             queryset, self.request.user
         )

--- a/akvo/rest/views/partnership.py
+++ b/akvo/rest/views/partnership.py
@@ -17,14 +17,14 @@ class PartnershipViewSet(PublicProjectViewSet):
     queryset = Partnership.objects.select_related('organisation', 'project').all()
     serializer_class = PartnershipSerializer
 
-    def get_queryset(self):
+    def filter_queryset(self, queryset):
         """Allow filtering on partner_type."""
         partner_type = self.request.query_params.get('partner_type', None)
         if partner_type and partner_type in Partnership.PARTNER_TYPES_TO_ROLES_MAP:
-            self.queryset = self.queryset.filter(
+            queryset = queryset.filter(
                 iati_organisation_role=Partnership.PARTNER_TYPES_TO_ROLES_MAP[partner_type]
             ).distinct()
-        return super(PartnershipViewSet, self).get_queryset()
+        return super(PartnershipViewSet, self).filter_queryset(queryset)
 
 
 class PartnershipMoreLinkViewSet(PublicProjectViewSet):

--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -46,7 +46,7 @@ class ProjectViewSet(PublicProjectViewSet):
     serializer_class = ProjectSerializer
     project_relation = ''
 
-    def get_queryset(self):
+    def filter_queryset(self, queryset):
         """
         Allow custom filter for sync_owner, since this field has been replaced by the
         reporting org partnership.
@@ -57,11 +57,11 @@ class ProjectViewSet(PublicProjectViewSet):
 
         reporting_org = reporting_org or sync_owner
         if reporting_org:
-            self.queryset = self.queryset.filter(
+            queryset = queryset.filter(
                 partnerships__iati_organisation_role=101,
                 partnerships__organisation__pk=reporting_org
             ).distinct()
-        return super(ProjectViewSet, self).get_queryset()
+        return super(ProjectViewSet, self).filter_queryset(queryset)
 
 
 class MyProjectsViewSet(PublicProjectViewSet):
@@ -138,18 +138,18 @@ class ProjectIatiExportViewSet(PublicProjectViewSet):
     paginate_by_param = 'limit'
     max_paginate_by = 50
 
-    def get_queryset(self):
+    def filter_queryset(self, queryset):
         """
         Allow custom filter for sync_owner, since this field has been replaced by the
         reporting org partnership.
         """
         reporting_org = self.request.query_params.get('reporting_org', None)
         if reporting_org:
-            self.queryset = self.queryset.filter(
+            queryset = queryset.filter(
                 partnerships__iati_organisation_role=101,
                 partnerships__organisation__pk=reporting_org
             ).distinct()
-        return super(ProjectIatiExportViewSet, self).get_queryset()
+        return super(ProjectIatiExportViewSet, self).filter_queryset(queryset)
 
     def list(self, request, *args, **kwargs):
         projects = self.queryset.filter(run_iati_checks=True)

--- a/akvo/rest/views/project_update.py
+++ b/akvo/rest/views/project_update.py
@@ -42,7 +42,7 @@ class ProjectUpdateViewSet(PublicProjectViewSet):
     paginate_by_param = 'limit'
     max_paginate_by = 1000
 
-    def get_queryset(self):
+    def filter_queryset(self, queryset):
         """
         Allow simple filtering on selected fields.
         We don't use the default filter_fields, because Up filters on
@@ -51,24 +51,24 @@ class ProjectUpdateViewSet(PublicProjectViewSet):
         # FIXME: Add filter for event_date?
         created_at__gt = validate_date(self.request.query_params.get('created_at__gt', None))
         if created_at__gt is not None:
-            self.queryset = self.queryset.filter(created_at__gt=created_at__gt)
+            queryset = queryset.filter(created_at__gt=created_at__gt)
         created_at__lt = validate_date(self.request.query_params.get('created_at__lt', None))
         if created_at__lt is not None:
-            self.queryset = self.queryset.filter(created_at__lt=created_at__lt)
+            queryset = queryset.filter(created_at__lt=created_at__lt)
         last_modified_at__gt = validate_date(self.request.query_params.get('last_modified_at__gt', None))
         if last_modified_at__gt is not None:
-            self.queryset = self.queryset.filter(last_modified_at__gt=last_modified_at__gt)
+            queryset = queryset.filter(last_modified_at__gt=last_modified_at__gt)
         last_modified_at__lt = validate_date(self.request.query_params.get('last_modified_at__lt', None))
         if last_modified_at__lt is not None:
-            self.queryset = self.queryset.filter(last_modified_at__lt=last_modified_at__lt)
+            queryset = queryset.filter(last_modified_at__lt=last_modified_at__lt)
         # Get updates per organisation
         project__partners = self.request.query_params.get('project__partners', None)
         if project__partners:
-            self.queryset = self.queryset.filter(project__partners=project__partners)
+            queryset = queryset.filter(project__partners=project__partners)
         user__organisations = self.request.query_params.get('user__organisations', None)
         if user__organisations:
-            self.queryset = self.queryset.filter(user__organisations=user__organisations)
-        return super(ProjectUpdateViewSet, self).get_queryset()
+            queryset = queryset.filter(user__organisations=user__organisations)
+        return super().filter_queryset(queryset)
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
@@ -97,7 +97,7 @@ class ProjectUpdateExtraViewSet(PublicProjectViewSet):
     )
     serializer_class = ProjectUpdateExtraSerializer
 
-    def get_queryset(self):
+    def filter_queryset(self, queryset):
         """
         Allow simple filtering on selected fields.
         We don't use the default filter_fields, because Up filters on
@@ -105,24 +105,24 @@ class ProjectUpdateExtraViewSet(PublicProjectViewSet):
         """
         created_at__gt = validate_date(self.request.query_params.get('created_at__gt', None))
         if created_at__gt is not None:
-            self.queryset = self.queryset.filter(created_at__gt=created_at__gt)
+            queryset = queryset.filter(created_at__gt=created_at__gt)
         created_at__lt = validate_date(self.request.query_params.get('created_at__lt', None))
         if created_at__lt is not None:
-            self.queryset = self.queryset.filter(created_at__lt=created_at__lt)
+            queryset = queryset.filter(created_at__lt=created_at__lt)
         last_modified_at__gt = validate_date(self.request.query_params.get('last_modified_at__gt', None))
         if last_modified_at__gt is not None:
-            self.queryset = self.queryset.filter(last_modified_at__gt=last_modified_at__gt)
+            queryset = queryset.filter(last_modified_at__gt=last_modified_at__gt)
         last_modified_at__lt = validate_date(self.request.query_params.get('last_modified_at__lt', None))
         if last_modified_at__lt is not None:
-            self.queryset = self.queryset.filter(last_modified_at__lt=last_modified_at__lt)
+            queryset = queryset.filter(last_modified_at__lt=last_modified_at__lt)
         # Get updates per organisation
         project__partners = self.request.query_params.get('project__partners', None)
         if project__partners:
-            self.queryset = self.queryset.filter(project__partners=project__partners)
+            queryset = queryset.filter(project__partners=project__partners)
         user__organisations = self.request.query_params.get('user__organisations', None)
         if user__organisations:
-            self.queryset = self.queryset.filter(user__organisations=user__organisations)
-        return super(ProjectUpdateExtraViewSet, self).get_queryset()
+            queryset = queryset.filter(user__organisations=user__organisations)
+        return super().filter_queryset(queryset)
 
 
 # validate date strings from URL

--- a/akvo/rest/viewsets.py
+++ b/akvo/rest/viewsets.py
@@ -58,7 +58,7 @@ class BaseRSRViewSet(viewsets.ModelViewSet):
             self.pagination_class = TastypieOffsetPagination
         return super(BaseRSRViewSet, self).paginate_queryset(queryset)
 
-    def get_queryset(self):
+    def filter_queryset(self, queryset):
 
         def django_filter_filters(request):
             """
@@ -108,7 +108,7 @@ class BaseRSRViewSet(viewsets.ModelViewSet):
                 query_set_lookups += [{key: value}]
             return query_set_lookups
 
-        queryset = super(BaseRSRViewSet, self).get_queryset()
+        queryset = super().filter_queryset(queryset)
 
         # support for old DjangoFilterBackend-based filtering if not pk is given
         if not self.kwargs.get('pk'):
@@ -163,14 +163,14 @@ class PublicProjectViewSet(BaseRSRViewSet):
     # The lookup is used to filter out objects associated with private projects, see below.
     project_relation = 'project__'
 
-    def get_queryset(self):
+    def filter_queryset(self, queryset):
 
         if hasattr(self, '_cached_filtered_queryset'):
             return self._cached_filtered_queryset
 
         request = self.request
         user = request.user
-        queryset = super(PublicProjectViewSet, self).get_queryset()
+        queryset = super().filter_queryset(queryset)
 
         # filter projects if user is "non-privileged"
         if user.is_anonymous() or not (user.is_superuser or user.is_admin) and self.action == 'list':

--- a/akvo/rest/viewsets.py
+++ b/akvo/rest/viewsets.py
@@ -17,6 +17,7 @@ from rest_framework.response import Response
 from rest_framework import status
 
 from akvo.cache import cache_with_key
+from akvo.cache.prepo import QuerysetPrePo
 from akvo.rsr.models import PublishingStatus, Project, User
 from akvo.rest.models import TastyTokenAuthentication
 from akvo.rest.cache import delete_project_from_project_directory_cache
@@ -250,7 +251,12 @@ def make_projects_filter_cache_key(user: User, queryset: QuerySet, project_relat
 
 
 # Stop-gap solution until a reorg and optimization of the models is done
-@cache_with_key(make_projects_filter_cache_key, timeout=3600)
+@cache_with_key(
+    make_projects_filter_cache_key,
+    timeout=3600,
+    cache_name='default',
+    prepo_pickle=QuerysetPrePo,
+)
 def _projects_filter_for_non_privileged_users(user: User, queryset: QuerySet, project_relation: str,
                                               action: str = 'create'):
     if not user.is_anonymous() and (user.is_admin or user.is_superuser):

--- a/akvo/settings/20-default.conf
+++ b/akvo/settings/20-default.conf
@@ -33,7 +33,7 @@ SUPPORT_EMAIL = [ADMINS[0][1]]
 
 CACHES = {
     'default': {
-        'BACKEND': 'akvo.cache.AkvoMemcachedCache',
+        'BACKEND': 'akvo.cache.memcache.AkvoMemcachedCache',
         'LOCATION': 'rsr-memcached:11211',
         'TIMEOUT': 300,
     },


### PR DESCRIPTION
The fix is two-fold:

 - Store querysets closest to their final, filtered form --> rename `get_queryset` to `filter_queryset` and cache it
 - Cache only the SQL query of a queryset instead of the DB result post query
More information is present in `QuerysetPrepo`.

The actual heavy part of `akvo.rest.viewsets._projects_filter_for_non_privileged_users` were the calls to `user.get_permission_filter`. They "only" modified the queryset and the actual DB query is somewhat fast. 

Fixes #4681

- [x] Test plan | Unit test | Integration test
- [x] Documentation

As a result, the UI frontend and API queries are faster.