### PR TITLE
[#4660] Do not run migration in reports container

### DIFF
--- a/scripts/docker/dev/start-django.sh
+++ b/scripts/docker/dev/start-django.sh
@@ -4,18 +4,21 @@ set -eu
 
 ./scripts/docker/dev/wait-for-dependencies.sh
 
-pushd akvo/rsr/front-end
-  if [[ ! -d "node_modules" ]]; then
-    npm install
-  fi
-  if [[ ! -f "static/rsr/dist/vendors.js" ]]; then
-    npm run dev
-  fi
-popd
+if [ -z "${IS_REPORTS_CONTAINER:-}" ]; then
+  pushd akvo/rsr/front-end
+    if [[ ! -d "node_modules" ]]; then
+      npm install
+    fi
+    if [[ ! -f "static/rsr/dist/vendors.js" ]]; then
+      npm run dev
+    fi
+  popd
 
-SKIP_REQUIRED_AUTH_GROUPS=true python manage.py migrate --noinput
-SKIP_REQUIRED_AUTH_GROUPS=true python manage.py createcachetable || true
+  SKIP_REQUIRED_AUTH_GROUPS=true python manage.py migrate --noinput
+  SKIP_REQUIRED_AUTH_GROUPS=true python manage.py createcachetable || true
 
-python manage.py populate_local_db
+  python manage.py populate_local_db
+fi
+
 
 python manage.py runserver 0.0.0.0:${DJANGO_PORT:-8000}


### PR DESCRIPTION
When running `docker-compose up` with empty postgres volume, either the
web or the reports container will be terminated due to failure to run
the migration.

- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
