### PR TITLE
[#4674] chore(upgrade): Fix models.permalink

### DIFF
--- a/akvo/rsr/models/focus_area.py
+++ b/akvo/rsr/models/focus_area.py
@@ -7,6 +7,7 @@
 
 from django.apps import apps
 from django.db import models
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from sorl.thumbnail.fields import ImageField
@@ -56,9 +57,8 @@ class FocusArea(models.Model):
         )
     )
 
-    @models.permalink
     def get_absolute_url(self):
-        return ('project-directory', ())
+        return reverse('project-directory')
 
     def projects(self):
         'return all projects that "belong" to the FA through the Categories it links to'

--- a/akvo/rsr/models/organisation.py
+++ b/akvo/rsr/models/organisation.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Sum, Q, signals
 from django.dispatch import receiver
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from sorl.thumbnail.fields import ImageField
@@ -184,9 +185,8 @@ class Organisation(TimestampsMixin, models.Model):
     )
     objects = OrgManager()
 
-    @models.permalink
     def get_absolute_url(self):
-        return 'organisation-main', (), {'organisation_id': self.pk}
+        return reverse('organisation-main', kwargs={'organisation_id': self.pk})
 
     @property
     def canonical_name(self):

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -21,6 +21,7 @@ from django.apps import apps
 from django.db.models import Sum
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from django.db import transaction
@@ -542,9 +543,8 @@ class Project(TimestampsMixin, models.Model):
                                              'time than end date (actual).')}
             )
 
-    @models.permalink
     def get_absolute_url(self):
-        return ('project-main', (), {'project_id': self.pk})
+        return reverse('project-main', kwargs={'project_id': self.pk})
 
     @property
     def cacheable_url(self):

--- a/akvo/rsr/models/project_update.py
+++ b/akvo/rsr/models/project_update.py
@@ -8,6 +8,7 @@ import datetime
 
 from django.conf import settings
 from django.db import models
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from embed_video.fields import EmbedVideoField
 from sorl.thumbnail.fields import ImageField
@@ -84,9 +85,8 @@ class ProjectUpdate(TimestampsMixin, models.Model):
     def time_last_updated_gmt(self):
         return to_gmt(self.last_modified_at)
 
-    @models.permalink
     def get_absolute_url(self):
-        return 'update-main', (), {'project_id': self.project_id, 'update_id': self.pk}
+        return reverse('update-main', kwargs={'project_id': self.project_id, 'update_id': self.pk})
 
     @property
     def edited(self):

--- a/scripts/docker/ci/build.sh
+++ b/scripts/docker/ci/build.sh
@@ -36,7 +36,9 @@ log Building assets
 python manage.py collectstatic --noinput
 
 log Running tests
+export PYTHONWARNINGS=all
 COVERAGE_PROCESS_START=.coveragerc coverage run --parallel-mode --concurrency=multiprocessing manage.py test --parallel 4 akvo
+export -n PYTHONWARNINGS
 
 log Coverage
 coverage combine


### PR DESCRIPTION
https://docs.djangoproject.com/en/3.2/releases/1.11/#models-permalink-decorator

Deprecation warnings were also activated in the CI and this one doesn't show up anymore.

Fixes #4674 
