### PR TITLE
Fix #4673: Deprecation(django): invalid escape sequence \.

### DIFF
--- a/scripts/docker/ci/build.sh
+++ b/scripts/docker/ci/build.sh
@@ -36,7 +36,9 @@ log Building assets
 python manage.py collectstatic --noinput
 
 log Running tests
+export PYTHONWARNINGS=all
 COVERAGE_PROCESS_START=.coveragerc coverage run --parallel-mode --concurrency=multiprocessing manage.py test --parallel 4 akvo
+export -n PYTHONWARNINGS
 
 log Coverage
 coverage combine

--- a/scripts/docker/dev/50-docker-local-dev.conf
+++ b/scripts/docker/dev/50-docker-local-dev.conf
@@ -37,13 +37,13 @@ GOOGLE_MAPS_PROJECT_UPDATE_MARKER_ICON = '%srsr/images/maps/greenMarker.png' %  
 GOOGLE_MAPS_ORGANISATION_MARKER_ICON = '%srsr/images/maps/redMarker.png' % STATIC_URL
 
 RSR_SITE_REGEXPS = [
-            '^localakvo\.org$',
-            '^rsr\.localdev\.akvo\.org$',
+            r'^localakvo\.org$',
+            r'^rsr\.localdev\.akvo\.org$',
     ]
 
 PARTNER_SITE_REGEXPS = [
-    '^.*\.localdev\.akvo\.org$',
-    '^.*\.localakvoapp\.org$',
+    r'^.*\.localdev\.akvo\.org$',
+    r'^.*\.localakvoapp\.org$',
 ]
 
 RSR_DOMAIN = os.getenv('RSR_DOMAIN', 'localhost')


### PR DESCRIPTION
It was just missing `r'...'`


Fix #4673: Deprecation(django): invalid escape sequence \. 