### PR TITLE
[#4668]: Speed up django unit tests

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -38,7 +38,7 @@ When the local server is running, you can run the following command in a
 separate terminal to run the tests.
 
 ```sh
-docker-compose exec web ./scripts/docker/dev/run-as-user.sh python manage.py test -k -v 3 akvo.rsr.tests.test_templatetags
+docker-compose exec web ./manage.py test -k -v 3 akvo.rsr.tests.test_templatetags
 ```
 
 - `-v` makes the output of the tests verbose

--- a/akvo/rsr/tests/models/test_custom_field.py
+++ b/akvo/rsr/tests/models/test_custom_field.py
@@ -5,7 +5,7 @@
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
 
-from unittest import TestCase
+from django.test import TestCase
 
 from akvo.rsr.models import Project, ProjectCustomField
 

--- a/akvo/rsr/tests/models/test_project.py
+++ b/akvo/rsr/tests/models/test_project.py
@@ -4,9 +4,9 @@
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 from datetime import date
-from unittest import TestCase
 
 from django.contrib.auth import get_user_model
+from django.test import TestCase
 
 from akvo.rsr.tests.base import BaseTestCase
 from akvo.rsr.models import BudgetItem, Partnership, Project, ProjectUpdate, Organisation, \

--- a/akvo/rsr/tests/models/test_results_aggregation.py
+++ b/akvo/rsr/tests/models/test_results_aggregation.py
@@ -5,10 +5,9 @@
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
 
-from unittest import TestCase
-
 from decimal import Decimal
 from django.contrib.auth import get_user_model
+from django.test import TestCase
 from django_pgviews.models import ViewSyncer
 
 from akvo.rsr.models import (Indicator, IndicatorPeriod, IndicatorPeriodData, Project, Result,

--- a/scripts/docker/ci/build.sh
+++ b/scripts/docker/ci/build.sh
@@ -36,9 +36,15 @@ log Building assets
 python manage.py collectstatic --noinput
 
 log Running tests
+# Run one test to run the test migration
 export PYTHONWARNINGS=all
-COVERAGE_PROCESS_START=.coveragerc coverage run --parallel-mode --concurrency=multiprocessing manage.py test --parallel 4 akvo
+./manage.py test akvo.codelists.tests.test_iati_codelist_generator.CodelistGeneratorTestCase
 export -n PYTHONWARNINGS
+# Run all the tests with the existing database
+# Functions to make sure --keepdb works
+COVERAGE_PROCESS_START=.coveragerc \
+  coverage run --parallel-mode --concurrency=multiprocessing \
+  manage.py test --keepdb --parallel 4 akvo
 
 log Coverage
 coverage combine


### PR DESCRIPTION
We can now use `--keepdb` for our tests which saves us the time of running migrations every time we run a test.
Migrations take about 1:20m to run right now, so that time is saved.

Fix #4668: Speed up django unit tests

# Results

```sh
# All tests with migrations
$ time docker-compose run --rm web ./manage.py test --failfast --noinput akvo &>/dev/null

real    13m1.992s
user    0m1.297s
sys     0m0.869s

# All tests with keepdb (second time)
$ time docker-compose run --rm web ./manage.py test --failfast --noinput --keepdb akvo &>/dev/null

real    11m19.324s
user    0m1.380s
sys     0m0.777s

# Single test with keepdb first time (requires migration)
$ time docker-compose run --rm web ./manage.py test --failfast --noinput --keepdb akvo.codelists.tests.test_iati_codelist_generator.CodelistGeneratorTestCase.test_prevent_changing_generated_files_by_hand &>/dev/null

real    1m56.849s
user    0m1.310s
sys     0m0.763s

# Single test with keepdb (migrations have already been run)
$ time docker-compose run --rm web ./manage.py test --failfast --noinput --keepdb akvo.codelists.tests.test_iati_codelist_generator.CodelistGeneratorTestCase.test_prevent_changing_generated_files_by_hand &>/dev/null

real    0m12.204s
user    0m1.329s
sys     0m0.760s
```
