### PR TITLE
[#4702]: CI tests are unstable... why?

### DIFF
--- a/akvo/rsr/tests/base.py
+++ b/akvo/rsr/tests/base.py
@@ -2,9 +2,12 @@
 # Akvo RSR is covered by the GNU Affero General Public License.
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+import logging
 
 from django.conf import settings
+from django.contrib.auth import user_login_failed
 from django.contrib.auth.models import Group
+from django.http import HttpRequest
 from django.test import TestCase, Client
 
 from akvo.rsr.models import (
@@ -17,9 +20,24 @@ from akvo.utils import check_auth_groups
 class BaseTestCase(TestCase):
     """Testing that permissions work correctly."""
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestCase, cls).setUpClass()
+        user_login_failed.connect(cls.handle_user_login_failed)
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestCase, cls).tearDownClass()
+        user_login_failed.disconnect(cls.handle_user_login_failed)
+
     def setUp(self):
         check_auth_groups(settings.REQUIRED_AUTH_GROUPS)
         self.c = Client(HTTP_HOST=settings.RSR_DOMAIN)
+
+    @classmethod
+    def handle_user_login_failed(cls, signal, sender: str, credentials: dict, request: HttpRequest):
+        logging.warning("Couldn't login user from %s, with %s. Existing users: %s",
+                        sender, credentials, User.objects.all())
 
     @staticmethod
     def create_user(email, password=None, is_active=True, is_admin=False, is_superuser=False):

--- a/akvo/rsr/tests/rest/test_indicator_period.py
+++ b/akvo/rsr/tests/rest/test_indicator_period.py
@@ -18,7 +18,7 @@ class IndicatorPeriodNestedDisaggregationTargetPatchTestCase(BaseTestCase):
     """Test bulk patch disaggregation_targets on indicator_period endpoint"""
 
     def send_patch(self, period, data, username, password):
-        self.c.login(username=username, password=password)
+        self.assertTrue(self.c.login(username=username, password=password))
         return self.c.patch(
             '/rest/v1/indicator_period/{}/'.format(period.id),
             data=json.dumps(data),

--- a/scripts/docker/ci/build.sh
+++ b/scripts/docker/ci/build.sh
@@ -38,7 +38,7 @@ python manage.py collectstatic --noinput
 log Running tests
 # Run one test to run the test migration
 export PYTHONWARNINGS=all
-./manage.py test akvo.codelists.tests.test_iati_codelist_generator.CodelistGeneratorTestCase
+./manage.py test --keepdb akvo.codelists.tests.test_iati_codelist_generator.CodelistGeneratorTestCase
 export -n PYTHONWARNINGS
 # Run all the tests with the existing database
 # Functions to make sure --keepdb works


### PR DESCRIPTION
This first part just adds logs to try and find out why the test is failing. The problems ([link](https://akvo.semaphoreci.com/jobs/3c798ac4-080d-4b67-ae1c-3129bbd8bf34)) couldn't be recreated locally.

Related to #4702: CI tests are unstable... why?
