### PR TITLE
Fix: Make react hot reload work again locally

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -25,6 +25,8 @@ services:
       - web
     expose:
       - 8081
+    ports:
+      - "127.0.0.1:8081:8081"
     volumes:
       - .:/var/akvo/rsr/code:delegated
       - /var/akvo/rsr/code/src/
@@ -36,6 +38,8 @@ services:
       - web
     expose:
       - 8080
+    ports:
+      - "127.0.0.1:8080:8080"
     volumes:
       - .:/var/akvo/rsr/code:delegated
       - /var/akvo/rsr/code/src/


### PR DESCRIPTION
I didn't want to mess around with JS code and point the hot reload in the client to another port.
It just isn't clear to me how to make that change a dev-only change.

The easiest route I therefore picked was to make it possible for the react client to access the ports
 it was expecting to access
