### PR TITLE
[#4718]  nginx container won't startup locally without reports container

### DIFF
--- a/scripts/docker/dev/nginx/default.conf
+++ b/scripts/docker/dev/nginx/default.conf
@@ -8,6 +8,9 @@ server {
     proxy_read_timeout          600;
     send_timeout                600;
 
+    # Docker's internal resolver
+    resolver 127.0.0.11;
+
     location /my-rsr/ {
         proxy_pass   http://web-spa:8080/;
         proxy_set_header   Host             $host;
@@ -35,14 +38,16 @@ server {
     }
 
     location /py-reports/ {
-        proxy_pass   http://reports:9000/py-reports/;
+        set $upstream   http://reports:9000/py-reports/;
+        proxy_pass   $upstream;
         proxy_set_header   Host             $host;
         proxy_set_header   X-Real-IP        $remote_addr;
         proxy_set_header   X-Forwarded-Host $host;
     }
 
     location / {
-        proxy_pass   http://web:8000;
+        set $upstream http://web:8000;
+        proxy_pass   $upstream;
         proxy_set_header   Host             $host;
         proxy_set_header   X-Real-IP        $remote_addr;
         proxy_set_header   X-Forwarded-Host $host;


### PR DESCRIPTION
Fix #4718: `nginx` container can startup locally without `reports` container

The same format is applied to all `location` blocks, now `nginx` can start even all upstreams don't exist.