### PR TITLE
[#4725] quickfix: cache entire project directory request

### DIFF
--- a/akvo/rest/cache.py
+++ b/akvo/rest/cache.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
+from typing import Dict, List
 
 from akvo.cache import cache_with_key, delete_cache_data
 from akvo.rest.serializers import ProjectDirectorySerializer
+from akvo.rsr.models import Country, Partnership, ProjectLocation, RecipientCountry, Sector
 from akvo.rsr.models.project import Project, project_directory_cache_key
 
 PROJECT_DIRECTORY_CACHE = 'database'
@@ -11,24 +13,23 @@ PROJECT_DIRECTORY_CACHE = 'database'
 # when the data is updated from the project editor. Also, the script to fill the
 # cache should be able to clear the cache and create new values.
 @cache_with_key(project_directory_cache_key, timeout=None, cache_name=PROJECT_DIRECTORY_CACHE)
-def serialized_project(project_id):
-    project = Project.objects.only(
-        'id', 'title', 'subtitle',
-        'primary_location__id',
-        'primary_organisation__id',
-        'primary_organisation__name',
-        'primary_organisation__long_name'
-    ).select_related(
-        'primary_location',
-        'primary_organisation',
-    ).prefetch_related(
-        'locations',
-        'locations__country',
-        'recipient_countries',
-        'partners',
-    ).get(pk=project_id)
-    return ProjectDirectorySerializer(project).data
+def serialized_project(
+        project: Project,
+        location_cache: Dict[int, List[ProjectLocation]],
+        partnership_cache: Dict[int, List[Partnership]],
+        recipient_country_cache: Dict[int, List[RecipientCountry]],
+        sector_cache: Dict[int, List[Sector]],
+        country_cache: Dict[int, Country],
+):
+    return ProjectDirectorySerializer(
+        location_cache,
+        partnership_cache,
+        recipient_country_cache,
+        sector_cache,
+        country_cache,
+        instance=project,
+    ).data
 
 
-def delete_project_from_project_directory_cache(project_id):
-    delete_cache_data(project_directory_cache_key(project_id), PROJECT_DIRECTORY_CACHE)
+def delete_project_from_project_directory_cache(project: Project):
+    delete_cache_data(project_directory_cache_key(project), PROJECT_DIRECTORY_CACHE)

--- a/akvo/rest/serializers/project.py
+++ b/akvo/rest/serializers/project.py
@@ -7,17 +7,20 @@
 from datetime import timedelta
 from itertools import chain
 import logging
+from typing import Dict, List, Set
 
 from django.utils.timezone import now
 from rest_framework import serializers
 
-from akvo.rsr.models import Project, RelatedProject, ProjectUpdate, IndicatorPeriodData
+from akvo.rsr.models import (
+    Country, Partnership, Project, ProjectLocation, RecipientCountry, RelatedProject, ProjectUpdate,
+    IndicatorPeriodData, Sector,
+)
 from akvo.utils import get_thumbnail
 
 from ..fields import Base64ImageField
 
 from .budget_item import BudgetItemRawSerializer, BudgetItemRawDeepSerializer
-from .custom_field import ProjectDirectoryProjectCustomFieldSerializer
 from .legacy_data import LegacyDataSerializer
 from .link import LinkSerializer
 from .partnership import PartnershipRawSerializer, PartnershipRawDeepSerializer
@@ -133,9 +136,7 @@ class ProjectDirectorySerializer(serializers.ModelSerializer):
     longitude = serializers.ReadOnlyField(source='primary_location.longitude', default=None)
     image = serializers.SerializerMethodField()
     countries = serializers.SerializerMethodField()
-    url = serializers.ReadOnlyField(source='cacheable_url')
     organisation = serializers.ReadOnlyField(source='primary_organisation.name')
-    organisation_url = serializers.ReadOnlyField(source='primary_organisation.get_absolute_url')
     organisations = serializers.SerializerMethodField()
     sectors = serializers.SerializerMethodField()
     dropdown_custom_fields = serializers.SerializerMethodField()
@@ -152,21 +153,44 @@ class ProjectDirectorySerializer(serializers.ModelSerializer):
             'longitude',
             'image',
             'countries',
-            'url',
             'organisation',
-            'organisation_url',
             'organisations',
             'sectors',
             'dropdown_custom_fields',
             'order_score',
         )
 
-    def get_countries(self, project):
-        country_codes = {
-            getattr(country, 'iso_code', getattr(country, 'country', ''))
-            for country in project.countries()
+    def __init__(
+            self,
+            location_cache: Dict[int, List[ProjectLocation]],
+            partnership_cache: Dict[int, List[Partnership]],
+            recipient_country_cache: Dict[int, List[RecipientCountry]],
+            sector_cache: Dict[int, List[Sector]],
+            country_cache: Dict[int, Country],
+            **kwargs
+    ):
+        """
+        Caches are used as a temporary measure in order not to make many any db requests
+        """
+
+        super().__init__(**kwargs)
+        self.country_cache = country_cache
+        self.location_cache = location_cache
+        self.partnership_cache = partnership_cache
+        self.recipient_country_cache = recipient_country_cache
+        self.sector_cache = sector_cache
+
+    def get_countries(self, project: Project) -> Set[str]:
+        country_codes = set(
+            recipient_country.country.upper()
+            for recipient_country in self.recipient_country_cache.get(project.id, [])
+        )
+        project_locations = {
+            country.iso_code.upper() for location in self.location_cache.get(project.id, [])
+            if (country := self.country_cache.get(location.country_id))
         }
-        return sorted({code.upper() for code in country_codes if code})
+
+        return project_locations.union(country_codes)
 
     def get_image(self, project):
         geometry = '350x200'
@@ -181,14 +205,17 @@ class ProjectDirectorySerializer(serializers.ModelSerializer):
         return url
 
     def get_organisations(self, project):
-        return [org.id for org in project.partners.distinct()]
+        return [
+            partnership.organisation_id for partnership in self.partnership_cache.get(project.id, [])
+        ]
 
     def get_sectors(self, project):
-        return [sector.sector_code for sector in project.sectors.distinct()]
+        return [sector.sector_code for sector in self.sector_cache.get(project.id, [])]
 
     def get_dropdown_custom_fields(self, project):
-        custom_fields = project.custom_fields.filter(type='dropdown')
-        return ProjectDirectoryProjectCustomFieldSerializer(custom_fields, many=True).data
+        # custom_fields = project.custom_fields.filter(type='dropdown')
+        # return ProjectDirectoryProjectCustomFieldSerializer(custom_fields, many=True).data
+        return []
 
     def get_order_score(self, project):
         nine_months = now() - timedelta(days=9 * 30)

--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -21,15 +21,17 @@ from akvo.rest.serializers import (ProjectSerializer, ProjectExtraSerializer,
                                    ProjectExtraDeepSerializer,
                                    ProjectIatiExportSerializer,
                                    ProjectUpSerializer,
-                                   TypeaheadOrganisationSerializer,
                                    ProjectMetadataSerializer,
                                    OrganisationCustomFieldSerializer,
                                    ProjectHierarchyRootSerializer,
                                    ProjectHierarchyTreeSerializer,)
 from akvo.rest.models import TastyTokenAuthentication
-from akvo.rsr.models import Project, OrganisationCustomField, IndicatorPeriodData
+from akvo.rsr.models import (
+    Country, Organisation, Partnership, Project, OrganisationCustomField, IndicatorPeriodData,
+    ProjectLocation, RecipientCountry, Sector,
+)
 from akvo.rsr.views.my_rsr import user_viewable_projects
-from akvo.utils import codelist_choices, single_period_dates
+from akvo.utils import build_dict, codelist_choices, single_period_dates
 from ..viewsets import PublicProjectViewSet, ReadOnlyPublicProjectViewSet
 
 
@@ -264,7 +266,7 @@ class ProjectUpViewSet(ProjectViewSet):
 ###############################################################################
 
 # Cache for one hour
-# @cache_page(timeout=60 * 60, cache=PROJECT_DIRECTORY_CACHE)
+@cache_page(timeout=60 * 60, cache=PROJECT_DIRECTORY_CACHE)
 @api_view(['GET'])
 def project_directory(request):
     """Return the values for various project filters.
@@ -275,12 +277,43 @@ def project_directory(request):
     """
 
     page = request.rsr_page
-    projects = _project_list(request)
+    projects = _project_list(request).only(
+        'id', 'title', 'subtitle',
+        'current_image',
+        'project_plan_summary',
+        'primary_location__id',
+        'primary_organisation__id',
+        'primary_organisation__name',
+        'primary_organisation__long_name',
+        'primary_location__latitude',
+        'primary_location__longitude',
+    ).select_related(
+        'primary_location',
+        'primary_organisation',
+    )
+    location_cache = build_dict(
+        (location.location_target_id, location) for location in ProjectLocation.objects.all()
+    )
+    partnership_cache = build_dict((partnership.id, partnership) for partnership in Partnership.objects.all())
+    recipient_country_cache = build_dict((country.id, country) for country in RecipientCountry.objects.all())
+    sector_cache = build_dict((sector.project_id, sector) for sector in Sector.objects.all())
+    country_cache = {country.id: country for country in Country.objects.all()}
+
     projects_data = [
-        serialized_project(project_id) for project_id in projects.values_list('pk', flat=True)
+        serialized_project(
+            project,
+            location_cache,
+            partnership_cache,
+            recipient_country_cache,
+            sector_cache,
+            country_cache,
+        ) for project in projects
     ]
-    organisations = list(projects.all_partners().values('id', 'name', 'long_name'))
-    organisations = TypeaheadOrganisationSerializer(organisations, many=True).data
+    organisations = [{
+        'id': org.id,
+        'name': org.name,
+        'long_name': org.long_name,
+    } for org in Organisation.objects.all()]
 
     custom_fields = (
         OrganisationCustomField.objects.filter(type='dropdown',

--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -7,6 +7,7 @@ For additional details on the GNU license please see < http://www.gnu.org/licens
 
 from django.db.models import Q
 from django.shortcuts import get_object_or_404
+from django.views.decorators.cache import cache_page
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import api_view, authentication_classes, permission_classes
 from rest_framework.permissions import IsAuthenticated
@@ -15,7 +16,7 @@ from rest_framework.status import HTTP_201_CREATED, HTTP_403_FORBIDDEN
 from geojson import Feature, Point, FeatureCollection
 
 from akvo.codelists.store.default_codelists import SECTOR_CATEGORY
-from akvo.rest.cache import serialized_project
+from akvo.rest.cache import PROJECT_DIRECTORY_CACHE, serialized_project
 from akvo.rest.serializers import (ProjectSerializer, ProjectExtraSerializer,
                                    ProjectExtraDeepSerializer,
                                    ProjectIatiExportSerializer,
@@ -262,6 +263,8 @@ class ProjectUpViewSet(ProjectViewSet):
 # Project directory
 ###############################################################################
 
+# Cache for one hour
+@cache_page(timeout=60 * 60, cache=PROJECT_DIRECTORY_CACHE)
 @api_view(['GET'])
 def project_directory(request):
     """Return the values for various project filters.

--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -264,7 +264,7 @@ class ProjectUpViewSet(ProjectViewSet):
 ###############################################################################
 
 # Cache for one hour
-@cache_page(timeout=60 * 60, cache=PROJECT_DIRECTORY_CACHE)
+# @cache_page(timeout=60 * 60, cache=PROJECT_DIRECTORY_CACHE)
 @api_view(['GET'])
 def project_directory(request):
     """Return the values for various project filters.
@@ -324,7 +324,7 @@ def project_location_geojson(request):
                 properties=dict(
                     project_title=project.title,
                     project_subtitle=project.subtitle,
-                    project_url=request.build_absolute_uri(project.get_absolute_url()),
+                    project_url=request.build_absolute_uri(project.get_absolute_url),
                     project_id=project.pk,
                     name=location.name,
                     description=location.description))

--- a/akvo/rest/viewsets.py
+++ b/akvo/rest/viewsets.py
@@ -202,7 +202,7 @@ class PublicProjectViewSet(BaseRSRViewSet):
             raise exceptions.PermissionDenied
         elif project is not None:
             log_project_changes(request.user, project, obj, {}, 'added')
-            delete_project_from_project_directory_cache(project.pk)
+            delete_project_from_project_directory_cache(project)
             project.schedule_iati_checks()
         return response
 
@@ -216,7 +216,7 @@ class PublicProjectViewSet(BaseRSRViewSet):
             return Response(msg, status=status.HTTP_405_METHOD_NOT_ALLOWED)
         if project is not None:
             log_project_changes(request.user, project, obj, {}, 'deleted')
-            delete_project_from_project_directory_cache(project.pk)
+            delete_project_from_project_directory_cache(project)
             project.schedule_iati_checks()
         return response
 
@@ -226,7 +226,7 @@ class PublicProjectViewSet(BaseRSRViewSet):
         project = get_project_for_object(Project, obj)
         if project is not None:
             log_project_changes(request.user, project, obj, request.data, 'changed')
-            delete_project_from_project_directory_cache(project.pk)
+            delete_project_from_project_directory_cache(project)
             project.schedule_iati_checks()
         return response
 

--- a/akvo/rsr/dir/app/modules/index/projects.jsx
+++ b/akvo/rsr/dir/app/modules/index/projects.jsx
@@ -68,7 +68,7 @@ const Projects = ({ projects = [], loading, show, setShow, ulRef, showSortLabel 
             classNames="project"
           >
           <li>
-            <a href={`/${lang}${project.url}`} target="_blank" rel="noopener noreferrer">
+            <a href={`/${lang}/project/${project.id}`} target="_blank" rel="noopener noreferrer">
               <div className="img">
                 <img src={`${project.image}`} />
               </div>

--- a/akvo/rsr/feeds.py
+++ b/akvo/rsr/feeds.py
@@ -124,10 +124,10 @@ class UpdateFeed(Feed):
     def link(self, obj):
         if not obj:
             raise FeedDoesNotExist
-        return obj.get_absolute_url()
+        return obj.get_absolute_url
 
     def item_link(self, item):
-        return item.get_absolute_url()
+        return item.get_absolute_url
 
     def item_title(self, item):
         return item.title
@@ -136,7 +136,7 @@ class UpdateFeed(Feed):
         try:
             item.photo.size
             return '<![CDATA[<p><a href="%s"><img src="%s" alt="" /></a></p><p>%s</p>]]>' % (
-                item.get_absolute_url(),
+                item.get_absolute_url,
                 item.photo.thumbnail.absolute_url,
                 item.text,
             )

--- a/akvo/rsr/management/commands/populate_project_directory_cache.py
+++ b/akvo/rsr/management/commands/populate_project_directory_cache.py
@@ -12,20 +12,57 @@ Usage:
     python manage.py populate_project_directory_cache
 
 """
+from time import time
 
 from django.core.management.base import BaseCommand
 
 from akvo.rest.views.project import serialized_project
 from akvo.rest.cache import delete_project_from_project_directory_cache
-from akvo.rsr.models import Project
+from akvo.rsr.models import Country, Partnership, Project, ProjectLocation, RecipientCountry, Sector
+from akvo.utils import build_dict
 
 
 class Command(BaseCommand):
     help = __doc__
 
     def handle(self, *args, **options):
-        projects = Project.objects.published().values_list('pk', flat=True)
+        start = time()
+        projects = Project.objects.published().only(
+            'id', 'title', 'subtitle',
+            'current_image',
+            'project_plan_summary',
+            'primary_location__id',
+            'primary_organisation__id',
+            'primary_organisation__name',
+            'primary_organisation__long_name',
+            'primary_location__latitude',
+            'primary_location__longitude',
+        ).select_related(
+            'primary_location',
+            'primary_organisation',
+        )
 
-        for project_id in projects:
-            delete_project_from_project_directory_cache(project_id)
-            serialized_project(project_id)
+        location_cache = build_dict(
+            (location.location_target_id, location) for location in ProjectLocation.objects.all()
+        )
+        partnership_cache = build_dict((partnership.id, partnership) for partnership in Partnership.objects.all())
+        recipient_country_cache = build_dict((country.id, country) for country in RecipientCountry.objects.all())
+        sector_cache = build_dict((sector.project_id, sector) for sector in Sector.objects.all())
+        country_cache = {country.id: country for country in Country.objects.all()}
+        print(f"Making caches took {time() - start}")
+
+        start = time()
+        print(f"Populating project directory cache with {projects.count()} projects")
+        for project in projects:
+            project_start = time()
+            delete_project_from_project_directory_cache(project)
+            serialized_project(
+                project,
+                location_cache,
+                partnership_cache,
+                recipient_country_cache,
+                sector_cache,
+                country_cache,
+            )
+            print(f"project {time() - project_start}", flush=True)
+        print(f"total: {time() - start}")

--- a/akvo/rsr/management/commands/unep_survey_import.py
+++ b/akvo/rsr/management/commands/unep_survey_import.py
@@ -211,7 +211,7 @@ class CSVToProject(object):
                 print("    ", cf.value)
             print()
         print("#" * 30)
-        delete_project_from_project_directory_cache(self.project.pk)
+        delete_project_from_project_directory_cache(self.project)
         if self.delete_data:
             self.project.delete()
 

--- a/akvo/rsr/models/focus_area.py
+++ b/akvo/rsr/models/focus_area.py
@@ -8,6 +8,7 @@
 from django.apps import apps
 from django.db import models
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from sorl.thumbnail.fields import ImageField
@@ -57,6 +58,7 @@ class FocusArea(models.Model):
         )
     )
 
+    @cached_property
     def get_absolute_url(self):
         return reverse('project-directory')
 

--- a/akvo/rsr/models/organisation.py
+++ b/akvo/rsr/models/organisation.py
@@ -10,6 +10,7 @@ from django.db import models
 from django.db.models import Sum, Q, signals
 from django.dispatch import receiver
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from sorl.thumbnail.fields import ImageField
@@ -185,6 +186,7 @@ class Organisation(TimestampsMixin):
     )
     objects = OrgManager()
 
+    @cached_property
     def get_absolute_url(self):
         return reverse('organisation-main', kwargs={'organisation_id': self.pk})
 

--- a/akvo/rsr/models/partner_site.py
+++ b/akvo/rsr/models/partner_site.py
@@ -8,6 +8,7 @@ For additional details on the GNU license please see < http://www.gnu.org/licens
 
 from django.conf import settings
 from django.db import models
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from akvo.rsr.validators import hostname_validator
@@ -264,6 +265,7 @@ class PartnerSite(TimestampsMixin):
         """Return full domain."""
         return '%s.%s' % (self.hostname, getattr(settings, 'AKVOAPP_DOMAIN', 'akvoapp.org'))
 
+    @cached_property
     def get_absolute_url(self):
         """Return absolute url."""
         url = ''

--- a/akvo/rsr/models/partnership.py
+++ b/akvo/rsr/models/partnership.py
@@ -171,7 +171,7 @@ class Partnership(models.Model):
 
     def organisation_show_link(self):
         if self.organisation:
-            return '<a href="{0}">{1}</a>'.format(self.organisation.get_absolute_url(),
+            return '<a href="{0}">{1}</a>'.format(self.organisation.get_absolute_url,
                                                   self.organisation.long_name
                                                   or self.organisation.name)
         return ''

--- a/akvo/rsr/models/planned_disbursement.py
+++ b/akvo/rsr/models/planned_disbursement.py
@@ -67,14 +67,14 @@ class PlannedDisbursement(models.Model):
 
     def provider_organisation_show_link(self):
         if self.provider_organisation:
-            return '<a href="{0}">{1}</a>'.format(self.provider_organisation.get_absolute_url(),
+            return '<a href="{0}">{1}</a>'.format(self.provider_organisation.get_absolute_url,
                                                   self.provider_organisation.long_name
                                                   or self.provider_organisation.name)
         return ''
 
     def receiver_organisation_show_link(self):
         if self.receiver_organisation:
-            return '<a href="{0}">{1}</a>'.format(self.receiver_organisation.get_absolute_url(),
+            return '<a href="{0}">{1}</a>'.format(self.receiver_organisation.get_absolute_url,
                                                   self.receiver_organisation.long_name
                                                   or self.receiver_organisation.name)
         return ''

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -1799,8 +1799,8 @@ class Project(TimestampsMixin):
         return User.objects.filter(pk__in=user_ids)
 
 
-def project_directory_cache_key(project_id):
-    return f'project_directory_{project_id}'
+def project_directory_cache_key(project: Project, *args, **kwargs):
+    return f'project_directory_{project.pk}'
 
 
 @receiver(post_save, sender=Project)

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -548,13 +548,14 @@ class Project(TimestampsMixin):
                                              'time than end date (actual).')}
             )
 
+    @cached_property
     def get_absolute_url(self):
         return reverse('project-main', kwargs={'project_id': self.pk})
 
     @property
     def cacheable_url(self):
         # Language names are 2 chars long
-        return self.get_absolute_url()[3:]
+        return self.get_absolute_url[3:]
 
     @cached_property
     def is_unep_project(self):

--- a/akvo/rsr/models/project_update.py
+++ b/akvo/rsr/models/project_update.py
@@ -9,6 +9,7 @@ import datetime
 from django.conf import settings
 from django.db import models
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from embed_video.fields import EmbedVideoField
 from sorl.thumbnail.fields import ImageField
@@ -85,6 +86,7 @@ class ProjectUpdate(TimestampsMixin):
     def time_last_updated_gmt(self):
         return to_gmt(self.last_modified_at)
 
+    @cached_property
     def get_absolute_url(self):
         return reverse('update-main', kwargs={'project_id': self.project_id, 'update_id': self.pk})
 

--- a/akvo/rsr/models/related_project.py
+++ b/akvo/rsr/models/related_project.py
@@ -76,7 +76,7 @@ class RelatedProject(models.Model):
 
     def related_project_show_link(self):
         if self.related_project:
-            return '<a href="{0}">{1}</a>'.format(self.related_project.get_absolute_url(),
+            return '<a href="{0}">{1}</a>'.format(self.related_project.get_absolute_url,
                                                   self.related_project.title)
         return ''
 

--- a/akvo/rsr/models/transaction.py
+++ b/akvo/rsr/models/transaction.py
@@ -156,14 +156,14 @@ class Transaction(models.Model):
 
     def provider_organisation_show_link(self):
         if self.provider_organisation:
-            return '<a href="{0}">{1}</a>'.format(self.provider_organisation.get_absolute_url(),
+            return '<a href="{0}">{1}</a>'.format(self.provider_organisation.get_absolute_url,
                                                   self.provider_organisation.long_name
                                                   or self.provider_organisation.name)
         return ''
 
     def receiver_organisation_show_link(self):
         if self.receiver_organisation:
-            return '<a href="{0}">{1}</a>'.format(self.receiver_organisation.get_absolute_url(),
+            return '<a href="{0}">{1}</a>'.format(self.receiver_organisation.get_absolute_url,
                                                   self.receiver_organisation.long_name
                                                   or self.receiver_organisation.name)
         return ''

--- a/akvo/rsr/models/user.py
+++ b/akvo/rsr/models/user.py
@@ -13,6 +13,7 @@ from django.core.mail import send_mail
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 import rules
 from sorl.thumbnail.fields import ImageField
@@ -129,6 +130,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     def __str__(self):
         return self.username
 
+    @cached_property
     def get_absolute_url(self):
         return "/user/{}/".format(self.pk)
 

--- a/akvo/rsr/templatetags/maps.py
+++ b/akvo/rsr/templatetags/maps.py
@@ -85,7 +85,7 @@ def get_location(item):
                 'image': avatar(item),
                 'latitude': location.latitude,
                 'longitude': location.longitude,
-                'url': item.get_absolute_url(),
+                'url': item.get_absolute_url,
                 'icon': icon,
                 'pk': str(item.pk),
                 'text': text}

--- a/akvo/rsr/views/py_reports/organisation_data_quality_overview_report.py
+++ b/akvo/rsr/views/py_reports/organisation_data_quality_overview_report.py
@@ -124,7 +124,7 @@ def _render_excel(reader):
         ws.set_cell_style(row, 4, Style(alignment=Alignment(horizontal='right')))
         ws.set_cell_value(row, 4, project.date_end_planned.strftime('%-d-%b-%Y') if project.date_end_planned else '')
         ws.set_cell_value(row, 5, country)
-        ws.set_cell_value(row, 6, 'https://{}{}'.format(settings.RSR_DOMAIN, project.get_absolute_url()))
+        ws.set_cell_value(row, 6, 'https://{}{}'.format(settings.RSR_DOMAIN, project.get_absolute_url))
         row += 1
     # r12
     ws.set_cell_style(row, 1, table_footer_first_style)
@@ -171,7 +171,7 @@ def _render_excel(reader):
         ws.set_cell_style(row, 5, Style(alignment=Alignment(horizontal='right')))
         ws.set_cell_value(row, 5, project.date_end_planned.strftime('%-d-%b-%Y') if project.date_end_planned else '')
         ws.set_cell_value(row, 6, country)
-        ws.set_cell_value(row, 7, 'https://{}{}'.format(settings.RSR_DOMAIN, project.get_absolute_url()))
+        ws.set_cell_value(row, 7, 'https://{}{}'.format(settings.RSR_DOMAIN, project.get_absolute_url))
         row += 1
     # r6
     ws.set_cell_style(row, 1, table_footer_first_style)
@@ -220,7 +220,7 @@ def _render_excel(reader):
         ws.set_cell_style(row, 6, Style(format=Format("#,#0.00")))
         ws.set_cell_value(row, 6, project.funds_needed)
         ws.set_cell_value(row, 7, country)
-        ws.set_cell_value(row, 8, 'https://{}{}'.format(settings.RSR_DOMAIN, project.get_absolute_url()))
+        ws.set_cell_value(row, 8, 'https://{}{}'.format(settings.RSR_DOMAIN, project.get_absolute_url))
         row += 1
     # r4
     ws.set_cell_style(row, 1, table_footer_first_style)
@@ -254,7 +254,7 @@ def _render_excel(reader):
         ws.set_cell_style(row, 4, Style(alignment=Alignment(horizontal='right')))
         ws.set_cell_value(row, 4, project.date_end_planned.strftime('%-d-%b-%Y') if project.date_end_planned else '')
         ws.set_cell_value(row, 5, country)
-        ws.set_cell_value(row, 6, 'https://{}{}'.format(settings.RSR_DOMAIN, project.get_absolute_url()))
+        ws.set_cell_value(row, 6, 'https://{}{}'.format(settings.RSR_DOMAIN, project.get_absolute_url))
         row += 1
     # r8
     ws.set_cell_style(row, 1, table_footer_first_style)

--- a/akvo/rsr/views/py_reports/project_updates_excel_report.py
+++ b/akvo/rsr/views/py_reports/project_updates_excel_report.py
@@ -96,7 +96,7 @@ def render_report(request, project_id):
         ws.set_cell_value(row, 11, update.event_date)
         ws.set_cell_value(row, 12, update.user.first_name)
         ws.set_cell_value(row, 13, update.user.last_name)
-        ws.set_cell_value(row, 14, 'https://{}{}'.format(settings.RSR_DOMAIN, update.get_absolute_url()))
+        ws.set_cell_value(row, 14, 'https://{}{}'.format(settings.RSR_DOMAIN, update.get_absolute_url))
         row += 1
 
     filename = '{}-{}-updates-table-report.xlsx'.format(

--- a/akvo/rsr/views/py_reports/utils.py
+++ b/akvo/rsr/views/py_reports/utils.py
@@ -208,7 +208,7 @@ class ProjectProxy(ObjectReaderProxy):
 
     @property
     def absolute_url(self):
-        return 'https://{}{}'.format(settings.RSR_DOMAIN, self.get_absolute_url())
+        return 'https://{}{}'.format(settings.RSR_DOMAIN, self.get_absolute_url)
 
 
 def make_project_proxies(periods, proxy_factory=ProjectProxy):

--- a/akvo/settings/90-finish.conf
+++ b/akvo/settings/90-finish.conf
@@ -105,5 +105,6 @@ CRONJOBS = [
     ('* * * * *', 'django.core.management.call_command', ['iati_import']),
     ('* * * * *', 'django.core.management.call_command', ['iati_export']),
     ('10 2 * * *', 'django.core.management.call_command', ['a4a_optimy_import']),
-    ('*/5 * * * *', 'django.core.management.call_command', ['perform_iati_checks'])
+    ('*/5 * * * *', 'django.core.management.call_command', ['perform_iati_checks']),
+    ('0 */1 * * *', 'django.core.management.call_command', ['populate_project_directory_cache']),
 ]

--- a/akvo/utils.py
+++ b/akvo/utils.py
@@ -15,6 +15,8 @@ from os.path import splitext
 import zipfile
 
 from decimal import Decimal, InvalidOperation
+from typing import Dict, Iterable, List, Tuple, TypeVar
+
 from django.conf import settings
 from django.contrib.admin.models import LogEntry, ADDITION, CHANGE, DELETION
 from django.contrib.auth.models import Group
@@ -548,3 +550,14 @@ class ObjectReaderProxy(object):
 
     def __getattr__(self, attr):
         return getattr(self._real, attr)
+
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+def build_dict(iterable: Iterable[Tuple[K, V]]) -> Dict[K, List[V]]:
+    d = {}
+    for key, value in iterable:
+        d.setdefault(key, []).append(value)
+    return d


### PR DESCRIPTION
The projects don't change often, so we should be able to cache them for a while.
Additionally, every hour we will regenerate their cached values (take ~7m right now).

So the quick fix is two-fold:

 - cache the entire result and keep for an hour
 - regenerate per project cache every hour

Once the page cache expires, queries should take ~10-20 seconds, but only once until the next hour.

Related to #4725: /rest/v1/project_directory performance