### PR TITLE
[#4725] workaround: Ultra hacky limitation to speed up project_dir

### DIFF
--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -272,7 +272,7 @@ def project_directory(request):
     """
 
     page = request.rsr_page
-    projects = _project_list(request)
+    projects = _project_list(request)[:10]
     projects_data = [
         serialized_project(project_id) for project_id in projects.values_list('pk', flat=True)
     ]


### PR DESCRIPTION
The request takes way too long when the cache is broken.
On production, it never actually is able to fill the cache.

To give us time to work on a solution, this limits the number of projects in the directory from

#4725: /rest/v1/project_directory performance
