### PR TITLE
Flush session store as well when clearing sessions

### DIFF
--- a/akvo/rsr/management/commands/clear_all_sessions.py
+++ b/akvo/rsr/management/commands/clear_all_sessions.py
@@ -1,3 +1,5 @@
+from importlib import import_module
+
 from django.conf import settings
 from django.core.cache import caches
 from django.core.management.base import BaseCommand, CommandError
@@ -10,9 +12,16 @@ class Command(BaseCommand):
     def handle(self, **options):
         if settings.SESSION_ENGINE != 'django.contrib.sessions.backends.cached_db':
             raise CommandError("Session engine %s is unsupported" % settings.SESSION_ENGINE)
+
+        engine = import_module(settings.SESSION_ENGINE)
+        SessionStore = engine.SessionStore
+
         # Delete sessions from DB
         sessions = Session.objects.all()
         print(f"Deleting {sessions.count()} sessions")
+        for session in sessions:
+            if session.session_key:
+                SessionStore(session.session_key).flush()
         sessions.delete()
 
         # Delete all cached sessions


### PR DESCRIPTION
On rsr.test.akvo.org the sessions weren't being cleared.
I'm not entirely sure why the SessionStore has to be cleared as well,
 but it did the trick on that env.
