### PR TITLE
[#4738] chore: enable coverage on most paths

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,13 +1,22 @@
 [run]
 source = akvo
+
+[report]
+
 omit =
     akvo/rsr/migrations/*
     akvo/codelists/migrations/*
+    akvo/codelists/store/*
     akvo/codelists/scripts/*
+    akvo/iati/imports/mappers/CordaidZip/*
+    # Tests will have 100% coverage anyway
+    */tests/*
+    # wsgi stuff
     akvo/handler.py
     akvo/wsgi.py
+    # utils
+    akvo/utils.py
 
-[report]
 exclude_lines =
     pragma: no cover
     if settings.DEBUG:
@@ -16,5 +25,4 @@ exclude_lines =
     if 'rosetta' in settings.INSTALLED_APPS:
     if not chunk:
     raise NotImplementedError
-sort = Cover
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,19 +3,9 @@ source = akvo
 omit =
     akvo/rsr/migrations/*
     akvo/codelists/migrations/*
-    akvo/codelists/store/*
     akvo/codelists/scripts/*
-    akvo/iati/imports/mappers/CordaidZip/*
-    akvo/scripts/*
-    akvo/stats/*
     akvo/handler.py
     akvo/wsgi.py
-    # Cheating a lot here obviously:
-    akvo/cache/*
-    akvo/rest/*
-    akvo/rsr/*
-    # Skip coverage check on utils
-    akvo/utils.py
 
 [report]
 exclude_lines =
@@ -27,4 +17,4 @@ exclude_lines =
     if not chunk:
     raise NotImplementedError
 sort = Cover
-fail_under = 100
+

--- a/.coveragerc
+++ b/.coveragerc
@@ -26,3 +26,6 @@ exclude_lines =
     if not chunk:
     raise NotImplementedError
 
+[html]
+
+directory = coverage/report/

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ data/*
 
 # Dev environment
 .coverage
+htmlcov/
 .vagrant
 Vagrantfile
 dev-env

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,8 @@ data/*
 # Dev environment
 .coverage
 coverage.xml
-htmlcov/
+coverage.xml.bak
+coverage/
 .vagrant
 Vagrantfile
 dev-env

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ data/*
 
 # Dev environment
 .coverage
+coverage.xml
 htmlcov/
 .vagrant
 Vagrantfile

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,6 +10,7 @@ blocks:
       secrets:
         - name: GCP
         - name: docker-hub-credentials
+        - name: coveralls
       prologue:
         commands:
           - checkout
@@ -20,9 +21,18 @@ blocks:
         - name: 'Build&Test'
           commands:
             - export PATH=${HOME}/google-cloud-sdk/bin:$PATH
-            - export CI_BRANCH=${SEMAPHORE_GIT_BRANCH}
+            # https://docs.semaphoreci.com/ci-cd-environment/environment-variables/
+            # SEMAPHORE_GIT_BRANCH = target branch for PRs
+            # We need the current branch
+            - export CI_BRANCH="${SEMAPHORE_GIT_PR_BRANCH:-$SEMAPHORE_GIT_BRANCH}"
+            - export CI_BUILD_NUMBER=${SEMAPHORE_WORKFLOW_ID}
+            - export CI_BUILD_URL="https://akvo.semaphoreci.com/jobs/${SEMAPHORE_JOB_ID}"
+            - export CI_JOB_ID=${SEMAPHORE_JOB_ID}
+            - export CI_NAME="semaphore-ci"
             - export CI_TAG=${SEMAPHORE_GIT_TAG_NAME}
             - export CI_COMMIT=${SEMAPHORE_GIT_SHA}
+            - export CI_PULL_REQUEST=${SEMAPHORE_GIT_PR_NUMBER}
+            - export COVERALLS_REPO_TOKEN="${COVERALLS_AKVO_RSR_TOKEN}"
             - export TRAVIS_COMMIT=${SEMAPHORE_GIT_SHA}
             - |-
               if [ "$SEMAPHORE_GIT_REF_TYPE" = "pull-request" ]; then

--- a/README.dev.md
+++ b/README.dev.md
@@ -45,6 +45,21 @@ docker-compose exec web ./manage.py test -k -v 3 akvo.rsr.tests.test_templatetag
 - `-k` keeps the database between consecutive test runs, so that migrations
   needn't be run each time (which take a long time!)
 
+#### Coverage
+
+It may be good to know which portions of the code we have covered.
+
+```shell
+scripts/devhelpers/coverage.sh
+```
+
+This will run the tests and output the coverage information to stdout, HTML, and XML.
+The XML can be used by certain service and some IDEs (e.g [PyCharm][PyCharm Coverage]) to interactively show coverage
+ while browsing the source files.
+Otherwise, you can always browse the HTML at `htmlcov/index.html`.
+
+[PyCharm Coverage]: https://www.jetbrains.com/help/pycharm/switching-between-code-coverage-suites.html
+
 ### Front-end assets
 
 Front-end assets are managed by webpack. For production deployments, webpack

--- a/README.dev.md
+++ b/README.dev.md
@@ -56,7 +56,11 @@ scripts/devhelpers/coverage.sh
 This will run the tests and output the coverage information to stdout, HTML, and XML.
 The XML can be used by certain service and some IDEs (e.g [PyCharm][PyCharm Coverage]) to interactively show coverage
  while browsing the source files.
-Otherwise, you can always browse the HTML at `htmlcov/index.html`.
+Otherwise, you can always browse the HTML at `coverage/report/index.html`.
+
+The coverage of the diff between your branch and master will also be available at
+ `coverage/diff.html`.
+You can use this to show which parts of the new code you wrote are covered.
 
 [PyCharm Coverage]: https://www.jetbrains.com/help/pycharm/switching-between-code-coverage-suites.html
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Akvo Really Simple Reporting (Akvo RSR)
 
-[![Build Status](https://travis-ci.org/akvo/akvo-rsr.svg?branch=develop)](https://travis-ci.org/akvo/akvo-rsr) [![Coverage Status](https://coveralls.io/repos/github/akvo/akvo-rsr/badge.svg?branch=develop)](https://coveralls.io/github/akvo/akvo-rsr?branch=develop) [![Code Health](https://landscape.io/github/akvo/akvo-rsr/develop/landscape.svg?style=flat)](https://landscape.io/github/akvo/akvo-rsr/develop)
+[![Build Status](https://akvo.semaphoreci.com/badges/akvo-rsr/branches/master.svg?style=shields)](https://akvo.semaphoreci.com/projects/akvo-rsr)
+[![Coverage Status](https://coveralls.io/repos/github/akvo/akvo-rsr/badge.svg?branch=master)](https://coveralls.io/github/akvo/akvo-rsr?branch=master)
 
 Akvo Foundation is a non-profit foundation that builds open source internet and mobile phone software which is used to make international development cooperation and governance more effective and transparent.
 

--- a/ci/build-semaphoreci.sh
+++ b/ci/build-semaphoreci.sh
@@ -48,9 +48,12 @@ docker-compose -p rsrci -f docker-compose.yaml -f docker-compose.ci.yaml up -d -
 
 if [[ ! "${SKIP_BACKEND_TESTS:-}" = yes ]]; then
   log Running tests
-  docker-compose -p rsrci -f docker-compose.yaml -f docker-compose.ci.yaml run web scripts/docker/dev/run-as-user.sh scripts/docker/ci/build.sh
+  docker-compose \
+    -p rsrci \
+    -f docker-compose.yaml \
+    -f docker-compose.ci.yaml \
+    run web scripts/docker/dev/run-as-user.sh scripts/docker/ci/build.sh
 fi
-
 
 #log Stopping docker-compose
 #docker-compose -p rsrci -f docker-compose.yaml -f docker-compose.ci.yaml down

--- a/docker-compose.ci.yaml
+++ b/docker-compose.ci.yaml
@@ -10,3 +10,12 @@ services:
     image: rsr-backend:dev
     command: "true"
     network_mode: service:mainnetwork
+    environment:
+      # env vars for coveralls
+      COVERALLS_REPO_TOKEN: "${COVERALLS_REPO_TOKEN}"
+      CI_BRANCH: "${CI_BRANCH}"
+      CI_BUILD_NUMBER: "${CI_BUILD_NUMBER}"
+      CI_BUILD_URL: "${CI_BUILD_URL}"
+      CI_JOB_ID: "${CI_JOB_ID}"
+      CI_NAME: "${CI_NAME}"
+      CI_PULL_REQUEST: "${CI_PULL_REQUEST}"

--- a/scripts/deployment/pip/requirements/3_dev.txt
+++ b/scripts/deployment/pip/requirements/3_dev.txt
@@ -159,6 +159,10 @@ coverage==5.3 \
     --hash=sha256:cb7df71de0af56000115eafd000b867d1261f786b5eebd88a0ca6360cccfaca7 \
     --hash=sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636 \
     --hash=sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8 \
+    # via -r scripts/deployment/pip/requirements/dev.in, coveralls
+coveralls==3.3.1 \
+    --hash=sha256:b32a8bb5d2df585207c119d6c01567b81fba690c9c10a753bfe27a335bfc43ea \
+    --hash=sha256:f42015f31d386b351d4226389b387ae173207058832fbf5c8ec4b40e27b16026 \
     # via -r scripts/deployment/pip/requirements/dev.in
 cssselect2==0.4.1 \
     --hash=sha256:2f4a9f20965367bae459e3bb42561f7927e0cfe5b7ea1692757cf67ef5d7dace \
@@ -255,6 +259,9 @@ djangorestframework==3.12.4 \
     --hash=sha256:6d1d59f623a5ad0509fe0d6bfe93cbdfe17b8116ebc8eda86d45f6e16e819aaf \
     --hash=sha256:f747949a8ddac876e879190df194b925c177cdeb725a099db1460872f7c0a7f2 \
     # via -r scripts/deployment/pip/requirements/production.in, django-rest-swagger, djangorestframework-csv
+docopt==0.6.2 \
+    --hash=sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491 \
+    # via coveralls
 et-xmlfile==1.0.1 \
     --hash=sha256:614d9722d572f6246302c4491846d2c393c199cfa4edc9af593437691683335b \
     # via openpyxl
@@ -667,7 +674,7 @@ pyyaml==5.4.1 \
 requests==2.26.0 \
     --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24 \
     --hash=sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7 \
-    # via -r scripts/deployment/pip/requirements/production.in, coreapi, django-embed-video, google-api-core, google-cloud-storage
+    # via -r scripts/deployment/pip/requirements/production.in, coreapi, coveralls, django-embed-video, google-api-core, google-cloud-storage
 rsa==4.7.2 \
     --hash=sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2 \
     --hash=sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9 \

--- a/scripts/deployment/pip/requirements/3_dev.txt
+++ b/scripts/deployment/pip/requirements/3_dev.txt
@@ -108,6 +108,10 @@ cffi==1.14.3 \
     --hash=sha256:f92cdecb618e5fa4658aeb97d5eb3d2f47aa94ac6477c6daf0f306c5a3b9e6b1 \
     --hash=sha256:f92f789e4f9241cd262ad7a555ca2c648a98178a953af117ef7fad46aa1d5591 \
     # via bcrypt, cairocffi, google-crc32c, weasyprint
+chardet==3.0.4 \
+    --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
+    --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
+    # via diff-cover
 charset-normalizer==2.0.9 \
     --hash=sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721 \
     --hash=sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c \
@@ -176,6 +180,10 @@ defusedxml==0.6.0 \
     --hash=sha256:6687150770438374ab581bb7a1b327a847dd9c5749e396102de3fad4e8a3ef93 \
     --hash=sha256:f684034d135af4c6cbb949b8a4d2ed61634515257a67299e5f940fbaa34377f5 \
     # via cairosvg, djangorestframework-xml, odfpy
+diff-cover==6.4.4 \
+    --hash=sha256:b1d782c1ce53ad4b2c5545f8b7aa799eb61a0b12a62b376a18e2313c6f2d77f1 \
+    --hash=sha256:d89c165d3c852c3c10e9f969236e08d413225ce52be8e2477be2a070987229bf \
+    # via -r scripts/deployment/pip/requirements/dev.in
 django-bootstrap3==15.0.0 \
     --hash=sha256:601c918a466e6a702f7b394a94826ba9f53c9cc879ccfc26579e3473eef80f53 \
     --hash=sha256:f803efd5605046b8f467523dbe94653a4a8d6bcf97ad480b386ba5cf8f94fe6b \
@@ -355,7 +363,7 @@ jedi==0.17.2 \
 jinja2==2.11.3 \
     --hash=sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419 \
     --hash=sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6 \
-    # via coreschema, pyexcelerate
+    # via coreschema, diff-cover, pyexcelerate
 lxml==4.4.2 \
     --hash=sha256:00ac0d64949fef6b3693813fe636a2d56d97a5a49b5bbb86e4cc4cc50ebc9ea2 \
     --hash=sha256:0571e607558665ed42e450d7bf0e2941d542c18e117b1ebbf0ba72f287ad841c \
@@ -491,6 +499,10 @@ pip-tools==5.3.1 \
     --hash=sha256:5672c2b6ca0f1fd803f3b45568c2cf7fadf135b4971e7d665232b2075544c0ef \
     --hash=sha256:73787e23269bf8a9230f376c351297b9037ed0d32ab0f9bef4a187d976acc054 \
     # via -r scripts/deployment/pip/requirements/dev.in
+pluggy==1.0.0 \
+    --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
+    --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3 \
+    # via diff-cover
 prompt-toolkit==3.0.8 \
     --hash=sha256:25c95d2ac813909f813c93fde734b6e44406d1477a9faef7c915ff37d39c0a8c \
     --hash=sha256:7debb9a521e0b1ee7d2fe96ee4bd60ef03c6492784de0547337ca4433e46aa63 \
@@ -602,7 +614,7 @@ pyflakes==2.2.0 \
 pygments==2.9.0 \
     --hash=sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f \
     --hash=sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e \
-    # via ipython
+    # via diff-cover, ipython
 pyjwt==2.3.0 \
     --hash=sha256:b888b4d56f06f6dcd777210c334e69c737be74755d3e5e9ee3fe67dc18a0ee41 \
     --hash=sha256:e0c4bb8d9f0af0c7f5b1ec4c5036309617d03d56932877f2f7a0beeb5318322f \

--- a/scripts/deployment/pip/requirements/dev.in
+++ b/scripts/deployment/pip/requirements/dev.in
@@ -22,6 +22,8 @@ pip-tools
 # coverage test
 coverage
 coveralls
+# Highlight coverage between the diff of your branch and another one
+diff_cover
 
 # Profiling packages
 django-cprofile-middleware

--- a/scripts/deployment/pip/requirements/dev.in
+++ b/scripts/deployment/pip/requirements/dev.in
@@ -21,6 +21,7 @@ pip-tools
 
 # coverage test
 coverage
+coveralls
 
 # Profiling packages
 django-cprofile-middleware

--- a/scripts/devhelpers/coverage.sh
+++ b/scripts/devhelpers/coverage.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+
+function log {
+   echo "$(date +"%T") - coverage.sh - $*"
+}
+
+# Detect if executed outside of docker to run script in docker
+if [[ ! -e /.dockerenv ]] ; then
+  docker-compose run --rm web scripts/devhelpers/coverage.sh
+
+  # Replace docker paths with local paths in XML
+  # Makes it usable by other tools
+  GIT_ROOT="$(git rev-parse --show-toplevel)"
+  cd $GIT_ROOT
+  sed -i -e "s|/var/akvo/rsr/code|${GIT_ROOT}|g" coverage.xml
+else
+  COVERAGE_PROCESS_START=.coveragerc \
+    coverage run --parallel-mode --concurrency=multiprocessing \
+    manage.py test --keepdb --parallel 4 akvo
+
+  coverage combine
+  coverage report --skip-empty --skip-covered
+  coverage html --skip-empty --skip-covered
+  coverage xml
+fi

--- a/scripts/devhelpers/coverage.sh
+++ b/scripts/devhelpers/coverage.sh
@@ -12,16 +12,24 @@ if [[ ! -e /.dockerenv ]] ; then
 
   # Replace docker paths with local paths in XML
   # Makes it usable by other tools
+  # A backup is available with the .bak extension
   GIT_ROOT="$(git rev-parse --show-toplevel)"
   cd $GIT_ROOT
-  sed -i -e "s|/var/akvo/rsr/code|${GIT_ROOT}|g" coverage.xml
+  sed -i.bak -e "s|/var/akvo/rsr/code|${GIT_ROOT}|g" coverage.xml
 else
   COVERAGE_PROCESS_START=.coveragerc \
     coverage run --parallel-mode --concurrency=multiprocessing \
     manage.py test --keepdb --parallel 4 akvo
 
   coverage combine
+  mkdir -p coverage
   coverage report --skip-empty --skip-covered
   coverage html --skip-empty --skip-covered
   coverage xml
+
+  # Output the new lines aren't covered by this branch
+  diff-cover coverage.xml \
+    --html-report coverage/diff.html \
+    --compare-branch origin/master \
+    --show-uncovered
 fi

--- a/scripts/docker/ci/build.sh
+++ b/scripts/docker/ci/build.sh
@@ -50,4 +50,9 @@ log Coverage
 coverage combine
 coverage report -m
 
+# Push coverage to coveralls.io
+if [[ -n "${COVERALLS_REPO_TOKEN}" ]] ; then
+  coveralls
+fi
+
 log Done


### PR DESCRIPTION
We need to know the real coverage in order to help identifying those parts of the code that still need testing.

The coverage is available on [coverage.io](https://coveralls.io/github/akvo/akvo-rsr?branch=feature/4738-get-real-coverage-in-ci) and a script was added to generate it locally.
Additionally, the script generates a report of the coverage of the diff between the current branch and `origin/master`. That'll be helpful to ensure that what you wrote is actually tested.

Close #4738