### PR TITLE
[#4745] Project updates delete main photo

### DIFF
--- a/akvo/rsr/spa/app/modules/updates/styles.scss
+++ b/akvo/rsr/spa/app/modules/updates/styles.scss
@@ -99,3 +99,6 @@
     }
   }
 }
+.ant-upload-list-picture-card-container{
+  margin: 10px 8px 8px 0 !important;
+}

--- a/akvo/rsr/spa/app/modules/updates/updates-photo.js
+++ b/akvo/rsr/spa/app/modules/updates/updates-photo.js
@@ -1,19 +1,37 @@
 /* eslint-disable no-unused-vars */
 /* globals File */
 import React, { useState, useEffect } from 'react'
-import { Upload, Icon, message } from 'antd'
+import { Upload, message, Button, Modal } from 'antd'
 import { getBase64 } from '../../utils/misc'
 
 
-const UploadButton = () => (
-  <div>
-    <Icon type="plus" />
-    <div className="ant-upload-text">Upload</div>
-  </div>
-)
-
-const UpdatesPhoto = ({onChange, value}) => {
-  const [imageUrl, setImageUrl] = useState('')
+const UpdatesPhoto = ({
+  handleOnDeletePhoto,
+  onChange,
+  value,
+  fields,
+  index,
+  uid = null
+}) => {
+  const [fileList, setFileList] = useState([
+    {
+      uid,
+      url: value,
+    }
+  ])
+  const [preview, setPreview] = useState({
+    visible: false,
+    image: null
+  })
+  const handlePreview = async file => {
+    if (!file.url && !file.preview) {
+      file.preview = await getBase64(file.originFileObj, (res) => res)
+    }
+    setPreview({
+      visible: true,
+      image: file.url || file.preview
+    })
+  }
   const handleBeforeUpload = file => {
     const isJpgOrPng = file.type === 'image/jpeg' || file.type === 'image/png'
     if (!isJpgOrPng) {
@@ -25,25 +43,55 @@ const UpdatesPhoto = ({onChange, value}) => {
     }
     if (isJpgOrPng && isLt10M) {
       onChange(file)
-      getBase64(file, setImageUrl)
+      getBase64(file, (res) => {
+        setFileList([
+          {
+            ...fileList[0],
+            url: res
+          }
+        ])
+      })
     }
     return false
   }
   useEffect(() => {
     const isFile = value instanceof File
     if (!isFile) {
-      setImageUrl(value)
+      setFileList([
+        {
+          ...fileList[0],
+          uid,
+          url: value
+        }
+      ])
     }
   }, [value])
   return (
-    <Upload
-      listType="picture-card"
-      className="avatar-uploader"
-      showUploadList={false}
-      beforeUpload={handleBeforeUpload}
-    >
-      {imageUrl ? <img src={imageUrl} alt="updates preview" style={{ width: '100%' }} /> : <UploadButton />}
-    </Upload>
+    <>
+      <Upload
+        listType="picture"
+        beforeUpload={handleBeforeUpload}
+        fileList={fileList}
+        onRemove={({ uid: photoID }) => {
+          handleOnDeletePhoto(photoID, fields, index)
+        }}
+        onPreview={handlePreview}
+      >
+        <Button icon="upload">Upload</Button>
+      </Upload>
+      <Modal
+        visible={preview.visible}
+        footer={null}
+        onCancel={() => {
+          setPreview({
+            image: null,
+            visible: false
+          })
+        }}
+      >
+        <img src={preview.image} style={{ width: '100%' }} alt="preview" />
+      </Modal>
+    </>
   )
 }
 

--- a/akvo/rsr/spa/app/modules/updates/updates.jsx
+++ b/akvo/rsr/spa/app/modules/updates/updates.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 /* global window, FormData, File */
 import React, { useEffect, useState, useRef } from 'react'
-import { Input, Form, Button, Select, DatePicker, Icon, Spin, Modal } from 'antd'
+import { Input, Form, Button, Select, DatePicker, Icon, Spin, notification } from 'antd'
 import { useCurrentPosition } from 'react-use-geolocation'
 import moment from 'moment'
 import axios from 'axios'
@@ -20,7 +20,6 @@ import UpdatesPhoto from './updates-photo'
 import updatesSchema from './updates-validator'
 import { validateFormValues } from '../../utils/validation-utils'
 
-const { confirm } = Modal
 const { Item } = Form
 const { Option } = Select
 const axiosConfig = {
@@ -93,13 +92,13 @@ const Updates = ({ projectId }) => {
     const {photos: inputPhotos, ...inputValues} = input
     const {photos: initialPhotos, ...initialValues} = initial
     const {photo: diffPhoto, ...diffValues} = diff(initialValues, {...inputValues, eventDate: inputValues.eventDate.format('DD/MM/YYYY')})
-    const currentPhotos = inputPhotos.filter(photo => photo.hasOwnProperty('id'))
+    const currentPhotos = inputPhotos.filter(photo => photo?.hasOwnProperty('id'))
     const diffCurrentPhotos = currentPhotos.map(photo => {
       const initialPhoto = initialPhotos.find(it => it.id === photo.id)
       const diffProps = diff(initialPhoto, photo)
       return isEmpty(diffProps) ? {} : {id: initialPhoto.id, update: initialPhoto.update, ...diffProps}
     }).filter(it => !isEmpty(it))
-    const additionalPhotos = inputPhotos.filter(it => !it.hasOwnProperty('id') && it.photo && it.photo instanceof File)
+    const additionalPhotos = inputPhotos.filter(it => !it?.hasOwnProperty('id') && it?.photo && it?.photo instanceof File)
     let result = {...initial}
     try {
       if (!isEmpty(diffValues) || (diffPhoto instanceof File)) {
@@ -207,30 +206,54 @@ const Updates = ({ projectId }) => {
   }
 
   const handleOnDeletePhoto = (photoID, fields, index) => {
-    confirm({
-      title: 'Are you sure to delete this photo?',
-      content: 'After this action you can\'t put it back',
-      onOk() {
-        if (photoID) {
-          axios({
-            url: `${config.baseURL}/project_update/${updates[editing]?.id}/photos/${photoID}/`,
-            method: 'DELETE',
-            ...axiosConfig
+    if (photoID) {
+      axios({
+        url: `${config.baseURL}/project_update/${updates[editing]?.id}/photos/${photoID}/`,
+        method: 'DELETE',
+        ...axiosConfig
+      })
+      setUpdates((state) => {
+        return [
+          ...state.slice(0, editing),
+          {
+            ...updates[editing],
+            photos: updates[editing]?.photos?.filter(photo => photo?.id !== photoID)
+          },
+          ...state.slice(editing + 1)
+        ]
+      })
+      fields.remove(index)
+    } else {
+      const payload = {
+        photo: null,
+        photoCredit: '',
+        photoCaption: ''
+      }
+      api
+        .patch(`/project_update/${initialValues.id}/`, payload, axiosConfig)
+        .then(() => {
+          setInitialValues({
+            ...initialValues,
+            ...payload
           })
           setUpdates((state) => {
             return [
               ...state.slice(0, editing),
               {
-                ...updates[editing],
-                photos: updates[editing]?.photos?.filter(photo => photo?.id !== photoID)
+                ...initialValues,
+                ...payload
               },
               ...state.slice(editing + 1)
             ]
           })
-        }
-        fields.remove(index)
-      }
-    })
+        })
+        .catch(({ response: { data } }) => {
+          notification.error({
+            message: 'Error!',
+            description: Object.values(data)?.map((d, dx) => <span key={dx}>{d?.join('')}<br /></span>)
+          })
+        })
+    }
   }
 
   const showMore = (page) => {
@@ -314,7 +337,7 @@ const Updates = ({ projectId }) => {
                 form: {
                   mutators: { push }
                 },
-                submitting, pristine, invalid
+                submitting, pristine, invalid, values
               }) => (
                 <Form layout="vertical" onSubmit={handleSubmit}>
                   <Item {...getValidateStatus('title')} className="title-item" label={(
@@ -345,7 +368,7 @@ const Updates = ({ projectId }) => {
                     <Field name="eventDate" render={({ input }) => <DatePicker {...input} format="DD/MM/YYYY" />} />
                   </Item>
                   <Item className="title-item" label="Main photo" {...getValidateStatus('photo')}>
-                    <Field name="photo" render={({ input }) => <UpdatesPhoto {...input} />} />
+                    <Field name="photo" render={({ input }) => <UpdatesPhoto {...{ ...input, handleOnDeletePhoto }} />} />
                   </Item>
                   <Item className="title-item">
                     <Field name="photoCaption" placeholder="Main photo caption" component="input" className="ant-input" />
@@ -358,30 +381,46 @@ const Updates = ({ projectId }) => {
                       {({ fields }) =>
                         fields.map((name, index) => (
                           <div key={name}>
-                            <div style={{ float: 'left' }}>
-                              <Field
-                                name={`${name}.photo`}
-                                render={({ input }) => <UpdatesPhoto {...input} />}
-                              />
-                              <Field
-                                name={`${name}.caption`}
-                                placeholder="Photo caption"
-                                component="input"
-                                className="ant-input"
-                              />
-                              <Field
-                                name={`${name}.credit`}
-                                placeholder="Photo credit"
-                                component="input"
-                                className="ant-input"
-                              />
-                            </div>
-                            <div style={{ float: 'left', paddingLeft: 10 }}>
-                              <Field
-                                name={`${name}.id`}
-                                render={({ input }) => <a onClick={() => handleOnDeletePhoto(input?.value, fields, index)}><Icon type="delete" /></a>}
-                              />
-                            </div>
+                            <Field
+                              name={`${name}.photo`}
+                              render={({ input }) => {
+                                return values?.photos[index]?.id
+                                  ? (
+                                    <UpdatesPhoto
+                                      {...{
+                                        ...input,
+                                        handleOnDeletePhoto,
+                                        fields,
+                                        index,
+                                        uid: values.photos[index].id
+                                      }}
+                                    />
+                                  ) : (
+                                    <UpdatesPhoto
+                                      {...{
+                                        ...input,
+                                        fields,
+                                        index,
+                                        handleOnDeletePhoto: () => {
+                                          fields.remove(index)
+                                        }
+                                      }}
+                                    />
+                                  )
+                              }}
+                            />
+                            <Field
+                              name={`${name}.caption`}
+                              placeholder="Photo caption"
+                              component="input"
+                              className="ant-input"
+                            />
+                            <Field
+                              name={`${name}.credit`}
+                              placeholder="Photo credit"
+                              component="input"
+                              className="ant-input"
+                            />
                           </div>
                         ))
                       }


### PR DESCRIPTION
Fix issue : VNG partners can't create Project Updates

It seems that a user is not able to delete an uploaded image to draft Project Update once they have upload an image. We need to change this:

![image](https://user-images.githubusercontent.com/20871229/146889325-511d5b1b-44e8-44d1-9722-8cc0b474fd48.png)


- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
