### PR TITLE
[#4761] Fix: invalid space when searching project by title

### DIFF
--- a/akvo/rsr/spa/app/modules/projects/projects.jsx
+++ b/akvo/rsr/spa/app/modules/projects/projects.jsx
@@ -82,7 +82,7 @@ class Projects extends React.Component{
     this.setState({
       loading: true,
       pagination: { ...this.state.pagination, current: 1 },
-      params: {...this.state.params, src}
+      params: {...this.state.params, src: src?.trim()}
     })
     clearTimeout(tmid)
     tmid = setTimeout(this.fetch, 500)


### PR DESCRIPTION
## What happened?
Search projects by title doesn't work if we add extra space

### Bug reproduce
1. Login to RSR
2. Search project by title
3. Add space after project title
4. RSR shows no search results after keywords have trailing spaces


https://user-images.githubusercontent.com/20871229/147434224-36306661-bb63-45d0-b050-59066a2e91fe.mov


- [ ] Test plan | Unit test | Integration test
- [ ] Documentation
