### PR TITLE
[#4779] Make indicator baseline value optional in IATI export

### DIFF
--- a/akvo/codelists/store/codelists_v203.py
+++ b/akvo/codelists/store/codelists_v203.py
@@ -4879,12 +4879,16 @@ RELATED_ACTIVITY_TYPE = (
 )
 
 # From http://iatistandard.org/203/codelists/downloads/clv2/xml/ResultType.xml
+RESULT_TYPE_OUTPUT = "1"
+RESULT_TYPE_OUTCOME = "2"
+RESULT_TYPE_IMPACT = "3"
+RESULT_TYPE_OTHER = "9"
 RESULT_TYPE = (
     ("code", "name", "description"),
-    ("1", _(u"Output"), _(u"Results of the activity that came about as a direct effect of your work and specific, what is done, and what communities are reached. For example, X number of individuals.")),
-    ("2", _(u"Outcome"), _(u"Results of the activity that produce an effect on the overall communities or issues you serve. For example lower rate of infection after a vaccination programme.")),
-    ("3", _(u"Impact"), _(u"The long term effects of the outcomes, that lead to larger, over arching results, such as improved life-expectancy.")),
-    ("9", _(u"Other"), _(u"Another type of result, not specified above.")),
+    (RESULT_TYPE_OUTPUT, _(u"Output"), _(u"Results of the activity that came about as a direct effect of your work and specific, what is done, and what communities are reached. For example, X number of individuals.")),
+    (RESULT_TYPE_OUTCOME, _(u"Outcome"), _(u"Results of the activity that produce an effect on the overall communities or issues you serve. For example lower rate of infection after a vaccination programme.")),
+    (RESULT_TYPE_IMPACT, _(u"Impact"), _(u"The long term effects of the outcomes, that lead to larger, over arching results, such as improved life-expectancy.")),
+    (RESULT_TYPE_OTHER, _(u"Other"), _(u"Another type of result, not specified above.")),
 )
 
 # From http://iatistandard.org/203/codelists/downloads/clv2/xml/ResultVocabulary.xml

--- a/akvo/iati/checks/fields/results.py
+++ b/akvo/iati/checks/fields/results.py
@@ -59,12 +59,6 @@ def results(project):
                         'message': ('indicator baseline has no value specified, however the '
                                     'value of "N/A" has been set for the attribute')})))
 
-                elif indicator.baseline_year or indicator.baseline_comment:
-                    all_checks_passed = False
-                    checks.append(('error', json.dumps({
-                        'model': 'indicator', 'id': indicator.pk, 'result_id': result.pk,
-                        'message': 'indicator baseline has no value specified'})))
-
             if not indicator.baseline_year:
                 if DGIS_PROJECT:
                     all_checks_passed = False

--- a/akvo/rsr/tests/iati_checks/test_iati_checks_fields_results.py
+++ b/akvo/rsr/tests/iati_checks/test_iati_checks_fields_results.py
@@ -101,13 +101,11 @@ class IatiChecksFieldsReultsTestCase(TestCase):
 
         # Then
         self.assertFalse(all_checks_passed)
-        self.assertEqual(len(checks), 4)
+        self.assertEqual(len(checks), 3)
         self.assertIn('has no measure specified', checks[0][1])
         self.assertIn('has no title specified', checks[1][1])
         self.assertEqual('error', checks[2][0])
-        self.assertIn('baseline has no value specified', checks[2][1])
-        self.assertEqual('error', checks[3][0])
-        self.assertIn('baseline has no year specified', checks[3][1])
+        self.assertIn('baseline has no year specified', checks[2][1])
 
     def test_iati_checks_fields_results_indicator_dgis_error(self):
         # Given the use of the DGIS validation set


### PR DESCRIPTION
The [specs](https://iatistandard.org/en/iati-standard/203/activity-standard/iati-activities/iati-activity/result/indicator/baseline/) say it is optional.

Closes #4779: IATI export with results with missing baseline values isn't working

It will be necessary to run the iati check on projects once deployed (`./manage.py perform_iati_checks --all`)