### PR TITLE
[#4771] A comma too many, a comma too few

### DIFF
--- a/akvo/rsr/tests/results_framework/test_results_framework.py
+++ b/akvo/rsr/tests/results_framework/test_results_framework.py
@@ -234,7 +234,7 @@ class ResultsFrameworkTestCase(BaseTestCase):
         self.indicator.measure = "2"
         # # these properties were not set already, and hence should be updated too
         self.indicator.baseline_year = 2010
-        self.indicator.baseline_value = 'value',
+        self.indicator.baseline_value = 'value'
         self.indicator.baseline_comment = 'comment'
         self.indicator.export_to_iati = False
         self.indicator.scores = ['Good', 'Bad', 'Ugly']
@@ -270,7 +270,7 @@ class ResultsFrameworkTestCase(BaseTestCase):
 
         # When
         self.indicator.baseline_year = 2010
-        self.indicator.baseline_value = 'value',
+        self.indicator.baseline_value = 'value'
         self.indicator.baseline_comment = 'comment'
         self.indicator.save()
 

--- a/akvo/rsr/views/py_reports/__init__.py
+++ b/akvo/rsr/views/py_reports/__init__.py
@@ -68,6 +68,6 @@ __all__ = [
     'render_org_projects_overview_report',
     'render_program_overview_excel_report',
     'render_program_overview_pdf_report',
-    'render_program_period_lables_overview'
+    'render_program_period_lables_overview',
     'render_nuffic_country_level_report',
 ]


### PR DESCRIPTION
Closes #4771: Missing comma in `__all__` results in unexpected string concatenation

