### PR TITLE
Fix [#4795]: Support branch names with a single quote in the CI

### DIFF
--- a/ci/build-semaphoreci.sh
+++ b/ci/build-semaphoreci.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eu
 
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+
 if [[ "${CI_TAG:-}" =~ promote-.* ]]; then
     echo "Skipping build as it is a prod promotion"
     exit 0
@@ -8,6 +10,10 @@ fi
 
 function log {
    echo "$(date +"%T") - BUILD INFO - $*"
+}
+
+function quote() {
+    "$GIT_ROOT"/ci/quote.py "$1"
 }
 
 # Create the checksum function if it doesn't exist already
@@ -83,9 +89,9 @@ fi
 #docker-compose -p rsrci -f docker-compose.yaml -f docker-compose.ci.yaml down
 
 log Preparing deploy info file
-echo "DEPLOY_COMMIT_FULL_ID = '`git rev-parse HEAD`'" > ._66_deploy_info.conf
-echo "DEPLOY_COMMIT_ID = '`git rev-parse --short HEAD`'" >> ._66_deploy_info.conf
-echo "DEPLOY_BRANCH = '$CI_BRANCH'" >> ._66_deploy_info.conf
+echo "DEPLOY_COMMIT_FULL_ID = $(quote "`git rev-parse HEAD`")" > ._66_deploy_info.conf
+echo "DEPLOY_COMMIT_ID = $(quote "`git rev-parse --short HEAD`")" >> ._66_deploy_info.conf
+echo "DEPLOY_BRANCH = $(quote "$CI_BRANCH")" >> ._66_deploy_info.conf
 
 docker_build akvo/rsr-backend-prod-no-code -f Dockerfile-prod-no-code .
 

--- a/ci/quote.py
+++ b/ci/quote.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""
+Outputs a valid python string from the given input
+
+Only one parameter is accepted
+"""
+
+import shlex
+import sys
+
+quote = shlex.quote(sys.argv[1])
+if not (quote.startswith("'") or quote.startswith('"')):
+    quote = f"'{quote}'"
+
+print(quote)


### PR DESCRIPTION
Branch names can have all kinds of quotes and characters.
Since, I couldn't find a python function that does exactly what's needed (take a string and output the same string with escaped chars),  I took the next best thing and output a POSIX, escaped string.

Hopefully that should mostly be accepted by python.

If the CI for this passes, then the modifications should work as a single quote is in this branch's name.

Fix #4795