### PR TITLE
[#4811] Fix: Creating orgs with logos on google cloud

### DIFF
--- a/akvo/rsr/signals.py
+++ b/akvo/rsr/signals.py
@@ -97,7 +97,7 @@ def change_name_of_file_on_create(sender, **kwargs):
                         datetime.now().strftime("%Y-%m-%d_%H.%M.%S"),
                         os.path.splitext(img.name)[1],
                     )
-                    save_image(img, img_name)
+                    save_image(img, img_name, f.name)
                     # Create thumbnail for use in reports
                     if sender == ProjectUpdate:
                         get_report_thumbnail(img)

--- a/akvo/utils.py
+++ b/akvo/utils.py
@@ -523,13 +523,13 @@ def maybe_decimal(value):
         return None
 
 
-def save_image(img, name):
+def save_image(img, name, field_name):
     if isinstance(img.storage, GoogleCloudStorage):
         new_name = img.field.generate_filename(img.instance, name)
         blob = img.storage.bucket.blob(img.name)
         img.storage.bucket.rename_blob(blob, new_name)
         img.name = new_name
-        img.instance.save(update_fields=['photo'])
+        img.instance.save(update_fields=[field_name])
     else:
         img.save(name, img)
 


### PR DESCRIPTION
<!--
For internal contributors, before work can start on a PR that's user facing,
the "Test plan" will have to be reviewed.
-->


# TODO / Done

The image field name on the model being saved is now passed as a parameter to the `save_image` function.
The signal is for multiple models and their image fields don't have the same
 name as all other classes.
The old code just assumed "photo", but orgs have a "logo" field.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - As an admin open http://localhost/en/admin/rsr/organisation/add/
 -  Fill in required fields
 -  Add logo
 - Save

Closes #4811