### PR TITLE
[#4808]: Let a4a_optimy_import leave publishingstatus alone

### DIFF
--- a/akvo/rsr/management/commands/a4a_optimy_import.py
+++ b/akvo/rsr/management/commands/a4a_optimy_import.py
@@ -284,9 +284,6 @@ def create_project(project, answers):
         else:
             print(f"Could not find iso code for {name}")
 
-    # Publish the project
-    project.publish()
-
     return project
 
 


### PR DESCRIPTION
<!--
For internal contributors, before work can start on a PR that's user facing,
the "Test plan" will have to be reviewed.
-->


# TODO / Done

Remove line that modifies the publishing status.

# Test plan

Could only do this locally by inserting the credentials into the configuration and running the script to make sure publishing statuses didn't change.

Closes #4808