### PR TITLE
[#4809] Set default validation set for a4a_optimy_import

### DIFF
--- a/akvo/rsr/management/commands/a4a_optimy_import.py
+++ b/akvo/rsr/management/commands/a4a_optimy_import.py
@@ -28,7 +28,7 @@ from akvo.rsr.models import (
     Partnership,
     Project,
     ProjectCustomField,
-    ProjectLocation,
+    ProjectEditorValidationSet, ProjectLocation,
 )
 from akvo.utils import custom_get_or_create_country
 
@@ -84,6 +84,7 @@ DEFAULT_PROJECT_INFO = {
     "default_tied_status": "3",
     "default_finance_type": "110",
 }
+VALIDATION_SET_NAME = "DGIS Modified"
 
 
 def programs_exist():
@@ -172,6 +173,10 @@ def create_project(project, answers):
             name="Optimy Project ID",
             defaults=dict(value=project_id, section="1", order="1"),
         )
+
+        validation_set = ProjectEditorValidationSet.objects.filter(name=VALIDATION_SET_NAME).first()
+        if validation_set:
+            project.validations.add(validation_set)
 
     program = Project.objects.get(pk=lead_project_id)
     project.add_to_program(program)


### PR DESCRIPTION
<!--
For internal contributors, before work can start on a PR that's user facing,
the "Test plan" will have to be reviewed.
-->


# TODO / Done

Find the default validation for projects imported by optimy and add it to the project.

# Test plan

Not sure. Gotta check :thinking: 


Closes #4809