### PR TITLE
[#4802] Adding the 'Result type' and the corresponding title

### DIFF
--- a/akvo/rsr/spa/app/components/ResultType.jsx
+++ b/akvo/rsr/spa/app/components/ResultType.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { Typography } from 'antd'
+import { useTranslation } from 'react-i18next'
+
+import { resultTypes } from '../utils/constants'
+
+const { Text } = Typography
+
+const ResultType = ({ type, title }) => {
+  const { t } = useTranslation()
+  const resultName = resultTypes.find((r) => r.value === type)?.label
+  const titles = title?.split(':')
+  const isIncluded = (titles.length > 1 && title?.toLowerCase()?.includes(resultName))
+  return isIncluded
+    ? (
+      <>
+        <Text strong>{titles[0]}</Text>
+        <Text>&nbsp;:&nbsp;{titles[1]}</Text>
+      </>
+    )
+    : (
+      <>
+        <Text strong>{t(resultName)}</Text>
+        <Text>&nbsp;:&nbsp;{title}</Text>
+      </>
+    )
+}
+
+export default ResultType

--- a/akvo/rsr/spa/app/components/StatusIndicator.jsx
+++ b/akvo/rsr/spa/app/components/StatusIndicator.jsx
@@ -19,9 +19,9 @@ const StatusIndicator = ({ status }) => {
   }
   return (
     <Row>
-      <Col style={{ display: 'flex', gap: 15 }}>
-        <Text strong>Status : </Text>
-        <Text>{description}</Text>
+      <Col style={{ display: 'flex', gap: 10 }}>
+        <Text strong>Status</Text>
+        <Text>:&nbsp;{description}</Text>
       </Col>
     </Row>
   )

--- a/akvo/rsr/spa/app/modules/results-admin/ResultAdmin.jsx
+++ b/akvo/rsr/spa/app/modules/results-admin/ResultAdmin.jsx
@@ -75,6 +75,11 @@ const ResultAdmin = ({
       ...r,
       indicators: r.indicators.map((i) => ({
         ...i,
+        result: {
+          id: r.id,
+          title: r.title,
+          type: r.type
+        },
         periods: i.periods
           ?.filter((p) => (isPeriodNeedsReportingForAdmin(p, needsReportingTimeoutDays)))
           ?.filter((p) => {

--- a/akvo/rsr/spa/app/modules/results-admin/TobeReported.jsx
+++ b/akvo/rsr/spa/app/modules/results-admin/TobeReported.jsx
@@ -24,6 +24,7 @@ import ReportedEdit from './components/ReportedEdit'
 import { isPeriodNeedsReportingForAdmin } from '../results/filters'
 import Highlighted from '../../components/Highlighted'
 import StatusIndicator from '../../components/StatusIndicator'
+import ResultType from '../../components/ResultType'
 
 const { Text } = Typography
 
@@ -149,8 +150,9 @@ const TobeReported = ({
                     </div>
                   )}
                   <StatusIndicator status={item?.status} />
-                  <Text strong>Title : </Text>
+                  <ResultType {...item?.indicator?.result} />
                   <br />
+                  <Text strong>Title : </Text>
                   <Highlighted text={item?.indicator?.title} highlight={keyword} />
                   <br />
                   {((!isEmpty(item?.indicator?.description.trim())) && item?.indicator?.description?.trim().length > 5) && (

--- a/akvo/rsr/spa/app/modules/results-overview/ResultOverview.jsx
+++ b/akvo/rsr/spa/app/modules/results-overview/ResultOverview.jsx
@@ -201,9 +201,9 @@ const ResultOverview = ({
                     <Panel
                       header={(
                         <Row>
-                          <Col><Text strong>Title : </Text></Col>
                           <Col>
-                            <Highlighted text={indicator.title} highlight={search} />
+                            <Text strong>Title : </Text>
+                            <Highlighted text={indicator?.title} highlight={search} />
                           </Col>
                         </Row>
                       )}

--- a/akvo/rsr/spa/app/modules/results/EnumeratorPage.jsx
+++ b/akvo/rsr/spa/app/modules/results/EnumeratorPage.jsx
@@ -305,7 +305,6 @@ const EnumeratorPage = ({
                     )}
                     <StatusIndicator status={item?.status} />
                     <Text strong>Title : </Text>
-                    <br />
                     <Highlighted text={item?.indicator?.title} highlight={keyword} />
                   </Col>
                   <Col span={2} style={{ textAlign: 'center' }}>


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Adding the 'Result type' and the corresponding title
 
![image](https://user-images.githubusercontent.com/20871229/152930673-4eb9f828-43cd-41ce-bd03-f8f8929213ad.png)

 - [x] Put title on the same line at 'Results Overview' tab.

![image](https://user-images.githubusercontent.com/20871229/152930704-c5450209-2340-456e-80c8-b750a85270e6.png)

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Result Type show at Results Admin tab

<img width="1403" alt="Screen Shot 2022-02-08 at 13 20 21" src="https://user-images.githubusercontent.com/20871229/152930417-773321db-0cee-486b-887a-2b8a96356388.png">
<img width="1433" alt="Screen Shot 2022-02-08 at 13 20 34" src="https://user-images.githubusercontent.com/20871229/152930449-2ff99ecf-ff58-4c8d-9fca-cdb05d0ad8e1.png">

 - [ ] Label title inline with indicator title at Results Overview

<img width="1390" alt="Screen Shot 2022-02-08 at 13 20 54" src="https://user-images.githubusercontent.com/20871229/152930475-dd050154-c297-4589-9150-d0a9a1b0aa2c.png">



 
