### PR TITLE
[#4828] Fix Misplaced chart visual in the 'Description' section

### DIFF
--- a/akvo/rsr/spa/app/modules/results-overview/ResultOverview.jsx
+++ b/akvo/rsr/spa/app/modules/results-overview/ResultOverview.jsx
@@ -9,11 +9,13 @@ import SimpleMarkdown from 'simple-markdown'
 
 import { FilterBar, Indicator } from './components'
 import { resultTypes } from '../../utils/constants'
+import { setNumberFormat } from '../../utils/misc'
 import Portal from '../../utils/portal'
 import api from '../../utils/api'
 import '../results/styles.scss'
+import './ResultOverview.scss'
 import Highlighted from '../../components/Highlighted'
-
+import TargetCharts from '../../utils/target-charts'
 
 const { Panel } = Collapse
 const { Text } = Typography
@@ -197,6 +199,8 @@ const ResultOverview = ({
                 bordered={false}
               >
                 {result.indicators.filter(indicatorsFilter).map(indicator => {
+                  const sumActualValue = indicator?.periods.reduce((total, currentValue) => total + currentValue.actualValue, 0)
+                  const percent = parseInt(indicator?.targetValue > 0 ? (sumActualValue / indicator.targetValue) * 100 : 0, 10)
                   return (
                     <Panel
                       header={(
@@ -209,12 +213,54 @@ const ResultOverview = ({
                       )}
                       key={indicator.id}
                     >
-                      {((!isEmpty(indicator.description.trim())) && indicator.description.trim().length > 5) && (
-                        <details style={{ padding: '16px 22px' }}>
-                          <summary>Description</summary>
-                          <p>{mdOutput(mdParse(indicator.description))}</p>
-                        </details>
-                      )}
+                      {
+                        (targetsAt && targetsAt === 'indicator' && indicator?.targetValue)
+                          ? (
+                            <Row className="border-top border-bottom">
+                              <Col span={17}>
+                                {((!isEmpty(indicator.description.trim())) && indicator.description.trim().length > 5) && (
+                                  <details style={{ padding: '16px 22px' }}>
+                                    <summary>Description</summary>
+                                    <p>{mdOutput(mdParse(indicator.description))}</p>
+                                  </details>
+                                )}
+                              </Col>
+                              <Col span={4} className="target-indicator border-left">
+                                <TargetCharts actualValue={sumActualValue} targetValue={indicator.targetValue} />
+                              </Col>
+                              <Col span={3} className="target-indicator" style={{ paddingRight: 10 }}>
+                                <ul>
+                                  <li>
+                                    <div className="label">aggregated actual value</div>
+                                  </li>
+                                  <li>
+                                    <h4 className="value"><b>{setNumberFormat(sumActualValue)}</b></h4>
+                                  </li>
+                                  <li>
+                                    <div className="label">of</div>
+                                  </li>
+                                  <li>
+                                    <h4><b>{setNumberFormat(indicator.targetValue)}</b></h4>
+                                  </li>
+                                  <li>
+                                    <div className="label">target</div>
+                                  </li>
+                                </ul>
+                              </Col>
+                            </Row>
+                          ) : (
+                            <Row>
+                              <Col>
+                                {((!isEmpty(indicator.description.trim())) && indicator.description.trim().length > 5) && (
+                                  <details style={{ padding: '16px 22px' }}>
+                                    <summary>Description</summary>
+                                    <p>{mdOutput(mdParse(indicator.description))}</p>
+                                  </details>
+                                )}
+                              </Col>
+                            </Row>
+                          )
+                      }
                       <Indicator
                         {...{
                           result,

--- a/akvo/rsr/spa/app/modules/results-overview/ResultOverview.scss
+++ b/akvo/rsr/spa/app/modules/results-overview/ResultOverview.scss
@@ -1,0 +1,49 @@
+.indicator-chart {
+  padding: 8px 16px;
+  background-color: #fff;
+  margin: 0 5px;
+  .stats-indicator {
+    .stat {
+      &.value {
+        text-align: left !important;
+      }
+    }
+  }
+  .percent-label {
+    text-align: center;
+  }
+}
+.target-indicator {
+  min-height: 150px;
+  padding-top: 16px;
+  ul {
+    text-align: right;
+    overflow-wrap: break-word;
+  }
+  .charts {
+    .percent-label {
+      text-align: center;
+    }
+  }
+  h4.value {
+    color: #389a90;
+  }
+  .label {
+    font-weight: 500;
+    font-size: 10px;
+    color: #212121;
+    text-transform: uppercase;
+  }
+}
+.border-top {
+  border-top: 1px solid #d3d3d3;
+}
+.border-bottom {
+  border-bottom: 1px solid #d3d3d3;
+}
+.border-left {
+  border-left: 1px solid #d3d3d3;
+}
+.border-right {
+  border-right: 1px solid #d3d3d3;
+}

--- a/akvo/rsr/spa/app/modules/results-overview/components/Indicator.jsx
+++ b/akvo/rsr/spa/app/modules/results-overview/components/Indicator.jsx
@@ -1,10 +1,8 @@
 import React, { useState } from 'react'
-import { Row, Col, Collapse, Icon, Checkbox } from 'antd'
+import { Card, Collapse, Empty, Icon, Row, Col } from 'antd'
 import { useTranslation } from 'react-i18next'
 import moment from 'moment'
-import { setNumberFormat } from '../../../utils/misc'
 import { UpdatePeriod } from './UpdatePeriod'
-import TargetCharts from '../../../utils/target-charts'
 
 const { Panel } = Collapse
 const Aux = node => node.children
@@ -19,29 +17,18 @@ export const Indicator = ({
   const [activeKey, setActiveKey] = useState(-1)
 
   const { t } = useTranslation()
-  const sumActualValue = indicator?.periods.reduce((total, currentValue) => total + currentValue.actualValue, 0)
-
   return indicator.periods.length === 0
-    ? <div className="no-periods">{t('This indicator has no periods')}</div>
+    ? (
+      <Row>
+        <Col style={{ padding: 16 }}>
+          <Card>
+            <Empty description={t('This indicator has no periods')} />
+          </Card>
+        </Col>
+      </Row>
+    )
     : (
       <Aux>
-        {targetsAt && targetsAt === 'indicator' && indicator?.targetValue && (
-          <Row>
-            <Col span={16} />
-            <Col span={4} className="stats-indicator">
-              <div className="stat value">
-                <div className="label">aggregated actual value</div>
-                <b>{setNumberFormat(sumActualValue)}</b><br />
-                <span>
-                  of <b>{indicator?.targetValue}</b> target
-                </span>
-              </div>
-            </Col>
-            <Col span={4}>
-              {<TargetCharts targetValue={indicator?.targetValue} actualValue={sumActualValue} />}
-            </Col>
-          </Row>
-        )}
         <Collapse accordion className="periods" bordered={false} activeKey={activeKey} onChange={key => { setActiveKey(key) }}>
           {indicator.periods.map(period => {
             const updates = period?.updates?.sort((a, b) => b.id - a.id)

--- a/akvo/rsr/spa/app/utils/target-charts.jsx
+++ b/akvo/rsr/spa/app/utils/target-charts.jsx
@@ -13,8 +13,7 @@ const TargetCharts = ({ actualValue, targetValue }) => {
       backgroundColor: ['#389a90', '#e1eded'],
       hoverBorderWidth: 3,
       hoverBorderColor: '#fff',
-      hoverBackgroundColor: ['#389a90', '#e1eded'],
-      borderWidth: 3
+      hoverBackgroundColor: ['#389a90', '#e1eded']
     }
   ]
   const labels = []


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Fix chart position as designed by Ouma.
 - [x] Create empty state for indicator that doesn't have reporting periods.

# Original Design
by Ouma
https://xd.adobe.com/view/8b187c71-6cb6-4300-b4b3-ef46e4b9b667-de4b/screen/c8559c33-368a-4e42-a3e2-ec448ce60167/

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Aggregated actual value is 0 (zero)
 - [ ] Aggregated actual value  > 0 ( more than zero)
 
 
<img width="1440" alt="Screen Shot 2022-02-14 at 20 56 09" src="https://user-images.githubusercontent.com/20871229/153876993-0c8ff7b0-e25f-4037-885f-6384904c55f9.png">

 - [ ] Check indicator that has no reporting periods
 
<img width="1440" alt="Screen Shot 2022-02-14 at 20 54 16" src="https://user-images.githubusercontent.com/20871229/153876811-15898f0f-1d13-42de-b3cf-8ff9f61fb2f9.png">
