### PR TITLE
[#4849] Log when Project location is being deleted from a project

### DIFF
--- a/akvo/rsr/models/location.py
+++ b/akvo/rsr/models/location.py
@@ -3,9 +3,11 @@
 # Akvo RSR is covered by the GNU Affero General Public License.
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
-
+import logging
 
 from django.db import models
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
 
 from ..fields import LatitudeField, LongitudeField, ValidXMLCharField
@@ -213,9 +215,20 @@ ProjectLocation._meta.get_field('country').help_text = _(
     'The country or countries that benefit(s) from the activity.'
 )
 
+logger = logging.getLogger(__name__)
+
+
+@receiver(pre_delete, sender=ProjectLocation)
+def on_projectlocation_delete(sender, instance: ProjectLocation, using, **kwargs):
+    logger.warning(
+        "About to delete ProjectLocation(%s) %s of project(%s) %s",
+        instance.id, instance,
+        instance.location_target.id, instance.location_target,
+        stack_info=True
+    )
+
 
 class AdministrativeLocation(models.Model):
-
     project_relation = 'locations__administratives__in'
 
     location = models.ForeignKey(


### PR DESCRIPTION
This is temporary and should be removed once #4849 is fixed or the cause has been found

# TODO / Done

 - [ ] Add a `pre_delete` signal that logs when a project location is being deleted along with the stack trace

# Test plan

 - [x]  Local env: check that log is written when deleting a project location

example

```
WARNING 2022-02-15 14:35:10,710 location About to delete ProjectLocation(4) Latitude: No latitude specified, Longitude: No longitude specified, Country: No country specified of project(28) Test Project
Stack (most recent call last):
  File "/opt/.pycharm_helpers/pycharm/django_test_manage.py", line 168, in <module>
    utility.execute()
  File "/opt/.pycharm_helpers/pycharm/django_test_manage.py", line 142, in execute
    _create_command().run_from_argv(self.argv)
  File "/usr/local/lib/python3.8/site-packages/django/core/management/commands/test.py", line 23, in run_from_argv
    super().run_from_argv(argv)
  File "/usr/local/lib/python3.8/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.8/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/opt/.pycharm_helpers/pycharm/django_test_manage.py", line 104, in handle
    failures = TestRunner(test_labels, **options)
  File "/opt/.pycharm_helpers/pycharm/django_test_runner.py", line 254, in run_tests
    return DjangoTeamcityTestRunner(**options).run_tests(test_labels,
  File "/opt/.pycharm_helpers/pycharm/django_test_runner.py", line 156, in run_tests
    return super(DjangoTeamcityTestRunner, self).run_tests(test_labels, extra_tests, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/test/runner.py", line 729, in run_tests
    result = self.run_suite(suite)
  File "/opt/.pycharm_helpers/pycharm/django_test_runner.py", line 151, in run_suite
    return TeamcityTestRunner.run(self, suite, **self.options)
  File "/opt/.pycharm_helpers/pycharm/tcunittest.py", line 262, in run
    test(result)
  File "/usr/local/lib/python3.8/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/local/lib/python3.8/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/local/lib/python3.8/site-packages/django/test/testcases.py", line 245, in __call__
    self._setup_and_call(result)
  File "/usr/local/lib/python3.8/site-packages/django/test/testcases.py", line 281, in _setup_and_call
    super().__call__(result)
  File "/usr/local/lib/python3.8/unittest/case.py", line 736, in __call__
    return self.run(*args, **kwds)
  File "/usr/local/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/usr/local/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/opt/project/akvo/rsr/tests/rest/test_project_location.py", line 49, in test_project_location_delete
    location.delete()
  File "/opt/project/akvo/rsr/models/location.py", line 54, in delete
    super(BaseLocation, self).delete(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/django/db/models/base.py", line 967, in delete
    return collector.delete()
  File "/usr/local/lib/python3.8/site-packages/django/db/models/deletion.py", line 404, in delete
    signals.pre_delete.send(
  File "/usr/local/lib/python3.8/site-packages/django/dispatch/dispatcher.py", line 180, in send
    return [
  File "/usr/local/lib/python3.8/site-packages/django/dispatch/dispatcher.py", line 181, in <listcomp>
    (receiver, receiver(signal=self, sender=sender, **named))
  File "/opt/project/akvo/rsr/models/location.py", line 222, in on_projectlocation_delete
    logger.warning(
```

--------------

Related to #4849: Bug: Locations are reset on some projects