### PR TITLE
[#4856] part1: fix: restore DB dump in dev env as postgres user

### DIFF
--- a/scripts/data/make-and-restore-production-dump.sh
+++ b/scripts/data/make-and-restore-production-dump.sh
@@ -27,7 +27,6 @@ docker run \
 
 ## Run just these two commands if you already have a dump and you want to restore it.
 docker-compose exec \
-    -e RSR_PASSWORD=rsrpasswddb \
   rsrdbhost \
     /data-scripts/restore-from-dump.sh \
       /var/run/postgresql \

--- a/scripts/data/restore-from-dump.sh
+++ b/scripts/data/restore-from-dump.sh
@@ -7,15 +7,9 @@ RSR_DB_NAME="${2}"
 RSR_USER="${3}"
 DUMP_FILE="${4}"
 
-if [[ -z "${RSR_PASSWORD:-}" ]]; then
-    read -r -s -p "Password for user ${RSR_USER} for the new DB ${RSR_DB_NAME}@${DB_HOST}: " RSR_PASSWORD
-fi
-
-export PGPASSWORD="${RSR_PASSWORD}"
-
 echo ""
 
-psql_settings=("--username=${RSR_USER}" "--host=${DB_HOST}" "--dbname=${RSR_DB_NAME}" "--set" "ON_ERROR_STOP=on")
+psql_settings=("--username=postgres" "--host=${DB_HOST}" "--dbname=${RSR_DB_NAME}" "--set" "ON_ERROR_STOP=on")
 
 psql "${psql_settings[@]}" --command="DROP SCHEMA public CASCADE"
 psql "${psql_settings[@]}" --command="CREATE SCHEMA public"
@@ -25,3 +19,27 @@ gunzip --stdout "${DUMP_FILE}" \
   | sed -e "/rsr_reportserver_db_user/d" \
   | sed -e "/ALTER DEFAULT PRIVILEGES FOR ROLE postgres/d" \
   | psql "${psql_settings[@]}"
+
+echo "Setting the owner of public tables to ${RSR_USER}"
+echo "
+  select
+    'Alter table '||t.schemaname||'.'||t.tablename ||' owner to ${RSR_USER};'
+  from pg_tables t
+  where schemaname='public';
+" | psql "${psql_settings[@]}" \
+  | grep Alter \
+  | psql "${psql_settings[@]}"
+
+echo "Setting the owner of public views to ${RSR_USER}"
+echo "
+  select
+    'Alter view '||v.schemaname||'.'||v.viewname ||' owner to ${RSR_USER};'
+  from pg_views v
+  where schemaname='public';
+" | psql "${psql_settings[@]}" \
+  | grep Alter \
+  | psql "${psql_settings[@]}"
+
+echo "Granting access to all current and future public tables for user ${RSR_USER}"
+echo "GRANT ALL ON schema public TO ${RSR_USER};" | psql "${psql_settings[@]}"
+echo "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO ${RSR_USER};" | psql "${psql_settings[@]}"


### PR DESCRIPTION
# TODO / Done

This allows us to import dumps with privileged queries (e.g `CREATE EXTENSION`) by importing as the `postgres` user.
After the import, the RSR user is granted privileges and ownership of the tables and views. Without it, it's not possible to CRUD the tables/views.

Part 2 will be fixing training environments in order to import using the `postgres` user

# Test plan

 - [x] Load normal dumps
 - [x] Start web app
 - [x] Load dump with privileged extension

## Load normal dumps

This happens normally when starting up the DB service.

## Start web app

We ensure this way that migrations are run and RSR works normally.

## Load dump with privileged extension

We can manually import a dump like so

```sh
echo "CREATE EXTENSION IF NOT EXISTS ltree" | gzip - > scripts/data/dumps/test.gz
docker-compose exec \
    rsrdbhost /data-scripts/restore-from-dump.sh \
        /var/run/postgresql \
        rsrdb \
        rsruserdb \
        /data-scripts/dumps/test.gz
```
----------

Related to #4856: Bug: Restoring DB dump with `ltree` extension doesn't work