### PR TITLE
[#4872] fix opening project results using copied form access link

### DIFF
--- a/akvo/rest/authentication.py
+++ b/akvo/rest/authentication.py
@@ -3,9 +3,10 @@
 # Akvo RSR is covered by the GNU Affero General Public License.
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
-
+from typing import Optional
 
 from django.utils.translation import ugettext_lazy as _
+from request_token.models import RequestToken
 from rest_framework import exceptions
 from rest_framework.authentication import TokenAuthentication, BaseAuthentication
 from tastypie.models import ApiKey
@@ -47,7 +48,7 @@ class TastyTokenAuthentication(TokenAuthentication):
 class JWTAuthentication(BaseAuthentication):
 
     def authenticate(self, request):
-        token = getattr(request, 'token', None)
+        token: Optional[RequestToken] = getattr(request, 'token', None)
         if token is not None:
             if token.scope != JWT_WEB_FORMS_SCOPE:
                 raise exceptions.AuthenticationFailed(_('Incorrect JWT token scope.'))
@@ -56,9 +57,9 @@ class JWTAuthentication(BaseAuthentication):
             except Exception:
                 raise exceptions.AuthenticationFailed(_('Invalid JWT token.'))
 
-            return self.authenticate_credentials(token, request._request)
+            return self.authenticate_credentials(token)
 
-    def authenticate_credentials(self, token, request):
+    def authenticate_credentials(self, token):
         if not token.user.is_active:
             raise exceptions.AuthenticationFailed(_('User inactive or deleted.'))
-        return (token.user, token)
+        return token.user, token

--- a/akvo/rest/models.py
+++ b/akvo/rest/models.py
@@ -61,11 +61,4 @@ class JWTAuthentication(BaseAuthentication):
     def authenticate_credentials(self, token, request):
         if not token.user.is_active:
             raise exceptions.AuthenticationFailed(_('User inactive or deleted.'))
-
-        response = MockResponse()
-        token.log(request, response)
         return (token.user, token)
-
-
-class MockResponse():
-    status_code = None

--- a/akvo/rest/views/indicator_period.py
+++ b/akvo/rest/views/indicator_period.py
@@ -8,7 +8,7 @@ from ..serializers import IndicatorPeriodSerializer, IndicatorPeriodFrameworkSer
 from ..viewsets import PublicProjectViewSet
 
 from akvo.rsr.models import Project, Indicator, IndicatorPeriod
-from akvo.rest.models import TastyTokenAuthentication
+from akvo.rest.authentication import TastyTokenAuthentication
 from django.http import HttpResponseBadRequest, HttpResponseForbidden, JsonResponse
 from django.shortcuts import get_object_or_404
 from rest_framework import status

--- a/akvo/rest/views/indicator_period_data.py
+++ b/akvo/rest/views/indicator_period_data.py
@@ -8,7 +8,7 @@ import json
 import os
 
 from akvo.rsr.models import IndicatorPeriodData, IndicatorPeriodDataComment, Project
-from akvo.rest.models import TastyTokenAuthentication, JWTAuthentication
+from akvo.rest.authentication import TastyTokenAuthentication, JWTAuthentication
 from akvo.rsr.models.result.utils import QUANTITATIVE, PERCENTAGE_MEASURE
 
 from ..serializers import (IndicatorPeriodDataSerializer, IndicatorPeriodDataFrameworkSerializer,

--- a/akvo/rest/views/program_results_geo.py
+++ b/akvo/rest/views/program_results_geo.py
@@ -24,7 +24,7 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_403_FORBIDDEN
 
 from akvo.codelists.models import ResultType
-from akvo.rest.models import TastyTokenAuthentication
+from akvo.rest.authentication import TastyTokenAuthentication
 from akvo.rsr.models import Project, IndicatorPeriod, IndicatorPeriodData
 from akvo.rsr.models.result.utils import QUANTITATIVE, QUALITATIVE, PERCENTAGE_MEASURE, calculate_percentage
 from akvo.utils import ensure_decimal

--- a/akvo/rest/views/project.py
+++ b/akvo/rest/views/project.py
@@ -26,7 +26,7 @@ from akvo.rest.serializers import (ProjectSerializer, ProjectExtraSerializer,
                                    OrganisationCustomFieldSerializer,
                                    ProjectHierarchyRootSerializer,
                                    ProjectHierarchyTreeSerializer,)
-from akvo.rest.models import TastyTokenAuthentication
+from akvo.rest.authentication import TastyTokenAuthentication
 from akvo.rsr.models import Project, OrganisationCustomField, IndicatorPeriodData
 from akvo.rsr.views.my_rsr import user_viewable_projects
 from akvo.utils import codelist_choices, single_period_dates

--- a/akvo/rest/views/project_editor.py
+++ b/akvo/rest/views/project_editor.py
@@ -15,7 +15,7 @@ from rest_framework.exceptions import ValidationError as RestValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from akvo.rest.models import TastyTokenAuthentication
+from akvo.rest.authentication import TastyTokenAuthentication
 from akvo.rsr.models import Indicator, Project, Result
 
 

--- a/akvo/rest/views/project_enumerators.py
+++ b/akvo/rest/views/project_enumerators.py
@@ -148,7 +148,7 @@ def _assign_indicators(enumerator, indicator_ids):
         enumerator.assigned_indicators.remove(pk)
 
 
-def _update_user_token(user_id, project_id, preview=False):
+def _update_user_token(user_id, project_id, preview=False) -> RequestToken:
     token = RequestToken.objects.select_related('user')\
                                 .filter(scope=JWT_WEB_FORMS_SCOPE, user_id=user_id).first()
     issued_at = tz_now()

--- a/akvo/rest/views/project_enumerators.py
+++ b/akvo/rest/views/project_enumerators.py
@@ -15,7 +15,7 @@ from rest_framework.decorators import api_view, authentication_classes
 from rest_framework.response import Response
 
 from akvo.constants import JWT_WEB_FORMS_SCOPE, JWT_MAX_USE
-from akvo.rest.models import TastyTokenAuthentication
+from akvo.rest.authentication import TastyTokenAuthentication
 from akvo.rsr.models import Project, Indicator, IndicatorPeriod, User
 from akvo.utils import rsr_send_mail
 

--- a/akvo/rest/views/project_overview.py
+++ b/akvo/rest/views/project_overview.py
@@ -7,7 +7,7 @@
 
 
 from akvo.codelists.models import ResultType
-from akvo.rest.models import TastyTokenAuthentication
+from akvo.rest.authentication import TastyTokenAuthentication
 from akvo.rsr.models import Project, Result, Indicator, IndicatorPeriod, IndicatorPeriodData
 from akvo.rsr.models.result.utils import QUANTITATIVE, QUALITATIVE, PERCENTAGE_MEASURE, calculate_percentage
 from akvo.utils import ensure_decimal

--- a/akvo/rest/views/project_update.py
+++ b/akvo/rest/views/project_update.py
@@ -18,7 +18,7 @@ from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 
 from akvo.codelists.store.default_codelists import SECTOR_CATEGORY
-from akvo.rest.models import TastyTokenAuthentication, JWTAuthentication
+from akvo.rest.authentication import TastyTokenAuthentication, JWTAuthentication
 from akvo.rest.serializers import (
     ProjectUpdateSerializer, ProjectUpdateDirectorySerializer, ProjectUpdateExtraSerializer,
     TypeaheadSectorSerializer, TypeaheadOrganisationSerializer, ProjectUpdatePhotoSerializer,

--- a/akvo/rest/views/result.py
+++ b/akvo/rest/views/result.py
@@ -5,7 +5,7 @@ See more details in the license.txt file located at the root folder of the Akvo 
 For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 """
 
-from akvo.rest.models import TastyTokenAuthentication, JWTAuthentication
+from akvo.rest.authentication import TastyTokenAuthentication, JWTAuthentication
 from akvo.rsr.models import Indicator, Result, Project
 from django.shortcuts import get_object_or_404
 from rest_framework.authentication import SessionAuthentication

--- a/akvo/rest/views/user.py
+++ b/akvo/rest/views/user.py
@@ -15,7 +15,7 @@ from rest_framework.decorators import authentication_classes
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
-from akvo.rest.models import TastyTokenAuthentication
+from akvo.rest.authentication import TastyTokenAuthentication
 from ..viewsets import BaseRSRViewSet
 from ..serializers import UserSerializer, UserDetailsSerializer, UserPasswordSerializer
 

--- a/akvo/rest/viewsets.py
+++ b/akvo/rest/viewsets.py
@@ -18,7 +18,7 @@ from rest_framework import status
 from akvo.cache import cache_with_key
 from akvo.cache.prepo import QuerysetPrePo
 from akvo.rsr.models import PublishingStatus, Project, User
-from akvo.rest.models import TastyTokenAuthentication
+from akvo.rest.authentication import TastyTokenAuthentication
 from akvo.rest.cache import delete_project_from_project_directory_cache
 from akvo.utils import log_project_changes, get_project_for_object
 

--- a/akvo/rsr/models/__init__.py
+++ b/akvo/rsr/models/__init__.py
@@ -9,7 +9,7 @@ import logging
 from django.db.models.signals import pre_save, post_save, post_delete
 from django.contrib.admin.models import LogEntry
 
-from akvo.rest.models import create_api_key
+from akvo.rest.authentication import create_api_key
 
 from ..signals import (
     change_name_of_file_on_change, change_name_of_file_on_create,

--- a/akvo/rsr/tests/rest/test_authentication.py
+++ b/akvo/rsr/tests/rest/test_authentication.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+"""
+Akvo RSR is covered by the GNU Affero General Public License.
+
+See more details in the license.txt file located at the root folder of the Akvo RSR module.
+For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+"""
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.test import APIRequestFactory
+
+from akvo.rest.authentication import JWTAuthentication
+from akvo.rest.views.project_enumerators import _update_user_token
+from akvo.rsr.tests.base import BaseTestCase
+
+
+class JWTAuthenticationTest(BaseTestCase):
+    """Tests RSR authentication with django-request-token"""
+
+    def setUp(self):
+        self.user = self.create_user("myuser@test.test")
+        self.token = _update_user_token(self.user.id, 1)
+
+        factory = APIRequestFactory()
+        self.request = factory.get("/just/some/path")
+        self.request.token = self.token
+
+    def test_authentication(self):
+        authentication = JWTAuthentication()
+        response = authentication.authenticate(self.request)
+
+        self.assertIsNotNone(response)
+        authenticated_user, auth_token = response
+
+        self.assertEqual(authenticated_user, self.user)
+        self.assertEqual(auth_token, self.token)
+
+    def test_bad_scope(self):
+        self.token.scope = "VERY BAD SCOPE"
+        self.token.save()
+
+        with self.assertRaisesRegex(AuthenticationFailed, "Incorrect JWT token scope"):
+            authentication = JWTAuthentication()
+            authentication.authenticate(self.request)
+
+    def test_too_many_uses(self):
+        self.token.used_to_date = self.token.max_uses + 1
+        self.token.save()
+
+        with self.assertRaisesRegex(AuthenticationFailed, "Invalid JWT token."):
+            authentication = JWTAuthentication()
+            authentication.authenticate(self.request)


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Fixed the bug
 - [x] Added unit tests to counter re-occurence

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] unit tests
 - [x] manual test

## Manual test

- Open a project with enumerators (or create one yourself) --> http://localhost/my-rsr/projects/123/enumerators
- Copy a form access link 
![image](https://user-images.githubusercontent.com/91939214/156209652-51e05814-8e30-4807-ac12-cf824c7caee6.png)
 - Open the link in a private browser windows/tab

It should open and it should be possible to modify results.