### PR TITLE
[#4874] Fix: Database imported from production with superuser is read-only

### DIFF
--- a/ci/training-envs/templates/seedDatabase.yaml
+++ b/ci/training-envs/templates/seedDatabase.yaml
@@ -84,8 +84,10 @@ data:
           | grep Alter \
           | psql "${psql_settings[@]}"
 
-        echo "Granting access to all current and future public tables for user ${RSR_DB_USER}"
+        echo "Granting access to all current and future public tables+sequences for user ${RSR_DB_USER}"
         echo "GRANT ALL ON schema public TO ${RSR_DB_USER};" \
+          | psql "${psql_settings[@]}"
+        echo "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO ${RSR_DB_USER};" \
           | psql "${psql_settings[@]}"
         echo "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO ${RSR_DB_USER};" \
           | psql "${psql_settings[@]}"

--- a/scripts/data/restore-from-dump.sh
+++ b/scripts/data/restore-from-dump.sh
@@ -20,6 +20,8 @@ gunzip --stdout "${DUMP_FILE}" \
   | sed -e "/ALTER DEFAULT PRIVILEGES FOR ROLE postgres/d" \
   | psql "${psql_settings[@]}"
 
+# From here on, be sure to sync this with /ci/training-envs/templates/seedDatabase.yaml
+# Don't shoot the messenger, it was like this before I arrived :(
 echo "Setting the owner of public tables to ${RSR_USER}"
 echo "
   select
@@ -40,6 +42,7 @@ echo "
   | grep Alter \
   | psql "${psql_settings[@]}"
 
-echo "Granting access to all current and future public tables for user ${RSR_USER}"
+echo "Granting access to all current and future public tables+sequences for user ${RSR_USER}"
 echo "GRANT ALL ON schema public TO ${RSR_USER};" | psql "${psql_settings[@]}"
+echo "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO ${RSR_USER};" | psql "${psql_settings[@]}"
 echo "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO ${RSR_USER};" | psql "${psql_settings[@]}"


### PR DESCRIPTION

There was no write-access to the sequences, so new objects couldn't be inserted
 as the sequences couldn't be updated.

Apparently `GRANT ALL ON schema public` doesn't mean what we think it means...

# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Grant all rights to the RSR user to sequences in the public schema (where all the tables are)
 
# Test plan

 - [x] Restore production DB in to local
 - [x] Create an object using `./manage.py shell` 
![image](https://user-images.githubusercontent.com/91939214/156365028-50ca9a2b-f32d-4882-9f01-19fa98784927.png)
 - [x] Create a project in the UI 
![image](https://user-images.githubusercontent.com/91939214/156372719-d4bf1ccf-f6cb-47c4-9e5d-be2b4ca6ade2.png)
