### PR TITLE
[#4880] Use string instead of boolean in configmap

### DIFF
--- a/ci/k8s/config-prod.yml
+++ b/ci/k8s/config-prod.yml
@@ -4,7 +4,7 @@ metadata:
   name: akvo-rsr
   namespace: default
 data:
-  cloud-profiler-enable: true
+  cloud-profiler-enable: "true"
   google-storege-bucket-name: akvo-rsr-production-media-files
   default-file-storage: storages.backends.gcloud.GoogleCloudStorage
   google-sql-db-instance: rsr-prod-database

--- a/ci/k8s/config-test.yml
+++ b/ci/k8s/config-test.yml
@@ -4,7 +4,7 @@ metadata:
   name: akvo-rsr
   namespace: default
 data:
-  cloud-profiler-enable: true
+  cloud-profiler-enable: "true"
   google-storege-bucket-name: akvo-rsr-test-media-files
   default-file-storage: storages.backends.gcloud.GoogleCloudStorage
   google-sql-db-instance: shared-test-database


### PR DESCRIPTION
Sigh... why allow booleans in the first place if they can't be used at all?

# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Use string `"true"` instead of `true` in yaml

# Test plan

Unfortunately, the proof is in the pudding and we have to wait for the CI to run...