### PR TITLE
[#4827] Replace all line charts visuals and fix progressbar

### DIFF
--- a/akvo/rsr/spa/app/components/AddUpdate.jsx
+++ b/akvo/rsr/spa/app/components/AddUpdate.jsx
@@ -14,11 +14,11 @@ import { nicenum, dateTransform } from '../utils/misc'
 import FinalField from '../utils/final-field'
 import RTE from '../utils/rte'
 import DsgOverview from '../modules/results/dsg-overview'
-import Timeline from '../modules/results/timeline'
 import { DeclinedStatus } from './DeclinedStatus'
 import { PrevUpdate } from './PrevUpdate'
 import ScoringField from './ScoringField'
 import { StatusUpdate } from './StatusUpdate'
+import LineChart from './LineChart'
 
 const axiosConfig = {
   headers: { ...config.headers, 'Content-Type': 'multipart/form-data' },
@@ -447,7 +447,23 @@ export const AddUpdate = ({
                       <div className="timeline-outer">
                         <FormSpy subscription={{ values: true }}>
                           {({ values }) => {
-                            return <Timeline {...{ updates: [...period.updates, submittedUpdate == null ? { ...values, status: 'D' } : null].filter(it => it !== null), indicator, period, editPeriod }} />
+                            const updates = [...period.updates, submittedUpdate == null ? { ...values, status: 'D' } : null].filter(it => it !== null)
+                            const data = updates?.map((u, index) => ({
+                              label: u.lastModifiedAt ? moment(u.lastModifiedAt, 'YYYY-MM-DD').format('DD-MM-YYYY') : null,
+                              x: index,
+                              y: u.value
+                            }))
+                            return (
+                              <LineChart
+                                width={480}
+                                height={300}
+                                data={data}
+                                horizontalGuides={5}
+                                precision={2}
+                                verticalGuides={1}
+                                {...period}
+                              />
+                            )
                           }}
                         </FormSpy>
                       </div>

--- a/akvo/rsr/spa/app/components/ProgressBar.jsx
+++ b/akvo/rsr/spa/app/components/ProgressBar.jsx
@@ -6,7 +6,7 @@ import { setNumberFormat } from '../utils/misc'
 
 import './ProgressBar.scss'
 
-const ProgressBar = ({ period, values, valueRef }) => {
+const ProgressBar = ({ period, values, valueRef, onlyApproved = false }) => {
   const { t } = useTranslation()
 
   const handleOnClick = (index) => () => {
@@ -37,6 +37,7 @@ const ProgressBar = ({ period, values, valueRef }) => {
         {
           values
             .sort((a, b) => { if (b.status === 'D' && a.status !== 'D') return -1; return 0; })
+            .filter((value) => ((onlyApproved && value.status === 'A') || !onlyApproved))
             .map((value, index) => {
               let barProps = {
                 className: classNames('fill', {

--- a/akvo/rsr/spa/app/modules/results-admin/components/ReportedForm.jsx
+++ b/akvo/rsr/spa/app/modules/results-admin/components/ReportedForm.jsx
@@ -4,8 +4,8 @@ import { Icon, Form, Divider, Upload, Typography } from 'antd'
 import { useTranslation } from 'react-i18next'
 import classNames from 'classnames'
 import SimpleMarkdown from 'simple-markdown'
+import moment from 'moment'
 import DsgOverview from '../../results/dsg-overview'
-import Timeline from '../../results/timeline'
 import { DeclinedStatus } from '../../../components/DeclinedStatus'
 import { PrevUpdate } from '../../../components/PrevUpdate'
 import { StatusUpdate } from '../../../components/StatusUpdate'
@@ -13,6 +13,7 @@ import FinalField from '../../../utils/final-field'
 import { nicenum } from '../../../utils/misc'
 import RTE from '../../../utils/rte'
 import ScoringField from '../../../components/ScoringField'
+import LineChart from '../../../components/LineChart'
 
 const { Text } = Typography
 
@@ -224,7 +225,23 @@ const ReportedForm = ({
               <div className="timeline-outer">
                 <FormSpy subscription={{ values: true }}>
                   {({ values }) => {
-                    return <Timeline {...{ updates: [...period.updates, { ...values, status: 'D' }].filter(it => it !== null), indicator, period, editPeriod }} />
+                    const updates = [...period.updates, { ...values, status: 'D' }].filter(it => it !== null)
+                    const data = updates?.map((u, index) => ({
+                      label: u.lastModifiedAt ? moment(u.lastModifiedAt, 'YYYY-MM-DD').format('DD-MM-YYYY') : null,
+                      x: index,
+                      y: u.value
+                    }))
+                    return (
+                      <LineChart
+                        data={data}
+                        width={480}
+                        height={300}
+                        horizontalGuides={5}
+                        precision={2}
+                        verticalGuides={1}
+                        {...period}
+                      />
+                    )
                   }}
                 </FormSpy>
               </div>

--- a/akvo/rsr/spa/app/modules/results-overview/components/UpdateItems.jsx
+++ b/akvo/rsr/spa/app/modules/results-overview/components/UpdateItems.jsx
@@ -5,7 +5,6 @@ import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 import SVGInline from 'react-svg-inline'
 
-import Timeline from '../../results/timeline'
 import Update from '../../results/update'
 import DsgOverview from '../../results/dsg-overview'
 import { StatusPeriod } from '../../../components/StatusPeriod'
@@ -80,10 +79,10 @@ const UpdateItems = ({
           (isPeriod && period.updates.length > 0) && (
             <Card bordered={false} className="periodCard">
               <Card.Grid hoverable={false} style={{ width: '100%' }}>
-                <ProgressBar period={period} values={period.updates} />
+                <ProgressBar period={period} values={period.updates} onlyApproved />
               </Card.Grid>
               {
-                (data.length > 0) && (
+                (data.length > 0 && indicator?.measure === '1') && (
                   <Card.Grid hoverable={false} style={{ width: '100%' }}>
                     <LineChart
                       width={480}
@@ -121,7 +120,7 @@ const UpdateItems = ({
                 header={
                   <Aux>
                     <div className="label">{moment(update.lastModifiedAt).format('DD MMM YYYY')}</div>
-                    <div className="label">
+                    <div className="label author">
                       {update.userDetails && `${update.userDetails.firstName} ${update.userDetails.lastName}`}
                     </div>
                     <div className="value-container">

--- a/akvo/rsr/spa/app/modules/results/enumerator.jsx
+++ b/akvo/rsr/spa/app/modules/results/enumerator.jsx
@@ -24,12 +24,12 @@ import statusPending from '../../images/status-pending.svg'
 import statusApproved from '../../images/status-approved.svg'
 import statusRevision from '../../images/status-revision.svg'
 import DsgOverview from './dsg-overview'
-import Timeline from './timeline'
 import { isPeriodNeedsReporting } from './filters'
 import ScoringField from '../../components/ScoringField'
 import { IndicatorItem } from '../../components/IndicatorItem'
 import { StatusUpdate } from '../../components/StatusUpdate'
 import { DeclinedStatus } from '../../components'
+import LineChart from '../../components/LineChart'
 
 const { Panel } = Collapse
 
@@ -574,7 +574,23 @@ const AddUpdate = ({ period, indicator, addUpdateToPeriod, patchUpdateInPeriod, 
                       <div className="timeline-outer">
                         <FormSpy subscription={{ values: true }}>
                           {({ values }) => {
-                            return <Timeline {...{ updates: [...period.updates, submittedUpdate == null ? { ...values, status: 'D' } : null].filter(it => it !== null), indicator, period, editPeriod }} />
+                            const updates = [...period.updates, submittedUpdate == null ? { ...values, status: 'D' } : null].filter(it => it !== null)
+                            const data = updates?.map((u, index) => ({
+                              label: u.lastModifiedAt ? moment(u.lastModifiedAt, 'YYYY-MM-DD').format('DD-MM-YYYY') : null,
+                              x: index,
+                              y: u.value
+                            }))
+                            return (
+                            <LineChart
+                                width={480}
+                                height={300}
+                                data={data}
+                                horizontalGuides={5}
+                                precision={2}
+                                verticalGuides={1}
+                                {...period}
+                              />
+                            )
                           }}
                         </FormSpy>
                       </div>

--- a/akvo/rsr/spa/app/modules/results/period.jsx
+++ b/akvo/rsr/spa/app/modules/results/period.jsx
@@ -10,12 +10,12 @@ import humps from 'humps'
 import { useTranslation } from 'react-i18next'
 import SimpleMarkdown from 'simple-markdown'
 import api, { config } from '../../utils/api'
-import Timeline from './timeline'
 import { dateTransform } from '../../utils/misc'
 import Update from './update'
 import EditUpdate from './edit-update'
 import DsgOverview from './dsg-overview'
-import {StatusPeriod} from '../../components/StatusPeriod'
+import { StatusPeriod } from '../../components/StatusPeriod'
+import LineChart from '../../components/LineChart'
 
 const { Panel } = Collapse
 const Aux = node => node.children
@@ -244,6 +244,11 @@ const Period = ({ setResults, period, measure, treeFilter, statusFilter, increas
   const canAddUpdate = measure === '2' ? updates.filter(it => !it.isNew).length === 0 : true
   const mdParse = SimpleMarkdown.defaultBlockParse
   const mdOutput = SimpleMarkdown.defaultOutput
+  const data = updates?.map((u, index) => ({
+    label: u.lastModifiedAt ? moment(u.lastModifiedAt, 'YYYY-MM-DD').format('DD-MM-YYYY') : null,
+    x: index,
+    y: u.value
+  }))
   return (
     <Panel
       {...props}
@@ -283,7 +288,17 @@ const Period = ({ setResults, period, measure, treeFilter, statusFilter, increas
           <div className="graph">
             <div className="sticky">
               {disaggregations.length > 0 && <DsgOverview {...{ disaggregations, targets: period.disaggregationTargets, period, editPeriod, values: updates.map(it => ({ value: it.value, status: it.status })), updatesListRef, setHover }} />}
-              {disaggregations.length === 0 && <Timeline {...{ updates, indicator, period, pinned, updatesListRef, setHover, editPeriod, targetsAt }} />}
+              {disaggregations.length === 0 && (
+                <LineChart
+                  width={480}
+                  height={300}
+                  data={data}
+                  horizontalGuides={5}
+                  precision={2}
+                  verticalGuides={1}
+                  {...period}
+                />
+              )}
               {baseline.value &&
                 <div className="baseline-values">
                   <div className="baseline-value value">

--- a/akvo/rsr/spa/app/modules/results/styles.scss
+++ b/akvo/rsr/spa/app/modules/results/styles.scss
@@ -449,6 +449,9 @@
                 .label{
                   color: #717171;
                   margin-right: 25px;
+                  &.author {
+                    width: 120px;
+                  }
                 }
                 .status{
                   margin-left: auto;


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Replace all timeline component with new Line chart.
 - [x] Hide pending/draft value in progress bar chart.
 - [x] Hide Line chart for percentage indicator

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Replace chart visuals at edit form
 
<img width="1440" alt="Screen Shot 2022-03-09 at 15 19 25" src="https://user-images.githubusercontent.com/20871229/157406924-7b85c9aa-ca52-46a5-98ef-1df9ea4ff156.png">

 - [ ] Percentage indicator should not have line chart
<img width="1440" alt="Screen Shot 2022-03-09 at 14 35 38" src="https://user-images.githubusercontent.com/20871229/157407034-a6d0b22c-7014-4811-98bb-59368490228c.png">

- [ ]  Only approved values in progress bar
<img width="1440" alt="Screen Shot 2022-03-09 at 14 32 24" src="https://user-images.githubusercontent.com/20871229/157407195-0beae6bc-8787-4076-84f8-03021981357a.png">

 