### PR TITLE
[#4892] Fix bug:Unable to select a city when adding a new organization

### DIFF
--- a/akvo/rsr/spa/app/modules/editor/section7/location-items/search-item.jsx
+++ b/akvo/rsr/spa/app/modules/editor/section7/location-items/search-item.jsx
@@ -51,7 +51,9 @@ class SearchItem extends React.Component{
     $fetch(value, data => this.setState({ data, fetching: false }), this.gservice)
   }
   handleChange = (index) => {
-    this.props.setProcessing(true)
+    if (this.props.setProcessing) {
+      this.props.setProcessing(true)
+    }
     this.geocoder.geocode({ placeId: this.state.data[index].place_id }, (d) => {
       if(d.length < 1) return
       const coordinates = {


### PR DESCRIPTION



# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Check existing setProcessing props 

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Login with Admin/MnE/Project Editor and go to any project, then click section 3. Partners and user access.
 - [ ] Select Project partner and click **Add new organization**.
 - [ ] Search and Choose any at field City.
 
