### PR TITLE
[#4917] Set redirect old version for nuffic both organization and user

### DIFF
--- a/akvo/rest/serializers/project.py
+++ b/akvo/rest/serializers/project.py
@@ -14,6 +14,7 @@ from timeout_decorator import timeout
 
 from akvo.rsr.models import Project, RelatedProject, ProjectUpdate, IndicatorPeriodData
 from akvo.utils import get_thumbnail
+from . import OrganisationBasicSerializer
 
 from ..fields import Base64ImageField
 
@@ -296,6 +297,7 @@ class ProjectMetadataSerializer(BaseRSRSerializer):
     restricted = serializers.SerializerMethodField()
     roles = ProjectRoleSerializer(source='projectrole_set', many=True)
     is_program = serializers.ReadOnlyField(source='is_hierarchy_root')
+    primary_organisation = OrganisationBasicSerializer()
 
     def get_locations(self, obj):
         countries = {location.country for location in obj.locations.all() if location.country}
@@ -335,7 +337,7 @@ class ProjectMetadataSerializer(BaseRSRSerializer):
         fields = ('id', 'title', 'subtitle', 'date_end_actual', 'date_end_planned',
                   'date_start_actual', 'date_start_planned', 'locations', 'status',
                   'is_public', 'sectors', 'parent', 'editable', 'recipient_countries',
-                  'restricted', 'roles', 'use_project_roles', 'is_program')
+                  'restricted', 'roles', 'use_project_roles', 'is_program', 'primary_organisation')
 
 
 BASE_HIERARCHY_SERIALIZER_FIELDS = (

--- a/akvo/rsr/spa/app/modules/hierarchy/card.jsx
+++ b/akvo/rsr/spa/app/modules/hierarchy/card.jsx
@@ -4,15 +4,11 @@ import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 import ConditionalLink from '../projects/conditional-link'
 import countriesDict from '../../utils/countries-dict'
-import { flagOrgs } from '../../utils/feat-flags'
 
 const Card = ({ project, selected, onClick, filterCountry, countryFilter, level, program, canCreateProjects, isProgram, isOldVersion, isReff }) => {
   const { t } = useTranslation()
   const childrenCount = project.childrenCount ? project.childrenCount : (project.children ? project.children.filter(filterCountry).length : -1)
   const { locations, title, subtitle, referenced, recipientCountries = [] } = project
-  if (project.primaryOrganisation) {
-    isOldVersion = (flagOrgs.NUFFIC.has(project.primaryOrganisation))
-  }
   return (
     <li
       className={classNames('card', {

--- a/akvo/rsr/spa/app/modules/hierarchy/card.jsx
+++ b/akvo/rsr/spa/app/modules/hierarchy/card.jsx
@@ -4,11 +4,15 @@ import classNames from 'classnames'
 import { useTranslation } from 'react-i18next'
 import ConditionalLink from '../projects/conditional-link'
 import countriesDict from '../../utils/countries-dict'
+import { flagOrgs } from '../../utils/feat-flags'
 
 const Card = ({ project, selected, onClick, filterCountry, countryFilter, level, program, canCreateProjects, isProgram, isOldVersion, isReff }) => {
   const { t } = useTranslation()
   const childrenCount = project.childrenCount ? project.childrenCount : (project.children ? project.children.filter(filterCountry).length : -1)
   const { locations, title, subtitle, referenced, recipientCountries = [] } = project
+  if (project.primaryOrganisation) {
+    isOldVersion = (flagOrgs.NUFFIC.has(project.primaryOrganisation))
+  }
   return (
     <li
       className={classNames('card', {

--- a/akvo/rsr/spa/app/modules/hierarchy/hierarchy.jsx
+++ b/akvo/rsr/spa/app/modules/hierarchy/hierarchy.jsx
@@ -11,7 +11,6 @@ import Column from './column'
 import Card from './card'
 import FilterCountry from '../projects/filter-country'
 import { shouldShowFlag, flagOrgs } from '../../utils/feat-flags'
-import { getSubdomainName } from '../../utils/misc'
 
 const Hierarchy = ({ match: { params }, program, userRdr, asProjectTab }) => {
   const { t } = useTranslation()
@@ -21,7 +20,7 @@ const Hierarchy = ({ match: { params }, program, userRdr, asProjectTab }) => {
   const history = useHistory()
   const projectId = params.projectId || params.programId
   const canCreateProjects = userRdr.programs && userRdr.programs.findIndex(it => it.id === Number(projectId) && it.canCreateProjects) !== -1
-  const isOldVersion = userRdr?.organisations ? shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) && getSubdomainName() !== 'rsr4' : false
+  const isOldVersion = userRdr?.organisations ? shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) : false
   const toggleSelect = (item, colIndex) => {
     const itemIndex = selected.findIndex(it => it === item)
     if(itemIndex !== -1){

--- a/akvo/rsr/spa/app/modules/project-view/project-view.jsx
+++ b/akvo/rsr/spa/app/modules/project-view/project-view.jsx
@@ -16,7 +16,6 @@ import Reports from '../reports/reports'
 import Updates from '../updates/updates'
 import * as actions from '../editor/actions'
 import Hierarchy from '../hierarchy/hierarchy'
-import { getSubdomainName } from '../../utils/misc'
 
 const { TabPane } = Tabs
 const ResultsTabPane = ({
@@ -128,10 +127,10 @@ const ProjectView = ({ match: { params }, program, jwtView, userRdr, ..._props }
   }, [params.id])
   const urlPrefix = program ? '/programs/:id/editor' : '/projects/:id'
   const project = { id: params.id, title: rf?.title, primaryOrganisation: rf?.primaryOrganisation }
-  const showResultAdmin = (!userRdr?.organisations || shouldShowFlag(userRdr?.organisations, flagOrgs.NUFFIC) || (getSubdomainName() === 'rsr4')) ? false : true
+  const showResultAdmin = (!userRdr?.organisations || shouldShowFlag(userRdr?.organisations, flagOrgs.NUFFIC)) ? false : true
   const resultsProps = { rf, setRF, jwtView, targetsAt, showResultAdmin, role }
   const isRestricted = (role === 'user')
-  let isOldVersion = userRdr?.organisations && shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) && getSubdomainName() !== 'rsr4'
+  let isOldVersion = userRdr?.organisations && shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC)
   if (project.primaryOrganisation) {
     isOldVersion = (flagOrgs.NUFFIC.has(project.primaryOrganisation))
   }

--- a/akvo/rsr/spa/app/modules/project-view/project-view.jsx
+++ b/akvo/rsr/spa/app/modules/project-view/project-view.jsx
@@ -19,12 +19,23 @@ import Hierarchy from '../hierarchy/hierarchy'
 import { getSubdomainName } from '../../utils/misc'
 
 const { TabPane } = Tabs
-const ResultsTabPane = ({ t, disableResults, labelResultView, projectId, userRdr }) => {
+const ResultsTabPane = ({
+  t,
+  id: projectId,
+  disableResults,
+  labelResultView,
+  primaryOrganisation,
+  userRdr
+}) => {
+  let isOldVersion = userRdr?.organisations && shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) && getSubdomainName() !== 'rsr4'
+  if (primaryOrganisation) {
+    isOldVersion = (flagOrgs.NUFFIC.has(primaryOrganisation))
+  }
   return disableResults
     ? t(labelResultView)
     : (
       <>
-        {userRdr?.organisations && shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) && getSubdomainName() !== 'rsr4'
+        {isOldVersion
           ? <a href={`/en/myrsr/my_project/${projectId}/`}>{t(labelResultView)}</a>
           : <Link to={`/projects/${projectId}/results`}>{t(labelResultView)}</Link>
         }
@@ -56,7 +67,7 @@ const _Header = ({ title, project, publishingStatus, hasHierarchy, userRdr, show
           {!(isRestricted) && (
             <TabPane
               disabled={disableResults}
-              tab={<ResultsTabPane {...{ t, disableResults, labelResultView, projectId, userRdr }} />}
+              tab={<ResultsTabPane {...{ ...project, t, disableResults, labelResultView, userRdr }} />}
               key="results"
             />
           )}
@@ -123,7 +134,7 @@ const ProjectView = ({ match: { params }, program, jwtView, userRdr, ..._props }
     if (location != null) setPrevPathName(location.pathname)
   }, [params.id])
   const urlPrefix = program ? '/programs/:id/editor' : '/projects/:id'
-  const project = { id: params.id, title: rf?.title }
+  const project = { id: params.id, title: rf?.title, primaryOrganisation: rf?.primaryOrganisation }
   const showResultAdmin = (!userRdr?.organisations || shouldShowFlag(userRdr?.organisations, flagOrgs.NUFFIC) || (getSubdomainName() === 'rsr4')) ? false : true
   const resultsProps = { rf, setRF, jwtView, targetsAt, showResultAdmin, role }
   const isRestricted = (role === 'user')

--- a/akvo/rsr/spa/app/modules/projects/conditional-link.jsx
+++ b/akvo/rsr/spa/app/modules/projects/conditional-link.jsx
@@ -1,7 +1,11 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { flagOrgs } from '../../utils/feat-flags'
 
 const ConditionalLink = ({ record, children, isProgram, isOldVersion = false }) => {
+  if (record?.primaryOrganisation?.id) {
+    isOldVersion = (flagOrgs.NUFFIC.has(record.primaryOrganisation.id))
+  }
   if(record.restricted === true){
     return <a href={`/en/project/${record.id}/`} target="_blank" rel="noopener noreferrer">{children}</a>
   }

--- a/akvo/rsr/spa/app/modules/projects/table-view.jsx
+++ b/akvo/rsr/spa/app/modules/projects/table-view.jsx
@@ -12,7 +12,10 @@ COUNTRIES.forEach(({ name, code }) => { countryDict[code.toLowerCase()] = name }
 
 const TableView = ({ dataSource, loading, pagination, onChange, userRdr }) => {
   const { t } = useTranslation()
-  const isOldVersion = userRdr?.organisations ? shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) && getSubdomainName() !== 'rsr4' : false
+  let isOldVersion = userRdr?.organisations ? shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) && getSubdomainName() !== 'rsr4' : false
+  if (dataSource.primaryOrganisation) {
+    isOldVersion = (flagOrgs.NUFFIC.has(dataSource.primaryOrganisation))
+  }
   const columns = [
     {
       title: t('Privacy'),

--- a/akvo/rsr/spa/app/modules/projects/table-view.jsx
+++ b/akvo/rsr/spa/app/modules/projects/table-view.jsx
@@ -12,10 +12,7 @@ COUNTRIES.forEach(({ name, code }) => { countryDict[code.toLowerCase()] = name }
 
 const TableView = ({ dataSource, loading, pagination, onChange, userRdr }) => {
   const { t } = useTranslation()
-  let isOldVersion = userRdr?.organisations ? shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) && getSubdomainName() !== 'rsr4' : false
-  if (dataSource.primaryOrganisation) {
-    isOldVersion = (flagOrgs.NUFFIC.has(dataSource.primaryOrganisation))
-  }
+  const isOldVersion = userRdr?.organisations ? shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) && getSubdomainName() !== 'rsr4' : false
   const columns = [
     {
       title: t('Privacy'),
@@ -35,7 +32,7 @@ const TableView = ({ dataSource, loading, pagination, onChange, userRdr }) => {
         <div>
           {(record.parent !== null && !record.parent.isLead) && (<div className="parent-caption"><span>Contributes to:</span> <Link to={`/hierarchy/${record.id}`}>{record.parent.title}</Link><br /></div>)/* eslint-disable-line */}
           {(record.parent !== null && record.parent.isLead) && (<div className="parent-caption"><span>Program:</span> <Link to={`/programs/${record.parent.id}`}>{record.parent.title}</Link><br /></div>)/* eslint-disable-line */}
-          <ConditionalLink {...{ record, isOldVersion }}>{text !== '' ? text : t('Untitled project')}</ConditionalLink>
+          <ConditionalLink isProgram={record?.isProgram} {...{ record, isOldVersion }}>{text !== '' ? text : t('Untitled project')}</ConditionalLink>
           {record.subtitle !== '' && <small><br /><span className="subtitle">{record.subtitle}</span></small>}
           {record.useProjectRoles && [
             <Tooltip placement="right" overlayClassName="member-access-tooltip" title={<span><i>Only these members can access: </i><br /><div className="divider" />{record.roles.map(role => <span><b>{role.name}</b> | <i>{role.role}</i><br /></span>)}</span>}>
@@ -92,6 +89,7 @@ const TableView = ({ dataSource, loading, pagination, onChange, userRdr }) => {
       render: (value) => (<span className={value}>{t(value)}</span>)
     }
   ]
+
   return (
     <Table
       dataSource={dataSource}

--- a/akvo/rsr/spa/app/modules/projects/table-view.jsx
+++ b/akvo/rsr/spa/app/modules/projects/table-view.jsx
@@ -5,14 +5,13 @@ import { Link } from 'react-router-dom'
 import ConditionalLink from './conditional-link'
 import COUNTRIES from '../../utils/countries.json'
 import { flagOrgs, shouldShowFlag } from '../../utils/feat-flags'
-import { getSubdomainName } from '../../utils/misc'
 
 const countryDict = {}
 COUNTRIES.forEach(({ name, code }) => { countryDict[code.toLowerCase()] = name })
 
 const TableView = ({ dataSource, loading, pagination, onChange, userRdr }) => {
   const { t } = useTranslation()
-  const isOldVersion = userRdr?.organisations ? shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) && getSubdomainName() !== 'rsr4' : false
+  const isOldVersion = userRdr?.organisations ? shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) : false
   const columns = [
     {
       title: t('Privacy'),

--- a/akvo/rsr/spa/app/modules/results/EnumeratorPage.jsx
+++ b/akvo/rsr/spa/app/modules/results/EnumeratorPage.jsx
@@ -28,6 +28,7 @@ import api from '../../utils/api'
 import { FilterBar } from '../results-overview/components'
 import ReportedEdit from '../results-admin/components/ReportedEdit'
 import StatusIndicator from '../../components/StatusIndicator'
+import Portal from '../../utils/portal'
 
 const { Text } = Typography
 
@@ -324,6 +325,15 @@ const EnumeratorPage = ({
 
   return (
     <div className="enum-ui">
+      <Portal>
+        <div className="beta">
+          <div className="label">
+            <Icon type="experiment" />
+            {t('New view (beta)')}
+          </div>
+          <Button type="danger" href={`/${userRdr?.lang}/myrsr/my_project/${id}/`}>{t('Older version')}</Button>
+        </div>
+      </Portal>
       <PageHeader>
         <FilterBar {...{ periods, period, handleOnSearch, handleOnSelectPeriod }} disabled={(assign && assign.length === 0)} />
       </PageHeader>

--- a/akvo/rsr/spa/app/modules/results/router.jsx
+++ b/akvo/rsr/spa/app/modules/results/router.jsx
@@ -52,8 +52,10 @@ const Router = ({ match: { params: { id } }, jwtView, rf, setRF, location, targe
     if (!project && preload) {
       api.get(`/project/${id}`)
         .then(({ data }) => {
+          const pj = humps.camelizeKeys(data)
           setPreload(false)
-          setProject(humps.camelizeKeys(data))
+          setProject(pj)
+          setRF({ ...rf, primaryOrganisation: pj.primaryOrganisation })
         })
         .catch(() => setPreload(false))
     }


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Show the old/new version button switch for the Enumerator. 
 - [x] Set redirection to old version for all Nuffic projects.
 - [x] Adding ```primary_organisation``` at My projects end point from backend.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Login as Enumerator and go to Nuffic Project ID: [9731](http://localhost/my-rsr/projects/9731/results)
 - [ ] Login as MnE and go to Hierarchy tab at Nuffic Project ID : [9731](http://localhost/my-rsr/projects/9731/hierarchy) and then choose any project to check project redirection. It's should be go to old version.
- [ ]  Login as Enumerators of other organizations involved in the Nuffic project.
- [ ] Login as Enumerator from Nuffic.
- [ ] Login as MnE from Nuffic and assign some indicators to Enumerators on the Nuffic project.
- [ ] Login as Enumerator from Akvo and get assigment from Nuffic project, then the user should be able to switch old/new version without redirection.
