### PR TITLE
[#4917] Fix the old version redirection for akvo user

### DIFF
--- a/akvo/rsr/spa/app/modules/project-view/project-view.jsx
+++ b/akvo/rsr/spa/app/modules/project-view/project-view.jsx
@@ -130,21 +130,19 @@ const ProjectView = ({ match: { params }, program, jwtView, userRdr, ..._props }
   const showResultAdmin = (!userRdr?.organisations || shouldShowFlag(userRdr?.organisations, flagOrgs.NUFFIC)) ? false : true
   const resultsProps = { rf, setRF, jwtView, targetsAt, showResultAdmin, role }
   const isRestricted = (role === 'user')
-  let isOldVersion = userRdr?.organisations && shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC)
-  if (project.primaryOrganisation) {
-    isOldVersion = (flagOrgs.NUFFIC.has(project.primaryOrganisation))
-  }
   const showResultsBeta = userRdr?.organisations && shouldShowFlag(userRdr?.organisations, flagOrgs.AKVO_USERS)
+  let isOldVersion = userRdr?.organisations && shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC)
+  if (project.primaryOrganisation && !isOldVersion) {
+    isOldVersion = (flagOrgs.NUFFIC.has(project.primaryOrganisation) && !showResultsBeta)
+  }
+
   return [
     !program && <Header key="index-header" {...{ userRdr, showResultAdmin, jwtView, prevPathName, role, project, isRestricted, isOldVersion }} />,
     <Switch key="index-switch">
       <Route
         path={`${urlPrefix}/results`}
         render={props => {
-          if (
-            (isOldVersion && !program) &&
-            (userRdr?.organisations && !showResultsBeta)
-          ) {
+          if (userRdr?.organisations && isOldVersion && !program) {
             window.location.href = `/en/myrsr/my_project/${params.id}/`
             return null
           }


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Set conditional redirection for akvo user

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Login as akvo user and go to Nuffic project: [9731](http://localhost/my-rsr/projects/9731/results) and click [Results (new view - beta)](http://localhost/my-rsr/projects/9731/results). It's should be land to results tab and not auto redirect.
 
