### PR TITLE
[#4947] IATI export datetime using correct format

### DIFF
--- a/akvo/iati/exports/iati_export.py
+++ b/akvo/iati/exports/iati_export.py
@@ -14,6 +14,8 @@ from lxml import etree
 
 from django.core.files.storage import default_storage, FileSystemStorage
 
+from .utils import make_datetime_aware
+
 ELEMENTS = [
     'iati_identifier',
     'reporting_org',
@@ -91,9 +93,9 @@ class IatiXML(object):
         """
         project_element = etree.SubElement(self.iati_activities, "iati-activity")
 
-        if project.last_modified_at:
-            project_element.attrib['last-updated-datetime'] = project.last_modified_at.\
-                strftime("%Y-%m-%dT%H:%M:%SZ")
+        if last_modified_at := project.last_modified_at:
+            last_modified_dt = make_datetime_aware(last_modified_at)
+            project_element.attrib['last-updated-datetime'] = last_modified_dt.isoformat("T", "seconds")
 
         if project.language:
             project_element.attrib['{http://www.w3.org/XML/1998/namespace}lang'] = project.language
@@ -132,7 +134,7 @@ class IatiXML(object):
                                              nsmap={'akvo': 'http://akvo.org/iati-activities'})
         self.iati_activities.attrib['version'] = self.version
         self.iati_activities.attrib['generated-datetime'] = datetime.utcnow().\
-            strftime("%Y-%m-%dT%H:%M:%SZ")
+            isoformat("T", "seconds")
 
         for project in projects:
             # Add IATI activity export to indicate that export has started

--- a/akvo/iati/exports/iati_org_export.py
+++ b/akvo/iati/exports/iati_org_export.py
@@ -10,6 +10,8 @@ from .iati_export import save_iati_xml
 from datetime import datetime
 from lxml import etree
 
+from .utils import make_datetime_aware
+
 ORG_ELEMENTS = [
     'organisation_identifier',
     'name',
@@ -45,9 +47,9 @@ class IatiOrgXML(object):
         """
         organisation_element = etree.SubElement(self.iati_organisations, "iati-organisation")
 
-        if organisation.last_modified_at:
-            organisation_element.attrib['last-updated-datetime'] = organisation.last_modified_at.\
-                strftime("%Y-%m-%dT%H:%M:%SZ")
+        if last_modified_at := organisation.last_modified_at:
+            last_modified_dt = make_datetime_aware(last_modified_at)
+            organisation_element.attrib['last-updated-datetime'] = last_modified_dt.isoformat("T", "seconds")
 
         if organisation.language:
             organisation_element.attrib['{http://www.w3.org/XML/1998/namespace}lang'] = \
@@ -78,7 +80,7 @@ class IatiOrgXML(object):
         self.iati_organisations = etree.Element("iati-organisations")
         self.iati_organisations.attrib['version'] = self.version
         self.iati_organisations.attrib['generated-datetime'] = datetime.utcnow().\
-            strftime("%Y-%m-%dT%H:%M:%SZ")
+            isoformat("T", "seconds")
 
         for organisation in organisations:
             self.add_organisation(organisation)

--- a/akvo/iati/exports/utils.py
+++ b/akvo/iati/exports/utils.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+
+from django.utils import timezone
+
+
+def make_datetime_aware(dt: datetime):
+    last_modified_dt = dt
+    if timezone.is_naive(dt):
+        last_modified_dt = timezone.make_aware(dt, timezone.get_current_timezone())
+    return last_modified_dt

--- a/akvo/rsr/tests/iati_export/__init__.py
+++ b/akvo/rsr/tests/iati_export/__init__.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from unittest.util import safe_repr
+
+from lxml import etree
+from xmlunittest import XmlTestMixin
+
+
+class AkvoXmlMixin(XmlTestMixin):
+    def assertXmlAttributeIsXsdDateTime(self, node: etree.Element, attribute: str, msg: str = None) -> datetime:
+        """
+        Checks if the given node with the provided attribute has a datetime str value in xsd:dateTime
+
+        https://www.w3schools.blog/xsd-date-and-time-data-types
+
+        :return: The datetime value of the attribute
+        """
+        self.assertXmlHasAttribute(node, attribute)
+        attr_val = node.attrib[attribute]
+        try:
+            return datetime.fromisoformat(attr_val)
+        except ValueError:
+            standard_msg = "%s is not a valid ISO formatted datetime" % safe_repr(attr_val)
+            self.fail(self._formatMessage(msg, standard_msg))
+
+    def assertDatetimeEqual(self, left_dt: datetime, right_dt: datetime, microseconds=False):
+        """
+        Ensures that two datetimes are equal by converting them to timestamps
+
+        In this manner, timezones don't matter
+        :param left_dt:
+        :param right_dt:
+        :param microseconds: Include microseconds in the comparison
+        :return:
+        """
+        self.assertIsNotNone(left_dt)
+        self.assertIsNotNone(right_dt)
+
+        left_ts = left_dt.timestamp()
+        right_ts = right_dt.timestamp()
+        if microseconds:
+            self.assertAlmostEqual(left_ts, right_ts)
+        else:
+            self.assertEqual(int(left_ts), int(right_ts))

--- a/akvo/rsr/tests/iati_export/test_iati_export.py
+++ b/akvo/rsr/tests/iati_export/test_iati_export.py
@@ -11,7 +11,6 @@ import datetime
 import os
 import shutil
 from lxml import etree
-from xmlunittest import XmlTestMixin
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 
@@ -31,9 +30,10 @@ from akvo.rsr.models import (IatiExport, Organisation, Partnership, Project, Use
                              IndicatorDimensionValue, Disaggregation)
 from akvo.rsr.models.result.utils import QUALITATIVE
 from akvo.rsr.tests.base import BaseTestCase
+from akvo.rsr.tests.iati_export import AkvoXmlMixin
 
 
-class IatiExportTestCase(BaseTestCase, XmlTestMixin):
+class IatiExportTestCase(BaseTestCase, AkvoXmlMixin):
     """Tests the IATI export, and validates the XML file which is outputted."""
 
     def setUp(self):
@@ -559,6 +559,13 @@ class IatiExportTestCase(BaseTestCase, XmlTestMixin):
                                            './iati-activity/iati-identifier',
                                            './iati-activity/reporting-org',
                                            './iati-activity/title'))
+
+        # Ensure iati-activity date is according to iso format
+        dt = self.assertXmlAttributeIsXsdDateTime(
+            root_test.xpath("./iati-activity")[0],
+            "last-updated-datetime"
+        )
+        self.assertDatetimeEqual(self.project.last_modified_at, dt)
 
         # Test related activities are listed only once
         related_activity_id = self.related_project.iati_activity_id

--- a/akvo/rsr/tests/iati_export/test_iati_org_export.py
+++ b/akvo/rsr/tests/iati_export/test_iati_org_export.py
@@ -24,10 +24,11 @@ import datetime
 import os
 import shutil
 from lxml import etree
-from xmlunittest import XmlTestMixin
+
+from akvo.rsr.tests.iati_export import AkvoXmlMixin
 
 
-class IatiOrgExportTestCase(TestCase, XmlTestMixin):
+class IatiOrgExportTestCase(TestCase, AkvoXmlMixin):
     """Tests the IATI export, and validates the XML file which is outputted."""
 
     def setUp(self):
@@ -211,6 +212,12 @@ class IatiOrgExportTestCase(TestCase, XmlTestMixin):
         # Perform checks on IATI XML file
         root_test = self.assertXmlDocument(iati_org_xml)
         self.assertXmlNode(root_test, tag="iati-organisations")
+
+        dt = self.assertXmlAttributeIsXsdDateTime(
+            root_test.xpath("./iati-organisation")[0],
+            "last-updated-datetime"
+        )
+        self.assertDatetimeEqual(organisation.last_modified_at, dt)
 
     def test_empty_org_export(self):
         """

--- a/akvo/settings/20-default.conf
+++ b/akvo/settings/20-default.conf
@@ -94,3 +94,5 @@ FB_APP_ID =  188270094690212
 DATA_UPLOAD_MAX_MEMORY_SIZE = 26214400
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+
+USE_TZ = True


### PR DESCRIPTION


# TODO / Done

The datetime stored in the DB was not aware of timezones and thus used the time on the server.

The last-updated-datetime attribute is an xsd:dateTime which can have a timezone component.
However, because the datetime instance is timezone naive and we use a manually formatted string,
 we exported the wrong time.

We now indicate to django that it should store timezone aware dates in the DB.
Additionally, old "last_modified_at" dates will be converted to timezone aware dates when exporting.
And of course the `xsd:dateTime` is properly exported using `datetime.isoformat()`

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Unit test
 - [ ] Manual test on test env (can only be done after merging)

Closes #4947 