### PR TITLE
Remove YAML front matter from Pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,3 @@
----
-title: '[#IssueID\] : Feature Request: '
-labels: Needs Review
-assignees: 'AkvoAnt'
-
----
-
-<!--
-For internal contributors, before work can start on a PR that's user facing,
-the "Test plan" will have to be reviewed.
--->
-
-
 # TODO / Done
 
 Summarize what has been changed / what has to be done in order to finalize the PR.


### PR DESCRIPTION
Unfortunately, it's not supported by PR templates but by issue templates 🙄
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository