### PR TITLE
[#4952] Provide sector code list endpoint

### DIFF
--- a/akvo/rest/urls.py
+++ b/akvo/rest/urls.py
@@ -256,6 +256,9 @@ urlpatterns += (
     url(r'v1/organisation_directory$',
         views.organisation_directory,
         name='organisation_directory'),
+    url(r'v1/sector_codes$',
+        views.sector_codes,
+        name="sector_code_list"),
 )
 
 # GeoJSON views

--- a/akvo/rest/views/__init__.py
+++ b/akvo/rest/views/__init__.py
@@ -99,7 +99,7 @@ from .report import (report_formats, ReportViewSet, project_reports, program_rep
 from .result import (ResultsViewSet, ResultsFrameworkViewSet, ResultsFrameworkLiteViewSet,
                      project_results_framework)
 from .right_now_in_akvo import right_now_in_akvo_view
-from .sector import SectorViewSet
+from .sector import sector_codes, SectorViewSet
 from .server_info import server_info
 from .transaction import TransactionViewSet, TransactionSectorViewSet
 from .typeahead import (typeahead_organisation,
@@ -227,6 +227,7 @@ __all__ = [
     'ResultsFrameworkLiteViewSet',
     'project_results_framework',
     'right_now_in_akvo_view',
+    'sector_codes',
     'SectorViewSet',
     'server_info',
     'set_group',

--- a/akvo/rest/views/sector.py
+++ b/akvo/rest/views/sector.py
@@ -4,8 +4,13 @@
 See more details in the license.txt file located at the root folder of the Akvo RSR module.
 For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 """
+from rest_framework.decorators import api_view
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from akvo.rsr.models import Sector
+from akvo.codelists.store.codelists_v203 import SECTOR_CATEGORY
+from akvo.utils import codelist_choices
 from ..serializers import SectorSerializer
 from ..viewsets import PublicProjectViewSet
 
@@ -16,3 +21,12 @@ class SectorViewSet(PublicProjectViewSet):
 
     queryset = Sector.objects.all()
     serializer_class = SectorSerializer
+
+
+@api_view(['GET'])
+def sector_codes(request: Request):
+    sectors = [
+        {'id': id_, 'name': name}
+        for id_, name in codelist_choices(SECTOR_CATEGORY)
+    ]
+    return Response(sectors)

--- a/akvo/rest/views/tests/test_sector.py
+++ b/akvo/rest/views/tests/test_sector.py
@@ -1,0 +1,15 @@
+from rest_framework.reverse import reverse
+
+from akvo.codelists.store.codelists_v203 import SECTOR_CATEGORY
+from akvo.rsr.tests.base import BaseTestCase
+
+
+class TestSectorCodes(BaseTestCase):
+    def test_GET(self):
+        result = self.c.get("%s?format=json" % reverse("sector_code_list"))
+        data = result.data
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), len(SECTOR_CATEGORY) - 1)
+
+        item = data[0]
+        self.assertEqual({"id", "name"}, set(item.keys()))


### PR DESCRIPTION
# TODO / Done

This endpoint was split out from the `project_directory` endpoint.
It should reduce the amount of data loaded by the frontend to produce the map on the homepage.

The assumption was that the `/sectors` endpoint would provide 

# Test plan

 - [x] Unit test
 
Closes #4952