### PR TITLE
[#4975] Remove iati_import cronjob

### DIFF
--- a/akvo/settings/90-finish.conf
+++ b/akvo/settings/90-finish.conf
@@ -102,7 +102,6 @@ LOGGING = {
 
 CRONTAB_COMMAND_SUFFIX = '> /proc/1/fd/1 2>/proc/1/fd/2'
 CRONJOBS = [
-    ('* * * * *', 'django.core.management.call_command', ['iati_import']),
     ('* * * * *', 'django.core.management.call_command', ['iati_export']),
     ('10 2 * * *', 'django.core.management.call_command', ['a4a_optimy_import']),
     ('*/5 * * * *', 'django.core.management.call_command', ['perform_iati_checks']),


### PR DESCRIPTION


# TODO / Done

Remove iati_import cronjob
It doesn't handle the timezone properly and compares a timezone aware with a timezone naive date.
Dates in django are now timezone aware due to 1f98d87a195e1d4f9b512bf40467862b9af6357c

# Test plan

 - [ ] CI must pass. The cronjob won't be called anymore, which is handled by `django-crontab`