### PR TITLE
[#4764] Fix the first illustration not mirrored on safari

### DIFF
--- a/akvo/rsr/dir/app/images/home-monitoring.svg
+++ b/akvo/rsr/dir/app/images/home-monitoring.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300.577" height="439.34" viewBox="0 0 300.577 439.34" transform="scale(-1,1)">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300.577" height="439.34" viewBox="0 0 300.577 439.34">
   <defs>
     <clipPath id="clip-path">
       <path id="Path_699" data-name="Path 699" d="M557.15,525.039l67.688,38.43,120.544-69.524L672.91,456.678Z" fill="none"/>

--- a/akvo/rsr/dir/app/styles/app.scss
+++ b/akvo/rsr/dir/app/styles/app.scss
@@ -387,9 +387,19 @@
       .image-sm {
         opacity: 1;
         margin-top: 0;
+        & > .SVGInline {
+          & > svg {
+            -webkit-transform: scaleX(-1) !important;
+            transform: scaleX(-1);
+          }
+        }
       }
       .image-lg {
         display: none;
+        & > svg {
+          -webkit-transform: scaleX(-1);
+          transform: scaleX(-1);
+        }
       }
     }
   }

--- a/akvo/rsr/dir/app/styles/home-page.scss
+++ b/akvo/rsr/dir/app/styles/home-page.scss
@@ -55,9 +55,19 @@
     .image-sm {
       opacity: 0;
       margin-top: -160px;
+      & > .SVGInline {
+        & > svg {
+          -webkit-transform: scaleX(-1);
+          transform: scaleX(-1);
+        }
+      }
     }
     .image-lg {
       display: block;
+      & > svg {
+        -webkit-transform: scaleX(-1);
+        transform: scaleX(-1);
+      }
     }
   }
   .rsr-list-features {


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Replace transform scale with scaleX and adding webkit

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Go to home landing page and focus on the first illustration
 