### PR TITLE
[#4978] Remove Dutch foreign ministry org

### DIFF
--- a/akvo/rsr/management/commands/remote_netherlands_foreign_ministry.py
+++ b/akvo/rsr/management/commands/remote_netherlands_foreign_ministry.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# Akvo Reporting is covered by the GNU Affero General Public License.
+# See more details in the license.txt file located at the root folder of the Akvo RSR module.
+# For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
+import warnings
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from akvo.rsr.models import (
+    Organisation,
+)
+
+
+class Command(BaseCommand):
+    help = "Remove Netherlands Foreign Ministry which is a duplicate of the Dutch Foreign Ministry"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run", action="store_true", help="No action will be taken in the DB"
+        )
+
+    def handle(self, *args, **options):
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                self._handle(*args, **options)
+        except InterruptedError:
+            print("DRY RUN: No action was taken")
+
+    @transaction.atomic()
+    def _handle(self, *args, **options):
+        dry_run = options.get("dry_run")
+        if dry_run:
+            print("DRY RUN: No action will be taken")
+
+        original_org = Organisation.objects.get(id=464)
+        duplicate_org = Organisation.objects.get(id=4596)
+
+        self.stdout.write("Migrating partnerships of '%s' to '%s'" % (duplicate_org, original_org))
+        for partnership in duplicate_org.partnerships.all().order_by("project__id"):
+            partnership.organisation = original_org
+            partnership.save()
+            project = partnership.project
+            self.stdout.write("\tPartnership(%s): %s - %s" % (partnership.id, project.id, project.title))
+
+        self.stdout.write("Deleting org '%s'" % (duplicate_org, ))
+        duplicate_org.delete()
+
+        if dry_run:
+            raise InterruptedError()


### PR DESCRIPTION
The duplicate has many partnerships which are replaced by partnerships with the original org.

# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [ ] Remove Dutch foreign ministry org
 - [ ] Replace `Partnership`s with original org

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Test locally
 
## Test locally

 - Run script with `--dry-run`
 - Navigate to a project's partnerships
 - Check it has a partnership with the duplicate
 - Run script **without** params
 - Reload project partnership page
 - Verify that partnership shows old org

Example result

http://localhost/my-rsr/projects/6927/partners
![image](https://user-images.githubusercontent.com/91939214/171391856-b9798ed6-f018-45c9-8ce5-949b6dfe4f65.png)


Closes #4978