### PR TITLE
[#4992] Fix old Results UI still there for Nuffic

### DIFF
--- a/akvo/rsr/spa/app/modules/hierarchy/hierarchy.jsx
+++ b/akvo/rsr/spa/app/modules/hierarchy/hierarchy.jsx
@@ -10,7 +10,6 @@ import api from '../../utils/api'
 import Column from './column'
 import Card from './card'
 import FilterCountry from '../projects/filter-country'
-import { shouldShowFlag, flagOrgs } from '../../utils/feat-flags'
 
 const Hierarchy = ({ match: { params }, program, userRdr, asProjectTab }) => {
   const { t } = useTranslation()
@@ -20,7 +19,7 @@ const Hierarchy = ({ match: { params }, program, userRdr, asProjectTab }) => {
   const history = useHistory()
   const projectId = params.projectId || params.programId
   const canCreateProjects = userRdr.programs && userRdr.programs.findIndex(it => it.id === Number(projectId) && it.canCreateProjects) !== -1
-  const isOldVersion = userRdr?.organisations ? shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) : false
+  const isOldVersion = false
   const toggleSelect = (item, colIndex) => {
     const itemIndex = selected.findIndex(it => it === item)
     if(itemIndex !== -1){

--- a/akvo/rsr/spa/app/modules/project-view/project-view.jsx
+++ b/akvo/rsr/spa/app/modules/project-view/project-view.jsx
@@ -131,11 +131,7 @@ const ProjectView = ({ match: { params }, program, jwtView, userRdr, ..._props }
   const showResultAdmin = (!userRdr?.organisations || shouldShowFlag(userRdr?.organisations, flagOrgs.NUFFIC)) ? false : true
   const resultsProps = { rf, setRF, jwtView, targetsAt, showResultAdmin, role }
   const isRestricted = (role === 'user')
-  const showResultsBeta = userRdr?.organisations && shouldShowFlag(userRdr?.organisations, flagOrgs.AKVO_USERS)
-  let isOldVersion = userRdr?.organisations && shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC)
-  if (project.primaryOrganisation && !isOldVersion) {
-    isOldVersion = (flagOrgs.NUFFIC.has(project.primaryOrganisation) && !showResultsBeta)
-  }
+  const isOldVersion = false
 
   return [
     !program && <Header key="index-header" {...{ userRdr, showResultAdmin, jwtView, prevPathName, role, project, isRestricted, isOldVersion }} />,

--- a/akvo/rsr/spa/app/modules/projects/conditional-link.jsx
+++ b/akvo/rsr/spa/app/modules/projects/conditional-link.jsx
@@ -1,11 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import { flagOrgs } from '../../utils/feat-flags'
 
 const ConditionalLink = ({ record, children, isProgram, isOldVersion = false }) => {
-  if (record?.primaryOrganisation?.id) {
-    isOldVersion = (flagOrgs.NUFFIC.has(record.primaryOrganisation.id))
-  }
   if(record.restricted === true){
     return <a href={`/en/project/${record.id}/`} target="_blank" rel="noopener noreferrer">{children}</a>
   }

--- a/akvo/rsr/spa/app/modules/projects/table-view.jsx
+++ b/akvo/rsr/spa/app/modules/projects/table-view.jsx
@@ -4,14 +4,12 @@ import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import ConditionalLink from './conditional-link'
 import COUNTRIES from '../../utils/countries.json'
-import { flagOrgs, shouldShowFlag } from '../../utils/feat-flags'
 
 const countryDict = {}
 COUNTRIES.forEach(({ name, code }) => { countryDict[code.toLowerCase()] = name })
 
-const TableView = ({ dataSource, loading, pagination, onChange, userRdr }) => {
+const TableView = ({ dataSource, loading, pagination, onChange }) => {
   const { t } = useTranslation()
-  const isOldVersion = userRdr?.organisations ? shouldShowFlag(userRdr.organisations, flagOrgs.NUFFIC) : false
   const columns = [
     {
       title: t('Privacy'),
@@ -31,7 +29,7 @@ const TableView = ({ dataSource, loading, pagination, onChange, userRdr }) => {
         <div>
           {(record.parent !== null && !record.parent.isLead) && (<div className="parent-caption"><span>Contributes to:</span> <Link to={`/hierarchy/${record.id}`}>{record.parent.title}</Link><br /></div>)/* eslint-disable-line */}
           {(record.parent !== null && record.parent.isLead) && (<div className="parent-caption"><span>Program:</span> <Link to={`/programs/${record.parent.id}`}>{record.parent.title}</Link><br /></div>)/* eslint-disable-line */}
-          <ConditionalLink isProgram={record?.isProgram} {...{ record, isOldVersion }}>{text !== '' ? text : t('Untitled project')}</ConditionalLink>
+          <ConditionalLink isProgram={record?.isProgram} {...{ record }}>{text !== '' ? text : t('Untitled project')}</ConditionalLink>
           {record.subtitle !== '' && <small><br /><span className="subtitle">{record.subtitle}</span></small>}
           {record.useProjectRoles && [
             <Tooltip placement="right" overlayClassName="member-access-tooltip" title={<span><i>Only these members can access: </i><br /><div className="divider" />{record.roles.map(role => <span><b>{role.name}</b> | <i>{role.role}</i><br /></span>)}</span>}>

--- a/akvo/rsr/spa/app/modules/results-admin/PendingApproval.jsx
+++ b/akvo/rsr/spa/app/modules/results-admin/PendingApproval.jsx
@@ -25,10 +25,12 @@ import { Disaggregations } from './components'
 import editButton from '../../images/edit-button.svg'
 import api from '../../utils/api'
 import './PendingApproval.scss'
+import Highlighted from '../../components/Highlighted'
 
 const { Text } = Typography
 
 const CardTitle = ({
+  keyword,
   result,
   indicator,
   period
@@ -43,7 +45,7 @@ const CardTitle = ({
     </Col>
     <Col lg={13}>
       <Text className="label">INDICATOR</Text>
-      <h4>{indicator?.title}</h4>
+      <h4><Highlighted text={indicator?.title} highlight={keyword} /></h4>
     </Col>
     <Col span={24}>
       <div className="period-caption">
@@ -95,6 +97,7 @@ const CardActions = ({
 
 const PendingApproval = ({
   projectId,
+  keyword,
   results,
   editing,
   editPeriod,
@@ -301,7 +304,7 @@ const PendingApproval = ({
         {updates?.map((update, ix) => (
           <Col span={24} key={ix}>
             <Card
-              title={<CardTitle {...update} />}
+              title={<CardTitle {...update} keyword={keyword} />}
               extra={(
                 <CardActions
                   {...{

--- a/akvo/rsr/spa/app/modules/results-admin/ResultAdmin.jsx
+++ b/akvo/rsr/spa/app/modules/results-admin/ResultAdmin.jsx
@@ -193,7 +193,7 @@ const ResultAdmin = ({
     })
     ?.filter((p) => {
       if (keyword) {
-        return p?.indicator?.title?.includes(keyword)
+        return p?.indicator?.title?.toLowerCase()?.includes(keyword.toLowerCase())
       }
       return p
     })
@@ -313,6 +313,7 @@ const ResultAdmin = ({
                 {...{
                   results: pendingApproval,
                   projectId: id,
+                  keyword,
                   editing,
                   editPeriod,
                   handleOnEdit,


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Set isOldVersion to false to remove redirect to old version

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Click Nuffic project at My Project list.
 - [ ] Click Nuffic project at Hierarchy card item.
 - [ ] Move from any tab at details projects to Results Overview or Results Admin
 
