### PR TITLE
[#4242] Change released date from 17 to 27 May 2022

### DIFF
--- a/akvo/rsr/spa/app/modules/announcements/27-05-2022.jsx
+++ b/akvo/rsr/spa/app/modules/announcements/27-05-2022.jsx
@@ -1,7 +1,6 @@
 /* global window */
 import React, { useEffect, useState } from 'react'
 import { Button, Divider } from 'antd'
-import { Link } from 'react-router-dom'
 import api from '../../utils/api'
 
 export default ({ close }) => {

--- a/akvo/rsr/spa/app/modules/announcements/list.js
+++ b/akvo/rsr/spa/app/modules/announcements/list.js
@@ -1,5 +1,9 @@
 export default [
   {
+    date: '27-05-2022',
+    title: 'Easier reporting, cleaner design, and improved communications'
+  },
+  {
     date: '14-01-2021',
     title: 'Improved Results tab'
   },
@@ -10,9 +14,5 @@ export default [
   {
     date: '17-06-2020',
     title: 'Programme features & User access'
-  },
-  {
-    date: '17-05-2022',
-    title: 'Easier reporting, cleaner design, and improved communications'
   }
 ]


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Change released date from 17 to 27
 - [x] Reorder tabs headings in descending order.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Login with other user to get pop up at first login.
 - [ ] Click New features tabs at the bottom.
 - [ ] Move from one tab to another in the announcement pop up.
