### PR TITLE
[#5000] Fix no active field on revised update for enumerator form link

### DIFF
--- a/akvo/rsr/spa/app/modules/project-view/project-view.jsx
+++ b/akvo/rsr/spa/app/modules/project-view/project-view.jsx
@@ -128,7 +128,7 @@ const ProjectView = ({ match: { params }, program, jwtView, userRdr, ..._props }
   }, [params.id])
   const urlPrefix = program ? '/programs/:id/editor' : '/projects/:id'
   const project = { id: params.id, title: rf?.title, primaryOrganisation: rf?.primaryOrganisation }
-  const showResultAdmin = (!userRdr?.organisations || shouldShowFlag(userRdr?.organisations, flagOrgs.NUFFIC)) ? false : true
+  const showResultAdmin = true
   const resultsProps = { rf, setRF, jwtView, targetsAt, showResultAdmin, role }
   const isRestricted = (role === 'user')
   const isOldVersion = false

--- a/akvo/rsr/spa/app/modules/results/EnumeratorPage.jsx
+++ b/akvo/rsr/spa/app/modules/results/EnumeratorPage.jsx
@@ -334,8 +334,12 @@ const EnumeratorPage = ({
         renderItem={(item, ix) => {
           const iKey = item?.id || `${item?.indicator?.id}0${ix}`
           const updateClass = item?.statusDisplay?.toLowerCase()?.replace(/\s+/g, '-')
-          const canDelete = (editing?.id && editing?.status === 'D') && editing?.userDetails?.id === userRdr?.id
-          const disableInputs = ((editing?.userDetails && ['P', 'A'].includes(editing?.status)) || (editing?.userDetails?.id !== userRdr?.id && editing?.status === 'R') || isPreview)
+          const canDelete = (editing?.id && editing?.status === 'D') && (userRdr.id && (editing?.userDetails?.id === userRdr.id))
+          const disableInputs = (
+            (editing?.userDetails && ['P', 'A'].includes(editing?.status)) ||
+            ((userRdr.id && editing && editing.userDetails) && (editing.userDetails.id !== userRdr.id && editing.status === 'R')) ||
+            isPreview
+          )
           return (
             <List.Item className="enum-ui-item">
               <Card className={classNames(updateClass, { active: (activeKey === iKey) })}>


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Show Results Admin tab for all org that has access for it (MnE, Admin)
 - [x] Fix disabled input condition on enumerator form.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Login as MnE / Admin to access Result Admin
 - [ ] Access revisited / declined update from link
 
## Access revisited / declined update from link

 - Login as Enumerator
 - Go to any project, eg : [http://localhost/my-rsr/projects/9604/results](http://localhost/my-rsr/projects/9604/results)
 - Submit any update
 - Login as MnE with other browser
 - Review the last update of the enumerator and reject it.
 - Open link from email
 - Field input should be editable.
