### PR TITLE
#5004: Fix: Disallow saving a project during deletion

### DIFF
--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -61,6 +61,13 @@ DESCRIPTIONS_ORDER = [
     'project_plan_summary', 'goals_overview', 'background', 'current_status', 'target_group',
     'project_plan', 'sustainability']
 
+"""
+Projects in the process of being deleted
+Some signals attempt to update projects and they shouldn't attempt to do so
+ when a project is being deleted
+"""
+DELETION_SET = set()
+
 
 def get_default_descriptions_order():
     return DESCRIPTIONS_ORDER
@@ -472,8 +479,13 @@ class Project(TimestampsMixin):
         # Delete results on the project, before trying to delete the project,
         # since the RelatedProject object on the project refuses to get deleted
         # if there are existing results, causing the delete to raise 500s
-        self.results.all().delete()
-        return super(Project, self).delete(using=using, keep_parents=keep_parents)
+        if self.pk:
+            DELETION_SET.add(self.pk)
+        try:
+            self.results.all().delete()
+            return super(Project, self).delete(using=using, keep_parents=keep_parents)
+        finally:
+            DELETION_SET.discard(self.pk)
 
     def save(self, *args, **kwargs):
         # Strip title of any trailing or leading spaces
@@ -494,6 +506,9 @@ class Project(TimestampsMixin):
 
         orig, orig_aggregate_children, orig_aggregate_to_parent = None, None, None
         if self.pk:
+            # If the project is being deleted, don't allow saving it
+            if self.pk in DELETION_SET:
+                return
             orig = Project.objects.get(pk=self.pk)
 
             # Update funds and funds_needed if donations change.  Any other

--- a/akvo/rsr/tests/models/test_project.py
+++ b/akvo/rsr/tests/models/test_project.py
@@ -38,10 +38,6 @@ class ProjectModelTestCase(BaseTestCase):
             label='label 2'
         )
 
-    def tearDown(self):
-        Project.objects.all().delete()
-        Organisation.objects.all().delete()
-
     def test_project_last_update(self):
         """Test that Project.last_update is updated correctly when an update is deleted.
 
@@ -266,9 +262,6 @@ class ProjectHierarchyTestCase(TestCase):
         # 3   4
         #      \
         #       5
-
-    def tearDown(self):
-        Project.objects.all().delete()
 
     def test_project_descendants(self):
         # Note that descendants includes self


### PR DESCRIPTION
# TODO / Done

The `update_thumbnails` save signal was being called during project deletion.
That was triggered by related objects updating the project in their own delete signal.

It doesn't make sense to allow saving a project while it's being deleted,
 so the method simply returns in that case

# Test plan

 - [x] Manual test: call `./manage.py delete_project --delete 9023`
 - [x] Unit test


------------

Fixes #5004