### PR TITLE
[#5010] Fix enumerators tab not available for admin role

### DIFF
--- a/akvo/rsr/spa/app/modules/results/EnumeratorPage.jsx
+++ b/akvo/rsr/spa/app/modules/results/EnumeratorPage.jsx
@@ -119,7 +119,7 @@ const EnumeratorPage = ({
             (u?.userDetails?.id === userRdr.id) ||
             (isNuffic.includes(project?.primaryOrganisation) && (u?.userDetails?.id !== userRdr.id && u.status === 'D')) ||
             (!userRdr.id && params.get('rt'))
-          )
+          ) && u.status !== 'A'
         })
         ?.map((u) => ({
           ...u,

--- a/akvo/rsr/spa/app/utils/feat-flags.js
+++ b/akvo/rsr/spa/app/utils/feat-flags.js
@@ -15,3 +15,7 @@ export const isRSRTeamMember = (userRdr) => {
 export const isRSRAdmin = (userRdr) => {
   return userRdr?.isAdmin || userRdr?.isSuperuser
 }
+
+export const isAnAdmin = (userRdr) => {
+  return (userRdr?.approvedEmployments?.filter((a) => a?.groupName === 'Admins' || a?.group === 3)?.length)
+}


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Rename isNotAllowed to isAllowed
 - [x] Adding new function to check current user is an Admin

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Login as RSR Admin.
 - [ ] Login as an Admin from approved organisation.
 - [ ] Login as RSR Enumerator.
 - [ ] Login as an Enumerator from approved organisation.
 