### PR TITLE
[#5017] Speed up Results framework endpoint

### DIFF
--- a/akvo/rest/serializers/indicator.py
+++ b/akvo/rest/serializers/indicator.py
@@ -144,7 +144,7 @@ class IndicatorFrameworkNotSoLiteSerializer(BaseRSRSerializer):
     periods = IndicatorPeriodFrameworkNotSoLiteSerializer(many=True, required=False, read_only=True)
     parent_indicator = serializers.ReadOnlyField(source='parent_indicator_id')
     children_aggregate_percentage = serializers.ReadOnlyField()
-    labels = LabelListingField(read_only=True)
+    labels = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
     disaggregation_targets = serializers.SerializerMethodField()
     dimension_names = serializers.SerializerMethodField()
 

--- a/akvo/rest/serializers/indicator_period.py
+++ b/akvo/rest/serializers/indicator_period.py
@@ -157,16 +157,19 @@ class IndicatorPeriodFrameworkNotSoLiteSerializer(BaseRSRSerializer):
             for t in obj.disaggregation_targets.all()
         ]
 
-    def get_updates(self, obj):
+    def get_updates(self, obj: IndicatorPeriod):
+        # FIXME: this is a very slow method
+        #        The more projects there are, the slower
         user = self.context['request'].user
-        updates = IndicatorPeriodData.objects.filter(period=obj)\
-            .select_related('user')\
-            .prefetch_related('disaggregations', 'comments', 'comments__user')
         project_id = obj.indicator.result.project_id
         viewable_updates = user.viewable_indicator_updates(project_id) if not user.is_anonymous else []
-        updates = updates.filter(pk__in=viewable_updates).distinct()
-        serializer = IndicatorPeriodDataLiteSerializer(updates, many=True)
-        return serializer.data
+        if viewable_updates:
+            # Using filter will throw away prefetched objects
+            updates = [datum for datum in obj.data.all() if datum.id in viewable_updates]
+            serializer = IndicatorPeriodDataLiteSerializer(updates, many=True)
+            return serializer.data
+        else:
+            return []
 
     class Meta:
         model = IndicatorPeriod

--- a/akvo/rest/serializers/indicator_period_data.py
+++ b/akvo/rest/serializers/indicator_period_data.py
@@ -12,7 +12,7 @@ from django.contrib.contenttypes.models import ContentType
 
 from akvo.rest.serializers.disaggregation import DisaggregationSerializer, DisaggregationReadOnlySerializer
 from akvo.rest.serializers.rsr_serializer import BaseRSRSerializer
-from akvo.rest.serializers.user import UserDetailsSerializer
+from akvo.rest.serializers.user import UserDetailsSerializer, UserRawSerializer
 from akvo.rsr.models import (
     IndicatorPeriod, IndicatorPeriodData, IndicatorPeriodDataComment, IndicatorPeriodDataFile, IndicatorPeriodDataPhoto,
     IndicatorDimensionValue, Disaggregation
@@ -67,7 +67,7 @@ class IndicatorPeriodDataSerializer(BaseRSRSerializer):
 
 class IndicatorPeriodDataLiteSerializer(BaseRSRSerializer):
 
-    user_details = UserDetailsSerializer(required=False, source='user')
+    user_details = UserRawSerializer(required=False, source='user')
     status_display = serializers.ReadOnlyField()
     photo_url = serializers.ReadOnlyField()
     file_url = serializers.ReadOnlyField()

--- a/akvo/rest/serializers/result.py
+++ b/akvo/rest/serializers/result.py
@@ -6,7 +6,7 @@
 
 from akvo.rest.serializers.indicator import IndicatorFrameworkSerializer, IndicatorFrameworkLiteSerializer, IndicatorFrameworkNotSoLiteSerializer
 from akvo.rest.serializers.rsr_serializer import BaseRSRSerializer
-from akvo.rsr.models import Result, Project
+from akvo.rsr.models import Project, Result
 
 from rest_framework import serializers
 
@@ -53,7 +53,7 @@ class ResultsFrameworkLiteSerializer(ResultRawSerializer):
 class ResultFrameworkNotSoLiteSerializer(ResultRawSerializer):
 
     indicators = IndicatorFrameworkNotSoLiteSerializer(many=True, read_only=True)
-    project = serializers.PrimaryKeyRelatedField(queryset=Project.objects.all())
+    project = serializers.PrimaryKeyRelatedField(read_only=True)
     project_title = serializers.ReadOnlyField(source='project.title')
     parent_project = serializers.ReadOnlyField()
     child_projects = serializers.ReadOnlyField()

--- a/akvo/rest/views/result.py
+++ b/akvo/rest/views/result.py
@@ -63,9 +63,24 @@ def project_results_framework(request, project_pk):
     queryset = Result.objects.filter(project=project).select_related('project').prefetch_related(
         'indicators',
         'indicators__dimension_names',
+        'indicators__dimension_names__dimension_values',
+        'indicators__disaggregation_targets',
+        'indicators__labels',
         'indicators__periods',
-        'indicators__periods__disaggregations',
+        'indicators__periods__data',
+        'indicators__periods__data__comments',
+        'indicators__periods__data__disaggregations',
+        'indicators__periods__data__disaggregations__dimension_value',
+        'indicators__periods__data__disaggregations__dimension_value__name',
+        'indicators__periods__data__indicatorperioddatafile_set',
+        'indicators__periods__data__indicatorperioddataphoto_set',
+        'indicators__periods__data__user',
         'indicators__periods__disaggregation_targets',
+        'indicators__periods__disaggregation_targets__dimension_value',
+        'indicators__periods__disaggregation_targets__dimension_value__name',
+        'indicators__periods__disaggregations',
+        'indicators__periods__disaggregations__dimension_value',
+        'indicators__periods__disaggregations__dimension_value__name',
     )
     serializer = ResultFrameworkNotSoLiteSerializer(queryset, many=True, context={'request': request})
     # FIXME: It may be better to not serialize all the indicators at all, but


### PR DESCRIPTION

# TODO / Done

Prefetch as much data as possible.

`IndicatorPeriodFrameworkNoToLiteSerializer.get_updates` wasn't taking advantage of the prefetched data.
Now, it filters in python without making an extra query.
It's still suboptimal, but at least it's a bit faster.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Manual testing


----------------

Closes #5017
