### PR TITLE
[#5020] Fix broken image at detail project update

### DIFF
--- a/akvo/rsr/dir/app/modules/project-page/views/UpdatePage.jsx
+++ b/akvo/rsr/dir/app/modules/project-page/views/UpdatePage.jsx
@@ -17,6 +17,7 @@ import UpdateItem from './UpdateItem'
 import Section from '../../components/Section'
 import { prefixUrl } from '../../../utils/config'
 import { queryOtherStories, queryStory } from '../queries'
+import defaultImage from '../../../images/default-image.png'
 
 const { Title, Paragraph, Text } = Typography
 
@@ -70,7 +71,7 @@ const UpdatePage = ({ projectId }) => {
               <img
                 className="project-image"
                 alt={data ? data.title : ''}
-                src={data ? data.photo ? `${prefixUrl}/${data.photo.original}` : '#' : '#'}
+                src={data ? data.photo ? `${prefixUrl}${data.photo.original}` : defaultImage : defaultImage}
               />
             </Spin>
             <Text type="secondary">{data ? data.photoCaption : ''}</Text><br />


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Remove slash and prefixUrl at image source

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Go to Hortimpact project : [https://rsr.akvotest.org/dir/project/2602/update?id=23786](https://rsr.akvotest.org/dir/project/2602/update?id=23786)
 
<img width="1178" alt="Screen Shot 2022-06-30 at 09 50 39" src="https://user-images.githubusercontent.com/20871229/176582700-32ae32fc-afc4-4dd7-912b-b1fbae791c12.png">
> there is a slash in front which causes the url to be invalid
