### PR TITLE
Speed up indicator_data_period_framework endpoint

### DIFF
--- a/akvo/rest/serializers/indicator_period_data.py
+++ b/akvo/rest/serializers/indicator_period_data.py
@@ -94,7 +94,7 @@ class IndicatorPeriodDataFrameworkSerializer(BaseRSRSerializer):
     period = serializers.PrimaryKeyRelatedField(queryset=IndicatorPeriod.objects.all())
     comments = IndicatorPeriodDataCommentNestedSerializer(many=True, required=False)
     disaggregations = DisaggregationSerializer(many=True, required=False)
-    user_details = UserDetailsSerializer(read_only=True, source='user')
+    user_details = UserRawSerializer(read_only=True, source='user')
     approver_details = UserDetailsSerializer(read_only=True, source='approved_by')
     status_display = serializers.ReadOnlyField()
     photo_url = serializers.ReadOnlyField()


### PR DESCRIPTION
# TODO / Done

The UserDetailsSerializer adds many queries to get the approved_organisations.
From what I can see, the caller of POST/PATCH `indicator_data_period_framework` doesn't even consume the user data.
It would be great to remove it entirely, but it's not clear if the field is used elsewhere
 and the UserRawSerializer remove still provides some information.

After testing the Results admin to POST and PATCH, the operations took 1.5s instead of 16s.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Manual testing of Results Overview and Results admin for project [10355 ](http://localhost/my-rsr/projects/10355/results)
    - [x] Add new data using the results admin
    - [x] Reload page and delete data from Results Overview

Unlocking a period might be necessary
![image](https://user-images.githubusercontent.com/91939214/176700300-7b4ad565-2e6d-48c8-b7aa-f4e02dc4a026.png)
