### PR TITLE
[#5022] Replace get_absolute_url with cacheable_url and cached_proprty in serializers and models

### DIFF
--- a/akvo/rest/serializers/rsr_serializer.py
+++ b/akvo/rest/serializers/rsr_serializer.py
@@ -17,9 +17,9 @@ class BaseRSRSerializer(serializers.ModelSerializer):
     def __init__(self, *args, **kwargs):
         super(BaseRSRSerializer, self).__init__(*args, **kwargs)
 
-        # Add 'absolute_url' field if the model defines the get_absolute_url method
-        if getattr(self.Meta.model, 'get_absolute_url', None):
-            self.fields['absolute_url'] = serializers.ReadOnlyField(source='get_absolute_url')
+        # Add 'absolute_url' field if the model defines the cacheable_url method
+        if getattr(self.Meta.model, 'cacheable_url', None):
+            self.fields['absolute_url'] = serializers.ReadOnlyField(source='cacheable_url')
 
         # Add the ValidXMLXXXFields to the model-to-rest-field mapping and use the modified
         # CharField, NonNullCharField or URLField that returns '' for None values.

--- a/akvo/rsr/models/focus_area.py
+++ b/akvo/rsr/models/focus_area.py
@@ -8,6 +8,7 @@
 from django.apps import apps
 from django.db import models
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from sorl.thumbnail.fields import ImageField
@@ -59,6 +60,10 @@ class FocusArea(models.Model):
 
     def get_absolute_url(self):
         return reverse('project-directory')
+
+    @cached_property
+    def cacheable_url(self):
+        return self.get_absolute_url()
 
     def projects(self):
         'return all projects that "belong" to the FA through the Categories it links to'

--- a/akvo/rsr/models/organisation.py
+++ b/akvo/rsr/models/organisation.py
@@ -10,6 +10,7 @@ from django.db import models
 from django.db.models import Sum, Q, signals
 from django.dispatch import receiver
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from sorl.thumbnail.fields import ImageField
@@ -187,6 +188,10 @@ class Organisation(TimestampsMixin):
 
     def get_absolute_url(self):
         return reverse('organisation-main', kwargs={'organisation_id': self.pk})
+
+    @cached_property
+    def cacheable_url(self):
+        return self.get_absolute_url()
 
     @property
     def canonical_name(self):

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -574,7 +574,7 @@ class Project(TimestampsMixin):
     def get_absolute_url(self):
         return reverse('project-main', kwargs={'project_id': self.pk})
 
-    @property
+    @cached_property
     def cacheable_url(self):
         # Language names are 2 chars long
         return self.get_absolute_url()[3:]

--- a/akvo/rsr/models/project_update.py
+++ b/akvo/rsr/models/project_update.py
@@ -9,6 +9,7 @@ import datetime
 from django.conf import settings
 from django.db import models
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from embed_video.fields import EmbedVideoField
 from sorl.thumbnail.fields import ImageField
@@ -87,6 +88,10 @@ class ProjectUpdate(TimestampsMixin):
 
     def get_absolute_url(self):
         return reverse('update-main', kwargs={'project_id': self.project_id, 'update_id': self.pk})
+
+    @cached_property
+    def cacheable_url(self):
+        return self.get_absolute_url()
 
     @property
     def edited(self):

--- a/akvo/rsr/models/user.py
+++ b/akvo/rsr/models/user.py
@@ -13,6 +13,7 @@ from django.core.mail import send_mail
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 import rules
 from sorl.thumbnail.fields import ImageField
@@ -131,6 +132,10 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     def get_absolute_url(self):
         return "/user/{}/".format(self.pk)
+
+    @cached_property
+    def cacheable_url(self):
+        return self.get_absolute_url()
 
     def get_full_name(self):
         full_name = "{} {}".format(self.first_name, self.last_name).strip()


### PR DESCRIPTION


# TODO / Done

get_absolute_url uses `reverse()` which is filthy slow. Repeated calls to it slow down the application immensely.
We can cache that using `cached_property`, but optimally, we shouldn't be using such a method at all.

This is a quickfix to get use out of hot water. Hopefully, we can eradicate that method sometime...

# Test plan

 - [x] Manual testing of Results Overview and Results admin for project [10355 ](http://localhost/my-rsr/projects/10355/results)
    - [x] Add new data using the results admin
    - [x] Reload page and delete data from Results Overview

-----------

Closes #5022