### PR TITLE
[#4991] Reorder the links with the New features appearing at the bottom

### DIFF
--- a/akvo/rsr/spa/app/modules/announcements/HelpLinks.jsx
+++ b/akvo/rsr/spa/app/modules/announcements/HelpLinks.jsx
@@ -24,6 +24,7 @@ const HelpLinks = ({ userRole }) => {
   return (
     <ul className="help-links">
       <li>
+        <h5 className="help"><Text strong>Help</Text></h5>
         <ul>
           {
             links.length

--- a/akvo/rsr/spa/app/modules/announcements/announcement.jsx
+++ b/akvo/rsr/spa/app/modules/announcements/announcement.jsx
@@ -47,11 +47,10 @@ export default connect()(({ userRdr, openMenu }) => {
       <Popover
         content={(
           <div className="announcement-popover">
-            <h5 className="help"><Text strong>Help</Text></h5>
+            <HelpLinks userRole={userRdr?.userRole} />
             <div className="new-feature-container">
               <Button type="link" onClick={() => setShowModal(true)} className="new-feature">New Features</Button>
             </div>
-            <HelpLinks userRole={userRdr?.userRole} />
           </div>
         )}
         trigger="click"


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Reorder the links with the New features appearing at the bottom

<img width="311" alt="Screen Shot 2022-07-01 at 16 25 12" src="https://user-images.githubusercontent.com/20871229/176869105-11294ff2-873e-4631-9216-1849c8a63049.png">

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Login with any roles and see the support floating button
 
