### PR TITLE
[#5038] Fix enumerators can edit project updates they do not own

### DIFF
--- a/akvo/rsr/models/__init__.py
+++ b/akvo/rsr/models/__init__.py
@@ -305,8 +305,10 @@ rules.add_perm('rsr.change_organisationaccount', is_rsr_admin)
 
 rules.add_perm('rsr.add_projectupdate', is_rsr_admin | is_org_admin | is_org_user_manager |
                is_org_me_manager_or_project_editor | is_org_enumerator | is_org_user | is_own)
-rules.add_perm('rsr.change_projectupdate', is_own | is_rsr_admin | is_org_admin | is_org_user_manager |
+rules.add_perm('rsr.view_projectupdate', is_own | is_rsr_admin | is_org_admin | is_org_user_manager |
                is_org_me_manager_or_project_editor | is_org_user | is_org_enumerator)
+rules.add_perm('rsr.change_projectupdate', is_own | is_rsr_admin | is_org_admin | is_org_user_manager |
+               is_org_me_manager_or_project_editor | (is_own & is_org_user) | (is_own & is_org_enumerator))
 rules.add_perm('rsr.delete_projectupdate', is_own | is_rsr_admin | is_org_admin)
 
 rules.add_perm('rsr.add_projectupdatelocation', is_rsr_admin)

--- a/akvo/rsr/tests/rest/test_permissions.py
+++ b/akvo/rsr/tests/rest/test_permissions.py
@@ -29,8 +29,8 @@ User = get_user_model()
 group_count = collections.namedtuple('group_count', ('admin', 'anonymous', 'editor', 'other'))
 
 
-class PermissionFilteringTestCase(TestCase):
-    """Tests the filtering of querysets based on user permissions."""
+class CreatePermissionFilteringTestCase(TestCase):
+    """Tests the filtering of querysets for users who would like to create objects"""
 
     @classmethod
     def setUpClass(cls):
@@ -394,7 +394,7 @@ class PermissionFilteringTestCase(TestCase):
         # 8 project updates group_count(for each user in each group) per project
         # Every non-privileged user will also be able to see their update
         model_map[M.ProjectUpdate] = {
-            'group_count': group_count(64, 16, (48, 48), (48, 34)),
+            'group_count': group_count(64, 16, (48, 48), (34, 34)),
             'project_relation': 'project__'
         }
 

--- a/akvo/rsr/tests/rest/test_project_update.py
+++ b/akvo/rsr/tests/rest/test_project_update.py
@@ -10,9 +10,12 @@ For additional details on the GNU license please see < http://www.gnu.org/licens
 import json
 
 from os.path import abspath, dirname, join
+
+from django.contrib.auth.models import Group
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
-from akvo.rsr.models import Organisation, Partnership, Project, ProjectUpdate, ProjectUpdatePhoto
+from akvo.rsr.models import Organisation, Partnership, Project, ProjectRole, ProjectUpdate, ProjectUpdatePhoto
+from akvo.rsr.permissions import GROUP_NAME_ENUMERATORS
 from akvo.rsr.tests.base import BaseTestCase
 from akvo.rsr.tests.utils import ProjectFixtureBuilder
 
@@ -198,6 +201,119 @@ class RestProjectUpdateTestCase(BaseTestCase):
                                }),
                                content_type='application/json')
         self.assertEqual(response.status_code, 201)
+
+
+class RestProjectUpdateEnumeratorTestCase(BaseTestCase):
+    """Tests the project update REST endpoints from the perspective of an enumerator"""
+
+    def setUp(self):
+        """
+        Creates a project update made by an enumerator
+        """
+
+        super().setUp()
+        # Create active enumerator
+        self.enumerator = self.create_user("enumerator@test.akvo.org", "password")
+        self.org = Organisation.objects.create(name='org', long_name='org')
+        self.make_employment(self.enumerator, self.org, GROUP_NAME_ENUMERATORS)
+
+        # Create second enumerator
+        self.enumerator_steve = self.create_user("enumerator_steve@test.akvo.org", "password")
+        self.make_employment(self.enumerator_steve, self.org, GROUP_NAME_ENUMERATORS)
+
+        # Create projects
+        self.project = Project.objects.create(title="REST test project 2")
+        self.project.publish()
+        Partnership.objects.create(organisation=self.org, project=self.project)
+
+        # Create update
+        self.update_enum = ProjectUpdate.objects.create(
+            project=self.project,
+            user=self.enumerator,
+            title="My simple title",
+        )
+        self.update_steve = ProjectUpdate.objects.create(
+            project=self.project,
+            user=self.enumerator_steve,
+            title="My second simple title",
+        )
+
+        self.c.force_login(self.enumerator)
+
+    def test_view_all_updates(self):
+        """Ensure all updates can still be read"""
+
+        response = self.c.get("/rest/v1/project_update/?format=json")
+        self.assertEqual(response.status_code, 200, msg=response.content)
+        data = response.json()
+        self.assertEqual(data["count"], 2)
+
+    def test_own_update(self):
+        """Ensure the owned update has certain properties"""
+
+        response = self.c.get(f"/rest/v1/project_update/{self.update_enum.id}/?format=json")
+        self.assertEqual(response.status_code, 200, msg=response.content)
+        data = response.json()
+        self.assertEqual(data["editable"], True)
+        self.assertEqual(data["deletable"], True)
+
+    def test_other_update(self):
+        """Ensure the update owned by the other enumerator has certain properties"""
+
+        response = self.c.get(f"/rest/v1/project_update/{self.update_steve.id}/?format=json")
+        self.assertEqual(response.status_code, 200, msg=response.content)
+        data = response.json()
+
+        self.assertEqual(data["editable"], False)
+        self.assertEqual(data["deletable"], False)
+
+    def test_fail_modify_updates_by_other_enumerators(self):
+        """Modifying updates made by others should fail"""
+
+        response = self.c.patch(
+            f"/rest/v1/project_update/{self.update_steve.id}/?format=json",
+            json.dumps({"title": "new title"}),
+            content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 403, msg=response.content)
+
+    def test_fail_delete_updates_by_other_enumerators(self):
+        """Deleting updates made by others should fail"""
+        response = self.c.delete(
+            f"/rest/v1/project_update/{self.update_steve.id}/?format=json",
+        )
+        self.assertEqual(response.status_code, 403, msg=response.content)
+
+    def test_modify_own_update(self):
+        """Modifying owned updates should succeed"""
+        response = self.c.patch(
+
+            f"/rest/v1/project_update/{self.update_enum.id}/?format=json",
+            json.dumps({"title": "new title"}),
+            content_type="application/json"
+        )
+        self.assertEqual(response.status_code, 200, msg=response.content)
+
+    def test_delete_own_update(self):
+        """Deleting owned updates should succeed"""
+
+        response = self.c.delete(
+            f"/rest/v1/project_update/{self.update_enum.id}/?format=json",
+        )
+        self.assertEqual(response.status_code, 204, msg=response.content)
+
+
+class RestProjectRoleUpdateEnumeratorTestCase(RestProjectUpdateEnumeratorTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.project.use_project_roles = True
+        self.project.save(update_fields=['use_project_roles'])
+        ProjectRole.objects.create(
+            project=self.project,
+            user=self.enumerator,
+            group=Group.objects.get(name=GROUP_NAME_ENUMERATORS)
+        )
 
 
 def get_mock_image():

--- a/akvo/rsr/tests/test_permissions.py
+++ b/akvo/rsr/tests/test_permissions.py
@@ -552,10 +552,11 @@ class PermissionsTestCase(BaseTestCase):
         # "M&E manager" actions
         self.assertFalse(user.has_perm('rsr.do_me_manager_actions'))
 
-        # Project Update permissions
+        # Project Update & view permissions
         for i, project_update in enumerate(self.project_updates):
             test = self.assertTrue if i == 0 else self.assertFalse
             test(user.has_perm('rsr.change_projectupdate', project_update))
+            test(user.has_perm('rsr.view_projectupdate', project_update))
 
         # Project permissions
         for i, project in enumerate(self.projects):


### PR DESCRIPTION
# TODO / Done

Anybody able to view the update was able to edit it.
That was changed by limiting the operation to the owners and
 introducing the "rsr.view_projectupdate" permission.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] unit tests
 - [x] Scenario: 2 enumerators, 2 windows
 
## 2 enumerators, 2 windows

 - Add 2 enumerators to a project
 - Login with one enumerator in the browser window
 - Login with second enumerator in private browser window
 - Create updates with each enumerator

Expect to see the owned updates be editable and deletable, and the foreign updates to only be viewable.

![image](https://user-images.githubusercontent.com/91939214/178510470-84883c87-46e8-4640-8128-66f7ab87f484.png)


Fixes #5038