### PR TITLE
[#5061] fix project.created at is naive datetime when saving a project

### DIFF
--- a/akvo/iati/imports/__init__.py
+++ b/akvo/iati/imports/__init__.py
@@ -4,6 +4,7 @@
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 from django.core.exceptions import FieldDoesNotExist
+from django.utils import timezone
 
 from akvo.rsr.models.custom_field import ProjectCustomField
 from akvo.rsr.models.iati_import_log import IatiImportLog, LOG_ENTRY_TYPE
@@ -161,7 +162,7 @@ class ImportMapper(object):
             text=error,
             project=self.project,
             message_type=message_type,
-            created_at=datetime.now(),
+            created_at=timezone.now(),
         )]
 
     def get_text(self, element):

--- a/akvo/rsr/management/commands/cleanup_untitled_and_unpublished_projects.py
+++ b/akvo/rsr/management/commands/cleanup_untitled_and_unpublished_projects.py
@@ -5,11 +5,16 @@
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
 from datetime import datetime, timedelta
-from tablib import Dataset
+
 from django.core.management.base import BaseCommand
 from django.db import transaction
-from akvo.rsr.models import Project, PublishingStatus, IndicatorPeriodData, Result, IatiActivityImport
+from django.utils import timezone
+from django.utils.timezone import make_aware
+from tablib import Dataset
+
 from akvo.rsr.management.utils import VerbosityAwareWriter
+from akvo.rsr.models import IatiActivityImport, IndicatorPeriodData, Project, PublishingStatus, Result
+from akvo.utils.datetime import datetime_remove_time
 
 
 class Command(BaseCommand):
@@ -17,10 +22,14 @@ class Command(BaseCommand):
     Delete all Untitled and Unpublished projects
     """
 
-    DEFAULT_DATE = datetime.now() - timedelta(days=7)
+    DEFAULT_DATE = datetime_remove_time(timezone.now() - timedelta(days=7))
 
     def add_arguments(self, parser):
-        parser.add_argument('--date', type=lambda date: datetime.strptime(date, '%Y-%m-%d').date(), default=self.DEFAULT_DATE.date())
+        parser.add_argument(
+            '--date',
+            type=lambda date: make_aware(datetime.strptime(date, '%Y-%m-%d')),
+            default=self.DEFAULT_DATE,
+        )
         parser.add_argument('--dry-run', action='store_true', help='Do not actually delete projects')
 
     def handle(self, *args, **options):

--- a/akvo/rsr/management/commands/delete_empty_projects.py
+++ b/akvo/rsr/management/commands/delete_empty_projects.py
@@ -7,10 +7,11 @@
 
 from collections import Counter
 
-from datetime import datetime
 from django.contrib.admin.models import LogEntry, ADDITION
 from django.core.management.base import BaseCommand
 from optparse import make_option
+
+from django.utils import timezone
 
 from ...models import Project
 
@@ -51,7 +52,7 @@ class Command(BaseCommand):
             content_type=PROJECT_CONTENT_TYPE_ID, object_id__in=project_ids).order_by('-object_id')
 
         for log in project_logs:
-            time_since_creation = datetime.now() - log.action_time
+            time_since_creation = timezone.now() - log.action_time
             # Some projects only have one ChANGE entry, those should not be deleted
             if (
                     log.action_flag == ADDITION

--- a/akvo/rsr/management/commands/expire_all_sessions.py
+++ b/akvo/rsr/management/commands/expire_all_sessions.py
@@ -23,6 +23,7 @@ from django.contrib.auth import logout
 from django.contrib.sessions.models import Session
 from django.core.management.base import BaseCommand
 from django.http import HttpRequest
+from django.utils import timezone
 
 
 def init_session(session_key):
@@ -37,7 +38,7 @@ class Command(BaseCommand):
     help = "Expire all active sessions"
 
     def handle(self, *args, **options):
-        start = datetime.datetime.now() - datetime.timedelta(days=1)
+        start = timezone.now() - datetime.timedelta(days=1)
         request = HttpRequest()
         sessions = Session.objects.filter(expire_date__gt=start)
 

--- a/akvo/rsr/migrations/0047_auto_20160115_1039.py
+++ b/akvo/rsr/migrations/0047_auto_20160115_1039.py
@@ -2,6 +2,7 @@
 
 
 import django.db.models.deletion
+import pytz
 from django.db import models, migrations
 import akvo.rsr.models.iati_import_job
 import datetime
@@ -158,7 +159,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='iatiimportlog',
             name='created_at',
-            field=models.DateTimeField(default=datetime.datetime(2001, 1, 1, 0, 0), editable=False, db_index=True),
+            field=models.DateTimeField(default=datetime.datetime(2001, 1, 1, 0, 0, tzinfo=pytz.UTC), editable=False, db_index=True),
             preserve_default=False,
         ),
         migrations.AddField(

--- a/akvo/rsr/migrations/0219_project_naive_created_at.py
+++ b/akvo/rsr/migrations/0219_project_naive_created_at.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+from django.utils import timezone
+
+
+def make_timezone_aware_created_at(apps, schema):
+    Project = apps.get_model("rsr", "Project")
+    projects = []
+    for project in Project.objects.all():
+        project.created_at = timezone.make_aware(project.created_at)
+    Project.objects.bulk_update(projects, ["created_at"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('rsr', '0218_project_thumbnail_cache'),
+    ]
+
+    operations = [
+        migrations.RunPython(make_timezone_aware_created_at)
+    ]

--- a/akvo/rsr/migrations/0220_project_naive_created_at.py
+++ b/akvo/rsr/migrations/0220_project_naive_created_at.py
@@ -12,7 +12,7 @@ def make_timezone_aware_created_at(apps, schema):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('rsr', '0218_project_thumbnail_cache'),
+        ('rsr', '0219_iatiactivityvalidationjob_iatiorganisationvalidationjob'),
     ]
 
     operations = [

--- a/akvo/rsr/models/iati_activity_import.py
+++ b/akvo/rsr/models/iati_activity_import.py
@@ -6,7 +6,6 @@
 
 import inspect
 
-from datetime import datetime
 from lxml import etree
 
 from django.apps import apps
@@ -15,6 +14,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models, transaction
 from django.utils.translation import ugettext_lazy as _
+from django.utils import timezone
 
 from akvo import settings
 from akvo.rsr.mixins import TimestampsMixin
@@ -161,7 +161,7 @@ class IatiActivityImport(TimestampsMixin):
             tag=tag,
             field=field,
             text=text,
-            created_at=datetime.now(),
+            created_at=timezone.now(),
         )]
 
     def set_reporting_org(self):
@@ -330,7 +330,7 @@ class IatiActivityImport(TimestampsMixin):
                                 field='',
                                 text="Exception in {}, error message: \n{}".format(
                                     Klass.__name__, e),
-                                created_at=datetime.now()
+                                created_at=timezone.now()
                             )]
                         if changes:
                             self.changes += changes

--- a/akvo/rsr/models/iati_import_job.py
+++ b/akvo/rsr/models/iati_import_job.py
@@ -8,10 +8,10 @@ import hashlib
 import inspect
 import urllib.request
 
-from datetime import datetime
 import zipfile
 
 import tablib
+from django.utils import timezone
 from lxml import etree
 
 from django.contrib.admin.models import LogEntry
@@ -106,7 +106,7 @@ class IatiImportJob(models.Model):
             iati_import_job=self,
             message_type=message_type,
             text=text,
-            created_at=datetime.now(),
+            created_at=timezone.now(),
         )
 
     def save_import_logs(self, iati_activity_import):

--- a/akvo/rsr/models/project.py
+++ b/akvo/rsr/models/project.py
@@ -1835,7 +1835,7 @@ def update_thumbnails(sender, **kwargs):
     # Remove existing thumbnails when the current image is deleted
     if not project.current_image:
         deletions, _ = project.thumbnails.all().delete()
-        log.log(logging.DEBUG if not deletions else logging.INFO, "Deleted %s old thumbs after unset", deletions)
+        log.log(logging.NOTSET if not deletions else logging.INFO, "Deleted %s old thumbs after unset", deletions)
         return
 
     default_sizes = settings.DEFAULT_PROJECT_THUMBNAIL_SIZES
@@ -1862,7 +1862,7 @@ def update_thumbnails(sender, **kwargs):
 
     # Delete thumbnails without the current URL
     deletions, _ = project.thumbnails.exclude(full_size_url=full_size_url).delete()
-    log.log(logging.DEBUG if not deletions else logging.INFO, "Deleted %s thumbs with old URLs", deletions)
+    log.log(logging.NOTSET if not deletions else logging.INFO, "Deleted %s thumbs with old URLs", deletions)
 
 
 receiver(post_save, sender=Project)(update_thumbnails)

--- a/akvo/rsr/signals.py
+++ b/akvo/rsr/signals.py
@@ -7,7 +7,6 @@
 
 import logging
 import os
-from datetime import datetime
 
 from django.contrib.admin.models import ADDITION, CHANGE
 from django.contrib.auth import get_user_model
@@ -17,6 +16,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.apps import apps
 from django.db.models import Q
+from django.utils import timezone
 
 from sorl.thumbnail import ImageField
 
@@ -94,7 +94,7 @@ def change_name_of_file_on_create(sender, **kwargs):
                         opts.object_name,
                         instance.pk or '',
                         f.name,
-                        datetime.now().strftime("%Y-%m-%d_%H.%M.%S"),
+                        timezone.now().strftime("%Y-%m-%d_%H.%M.%S"),
                         os.path.splitext(img.name)[1],
                     )
                     save_image(img, img_name, f.name)
@@ -130,7 +130,7 @@ def change_name_of_file_on_change(sender, **kwargs):
                                 opts.object_name,
                                 instance.pk or '',
                                 f.name,
-                                datetime.now().strftime("%Y-%m-%d_%H.%M.%S"),
+                                timezone.now().strftime("%Y-%m-%d_%H.%M.%S"),
                                 os.path.splitext(img.name)[1],
                             )
                             # Create thumbnail for use in reports

--- a/akvo/rsr/tests/base.py
+++ b/akvo/rsr/tests/base.py
@@ -11,6 +11,7 @@ from django.contrib.auth import user_login_failed
 from django.contrib.auth.models import Group
 from django.http import HttpRequest
 from django.test import TestCase, Client
+from django.utils.timezone import is_naive, make_aware
 
 from akvo.rsr.models import (
     User, Employment, Organisation, Project, RelatedProject, Partnership, PublishingStatus,
@@ -79,9 +80,14 @@ class BaseTestCase(TestCase):
     @staticmethod
     def create_project(title, published=True, public=True, created_at=None):
         """Create a project with the given title."""
-        project = BaseTestCase._create_project_at(title, public, created_at) \
-            if isinstance(created_at, datetime) \
-            else Project.objects.create(title=title, is_public=public)
+        if isinstance(created_at, datetime):
+            project = BaseTestCase._create_project_at(
+                title,
+                public,
+                make_aware(created_at) if is_naive(created_at) else created_at
+            )
+        else:
+            project = Project.objects.create(title=title, is_public=public)
         status = (
             PublishingStatus.STATUS_PUBLISHED if published else PublishingStatus.STATUS_UNPUBLISHED
         )

--- a/akvo/rsr/views/py_reports/eutf_org_results_table_excel_report.py
+++ b/akvo/rsr/views/py_reports/eutf_org_results_table_excel_report.py
@@ -10,10 +10,10 @@ see < http://www.gnu.org/licenses/agpl.html >.
 from akvo.rsr.models import IndicatorPeriod, ProjectHierarchy, Result
 from akvo.rsr.models.result.utils import PERCENTAGE_MEASURE
 from akvo.rsr.decorators import with_download_indicator
-from datetime import datetime
 from django.contrib.auth.decorators import login_required
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
 from pyexcelerate import Workbook, Style, Font, Color, Fill, Alignment
 from pyexcelerate.Borders import Borders
 from pyexcelerate.Border import Border
@@ -175,6 +175,6 @@ def render_report(request, program_id, result_id=None):
                     highlight = False
 
     filename = '{}-{}-eutf-results-and-indicators-simple-table.xlsx'.format(
-        datetime.now().strftime('%Y%m%d'), organisation.id)
+        timezone.now().strftime('%Y%m%d'), organisation.id)
 
     return utils.make_excel_response(wb, filename)

--- a/akvo/rsr/views/py_reports/organisation_data_quality_overview_report.py
+++ b/akvo/rsr/views/py_reports/organisation_data_quality_overview_report.py
@@ -6,10 +6,10 @@ See more details in the license.txt file located at the root folder of the
 Akvo RSR module. For additional details on the GNU license please
 see < http://www.gnu.org/licenses/agpl.html >.
 """
+from django.utils import timezone
 
 from akvo.rsr.models import Organisation, Project
 from akvo.rsr.decorators import with_download_indicator
-from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth.decorators import login_required
 from django.conf import settings
@@ -28,7 +28,7 @@ from . import utils
 @with_download_indicator
 def render_report(request, org_id):
     organisation = get_object_or_404(Organisation, pk=org_id)
-    now = datetime.now()
+    now = timezone.now()
     reader = OrganisationDataQualityReader(organisation, now)
 
     format = request.GET.get('format')

--- a/akvo/rsr/views/py_reports/organisation_projects_overview_report.py
+++ b/akvo/rsr/views/py_reports/organisation_projects_overview_report.py
@@ -6,12 +6,12 @@ See more details in the license.txt file located at the root folder of the
 Akvo RSR module. For additional details on the GNU license please
 see < http://www.gnu.org/licenses/agpl.html >.
 """
+from django.utils import timezone
 
 from akvo.codelists.models import ActivityStatus
 from akvo.rsr.models import Organisation
 from akvo.utils import ObjectReaderProxy
 from akvo.rsr.decorators import with_download_indicator
-from datetime import datetime
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.db.models import Count, Sum
@@ -168,7 +168,7 @@ def render_report(request, org_id):
 
 
 def _render_pdf(reader, show_html=True):
-    current_date = datetime.now()
+    current_date = timezone.now()
     html = render_to_string(
         'reports/organisation-projects-overview.html',
         context={
@@ -416,6 +416,6 @@ def _render_excel(reader):
         row += 1
 
     filename = '{}-{}-organisation-projects-overview.xlsx'.format(
-        datetime.now().strftime('%Y%m%d'), reader.id)
+        timezone.now().strftime('%Y%m%d'), reader.id)
 
     return utils.make_excel_response(wb, filename)

--- a/akvo/rsr/views/py_reports/results_indicators_excel_report.py
+++ b/akvo/rsr/views/py_reports/results_indicators_excel_report.py
@@ -5,11 +5,11 @@ See more details in the license.txt file located at the root folder of the
 Akvo RSR module. For additional details on the GNU license please
 see < http://www.gnu.org/licenses/agpl.html >.
 """
+from django.utils import timezone
 
 from akvo.rsr.models import Organisation, IndicatorPeriod
 from akvo.rsr.models.result.utils import PERCENTAGE_MEASURE
 from akvo.rsr.decorators import with_download_indicator
-from datetime import datetime
 from django.contrib.auth.decorators import login_required
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
@@ -198,6 +198,6 @@ def render_report(request, org_id):
                     row += 1
 
     filename = '{}-{}-results-and-indicators-simple-table.xlsx'.format(
-        datetime.now().strftime('%Y%m%d'), organisation.id)
+        timezone.now().strftime('%Y%m%d'), organisation.id)
 
     return utils.make_excel_response(wb, filename)

--- a/akvo/utils/__init__.py
+++ b/akvo/utils/__init__.py
@@ -26,6 +26,7 @@ from django.core.signing import TimestampSigner
 from django.apps import apps
 from django.http import HttpResponse
 from django.template import loader
+from django.utils import timezone
 from django.utils.text import slugify
 import pytz
 from sorl.thumbnail import get_thumbnail as get_sorl_thumbnail
@@ -156,7 +157,7 @@ def model_and_instance_based_filename(object_name, pk, field_name, img_name):
         object_name,
         pk or '',
         field_name,
-        datetime.now().strftime("%Y-%m-%d_%H.%M.%S"),
+        timezone.now().strftime("%Y-%m-%d_%H.%M.%S"),
         splitext(img_name)[1],
     )
 

--- a/akvo/utils/datetime.py
+++ b/akvo/utils/datetime.py
@@ -1,0 +1,6 @@
+from datetime import datetime
+
+
+def datetime_remove_time(datetime_: datetime) -> datetime:
+    """Removes the time components from a datetime effectively making it a date"""
+    return datetime_.replace(hour=0, minute=0, second=0)


### PR DESCRIPTION
# TODO / Done

Reduce the number of useless logs and warnings

 - [x] Use `timezone.now()` instead of `datetime.now()` where possible
 - [x] Make datetimes timezone aware in most tests
 - [x] Migrate existing Projects with to timezone aware `created_at`

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Unit tests
 
Fixes #5061