### PR TITLE
devops: place rsr on its own node

### DIFF
--- a/ci/k8s/deployment.yml
+++ b/ci/k8s/deployment.yml
@@ -22,6 +22,21 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
     spec:
+      tolerations:
+        - key: "akvo-app"
+          operator: "Equal"
+          value: "rsr"
+          effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: "akvo-app"
+                    operator: "In"
+                    values:
+                      - "rsr"
       containers:
       - name: rsr-nginx
         image: eu.gcr.io/akvo-lumen/rsr-nginx:${TRAVIS_COMMIT}


### PR DESCRIPTION
# TODO / Done

RSR has just become quite CPU intensive and requires more memory than before.
As a workaround before optimizing performance and memory, the pod will:
 - tolerate a mode with the taint akvo-app=rsr
 - have an affinity for nodes with the label akvo-app=rsr

# Test plan

Can't really test this without running it. Only a dry run can check the syntax.

Related to #5062