### PR TITLE
[#5073] Fix editor long delays before loading

### DIFF
--- a/akvo/rsr/spa/app/modules/editor/project-init-handler.js
+++ b/akvo/rsr/spa/app/modules/editor/project-init-handler.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { connect } from 'react-redux'
 import api from '../../utils/api'
 import { endpoints, getTransform } from './endpoints'
@@ -11,10 +11,15 @@ const insertRouteParams = (route, params) => {
   })
   return route
 }
-let prevParams
-let sectionIndexPipeline = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+
+const SECTION_RESULTS_INDICATORS = 4;
+
+let sectionIndexPipeline = [1, 2, 3, SECTION_RESULTS_INDICATORS, 5, 6, 7, 8, 9, 10, 11];
+const SECTION_COUNT = sectionIndexPipeline.length + 1;
 
 const ProjectInitHandler = connect(({editorRdr}) => ({ editorRdr }), actions)(React.memo(({ match: {params}, ...props}) => {
+  const [nextSectionIndex, setNextSectionIndex] = useState(0)
+
   const fetchSection = (sectionIndex) => new Promise(async (resolve, reject) => {
     if(sectionIndex === 4 || sectionIndex === 6 || sectionIndex === 7 || sectionIndex === 8 || sectionIndex === 10){
       props.fetchSectionRoot(sectionIndex)
@@ -64,26 +69,32 @@ const ProjectInitHandler = connect(({editorRdr}) => ({ editorRdr }), actions)(Re
     }
     else resolve()
   })
-  let nextSectionIndex = 0
-  const fetchNextSection = () => {
-    fetchSection(sectionIndexPipeline[nextSectionIndex])
-    .then(() => {
-      props.setSectionFetched(sectionIndexPipeline[nextSectionIndex])
-      if (nextSectionIndex < 10) {
-        nextSectionIndex += 1
-        fetchNextSection()
-      }
-    })
-  }
+
   useEffect(() => {
-    if (prevParams && prevParams.id !== params.id && params.id !== 'new'){
-      fetchSection(3)
-      fetchSection(5)
+    if (!props?.editorRdr[`section${nextSectionIndex + 1}`]?.isFetched) {
+      fetchSection(sectionIndexPipeline[nextSectionIndex])
+        .then(() => {
+          if (nextSectionIndex === SECTION_RESULTS_INDICATORS) {
+            /**
+             * Results and indicator need 10s delay to avoid fields component errors.
+             * I've created an issue related to this case
+             */
+            // TODO: [#5075] Bug: Access Results and Indicators section directly
+            setTimeout(() => {
+              props.setSectionFetched(sectionIndexPipeline[nextSectionIndex])
+            }, 10000)
+          }
+          if (nextSectionIndex !== SECTION_RESULTS_INDICATORS) {
+            props.setSectionFetched(sectionIndexPipeline[nextSectionIndex])
+          }
+        })
     }
-  }, [params.id])
-  useEffect(() => {
-    prevParams = params
-  })
+    // eslint-disable-next-line no-restricted-globals
+    if (!isNaN(params?.id) && (nextSectionIndex < SECTION_COUNT)) {
+      const next = nextSectionIndex + 1
+      setNextSectionIndex(next)
+    }
+  }, [params.id, nextSectionIndex])
   useEffect(() => {
     if (params.id !== 'new') {
       if(params.id === props.editorRdr.projectId) return
@@ -94,7 +105,6 @@ const ProjectInitHandler = connect(({editorRdr}) => ({ editorRdr }), actions)(Re
           sectionIndexPipeline = [1, sectionIndexPipeline[index], ...sectionIndexPipeline.filter((it, itIndex) => index !== itIndex).slice(1)]
         }
       }
-      fetchNextSection()
     } else {
       props.resetProject()
     }


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Replace uncontrolled **nextSectionIndex** with controlled state in project editor.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Open general information directly by following <a href="http://localhost/my-rsr/projects/2/info" target="_blank">this URL</a>
 - [x] Open project contacts directly by following <a href="http://my-rsr/projects/2/contacts" target="_blank">this URL</a>
 - [x] Open partner & user access directly by following <a href="http://localhost/my-rsr/projects/2/partners" target="_blank">this URL</a>
 - [x] Open descriptions directly by following <a href="http://localhost/my-rsr/projects/2/descriptions" target="_blank">this URL</a>
 - [x] Open results & indicators directly by following <a href="http://localhost/my-rsr/projects/2/results-n-indicators" target="_blank">this URL</a>
 - [x] Open finance directly by following <a href="http://localhost/my-rsr/projects/2/finance" target="_blank">this URL</a>
 - [x] Open location directly by following <a href="http://localhost/my-rsr/projects/2/locations" target="_blank">this URL</a>
 - [x] Open project focus directly by following <a href="http://localhost/my-rsr/projects/2/focus" target="_blank">this URL</a>
 - [x] Open project links & documents by following <a href="http://localhost/my-rsr/projects/2/links-n-docs" target="_blank">this URL</a>
 - [x] Open comments & keywords directly by following <a href="http://localhost/my-rsr/projects/2/comments-n-keywords" target="_blank">this URL</a>
 - [x] Open CRS++ & FSS reporting directly by following <a href="http://localhost/my-rsr/projects/2/reporting" target="_blank">this URL</a>
 
