### PR TITLE
Fix bug project editor sections are loaded only once

### DIFF
--- a/akvo/rsr/spa/app/modules/editor/project-init-handler.js
+++ b/akvo/rsr/spa/app/modules/editor/project-init-handler.js
@@ -1,9 +1,9 @@
+/* eslint-disable no-restricted-globals */
 import React, { useEffect, useState } from 'react'
 import { connect } from 'react-redux'
 import api from '../../utils/api'
 import { endpoints, getTransform } from './endpoints'
 import * as actions from './actions'
-import sections from './sections'
 
 const insertRouteParams = (route, params) => {
   Object.keys(params).forEach(param => {
@@ -12,107 +12,114 @@ const insertRouteParams = (route, params) => {
   return route
 }
 
-const SECTION_RESULTS_INDICATORS = 4;
+const SECTION_INFO = 1;
+const SECTION_CONTACT = 2;
+const SECTION_USER_ACCESS = 3;
+const SECTION_DESCRIPTION = 4;
+const SECTION_RESULTS_INDICATORS = 5;
+const SECTION_FINANCE = 6;
+const SECTION_LOCATION = 7;
+const SECTION_FOCUS = 8;
+const SECTION_LINK_N_DOC = 9;
+const SECTION_COMMENT = 10;
+const SECTION_CRS = 11;
+const SECTION_COUNT = 11;
 
-let sectionIndexPipeline = [1, 2, 3, SECTION_RESULTS_INDICATORS, 5, 6, 7, 8, 9, 10, 11];
-const SECTION_COUNT = sectionIndexPipeline.length;
+const sectionInstanceToRoot = [
+  SECTION_DESCRIPTION,
+  SECTION_FINANCE,
+  SECTION_LOCATION,
+  SECTION_FOCUS,
+  SECTION_COMMENT
+];
+const sectionHasEndpoint = [
+  SECTION_INFO,
+  SECTION_CONTACT,
+  SECTION_USER_ACCESS,
+  SECTION_RESULTS_INDICATORS,
+  SECTION_FINANCE,
+  SECTION_LOCATION,
+  SECTION_FOCUS,
+  SECTION_LINK_N_DOC,
+  SECTION_CRS,
+]
 
-const ProjectInitHandler = connect(({editorRdr}) => ({ editorRdr }), actions)(React.memo(({ match: {params}, ...props}) => {
-  const [nextSectionIndex, setNextSectionIndex] = useState(0)
+const ProjectInitHandler = ({ match: { params }, editorRdr, ...props }) => {
+  const [preload, setPreload] = useState(true)
+  const [sectionIndex, setNextSectionIndex] = useState(2) // I started with 2 because 1 will be called first
 
-  const fetchSection = (sectionIndex) => new Promise(async (resolve, reject) => {
-    if(sectionIndex === 4 || sectionIndex === 6 || sectionIndex === 7 || sectionIndex === 8 || sectionIndex === 10){
-      props.fetchSectionRoot(sectionIndex)
-    }
-    if(sectionIndex === 4){
-      resolve()
-      return
-    }
-    const _endpoints = endpoints[`section${sectionIndex}`]
-    // fetch root
-    if(_endpoints.hasOwnProperty('root')){
-      await api.get(insertRouteParams(_endpoints.root, { projectId: params.id }))
-        .then(({data}) => props.fetchFields(sectionIndex, data))
-    }
-    // fetch sets
-    const setEndpoints = Object
+  const fetchSectionOne = endpoint => api
+    .get(insertRouteParams(endpoint, { projectId: params.id }))
+    .then(({ data }) => {
+      props.fetchFields(SECTION_INFO, data)
+      props.setSectionFetched(SECTION_INFO)
+    })
+
+  const fetchNextSection = index => {
+    const _endpoints = endpoints[`section${index}`] || endpoints.section1
+    const sectionEndPoints = Object
       .keys(_endpoints)
       .filter(it => it !== 'root' && it.indexOf('.') === -1)
-      .map(it => ({ setName: it, endpoint: _endpoints[it]}))
-    if(setEndpoints.length > 0) {
-      const fetchSet = (index) => {
-        const { endpoint, setName } = setEndpoints[index]
-        let _params = endpoint === '/project_location/' ? {location_target: params.id} : {project: params.id}
-        _params = endpoint?.includes('related_project') ? { ..._params, relation: 1 } : _params
-        if (sectionIndex !== 6) _params.limit = 300
-        api.get(endpoint, _params, getTransform(sectionIndex, setName, 'response'))
-          .then(({ data: { results, count } }) => {
-            if (sectionIndex === 7 && setName === 'locationItems') {
-              props.fetchSetItems(sectionIndex, 'projectId', params.id, count)
-            }
-            if (sectionIndex === 1 && setName === 'relatedProjects' && !(results.length)) {
-              results = [
-                {
-                  project: params.id,
-                  relatedProject: null,
-                  relatedIatiId: '',
-                  relation: 1
-                }
-              ]
-            }
-            props.fetchSetItems(sectionIndex, setName, results, count)
-            if(index < setEndpoints.length - 1) fetchSet(index + 1)
-            else resolve()
-          })
-      }
-      fetchSet(0)
-    }
-    else resolve()
-  })
+      .map(it => ({ setName: it, endpoint: _endpoints[it] }))
+
+    sectionEndPoints.forEach(item => {
+      const { endpoint, setName } = item
+      let _params = endpoint === '/project_location/' ? { location_target: params.id } : { project: params.id }
+      _params = endpoint?.includes('related_project') ? { ..._params, relation: 1 } : _params
+
+      api
+        .get(endpoint, _params, getTransform(index, setName, 'response'))
+        .then(({ data: { results, count } }) => {
+          props.fetchSetItems(index, setName, results, count)
+          props.setSectionFetched(index)
+        })
+    })
+  }
 
   useEffect(() => {
-    if (!props?.editorRdr[`section${nextSectionIndex + 1}`]?.isFetched) {
-      fetchSection(sectionIndexPipeline[nextSectionIndex])
-        .then(() => {
-          if(nextSectionIndex >= SECTION_COUNT){
-            return
-          }
-          if (nextSectionIndex === SECTION_RESULTS_INDICATORS) {
-            /**
-             * Results and indicator need 10s delay to avoid fields component errors.
-             * I've created an issue related to this case
-             */
-            // TODO: [#5075] Bug: Access Results and Indicators section directly
-            setTimeout(() => {
-              props.setSectionFetched(sectionIndexPipeline[nextSectionIndex])
-            }, 10000)
-          }
-          if (nextSectionIndex !== SECTION_RESULTS_INDICATORS) {
-            props.setSectionFetched(sectionIndexPipeline[nextSectionIndex])
-          }
-        })
+    if (preload) {
+      /**
+       * those command only execute once
+       */
+      setPreload(false)
+      if (params.id !== editorRdr.projectId || !editorRdr.section1.isFetched) {
+        /**
+         * if previous ID not equal with current ID then
+         * Reset all states and set old ID with current ID
+         */
+        props.resetProject()
+        props.setProjectId(params.id)
+        fetchSectionOne(endpoints.section1.root)
+      }
     }
-    const next = nextSectionIndex + 1
-    // eslint-disable-next-line no-restricted-globals
-    if (!isNaN(params?.id) && (next < SECTION_COUNT)) {
+
+    /**
+     * As long as ID is numeric &&
+     * sectionIndex is less then number of sections &&
+     * first section is fetched then
+     * it will increment to move to the next section
+     */
+    if (
+      !isNaN(params?.id) &&
+      (sectionIndex <= SECTION_COUNT) &&
+      editorRdr.section1.isFetched
+    ) {
+      if (sectionHasEndpoint.includes(sectionIndex)) {
+        fetchNextSection(sectionIndex)
+      }
+
+      if (sectionInstanceToRoot.includes(sectionIndex)) {
+        props.fetchSectionRoot(sectionIndex)
+        props.setSectionFetched(sectionIndex)
+      }
+
+      const next = sectionIndex + 1
       setNextSectionIndex(next)
     }
-  }, [params.id, nextSectionIndex])
-  useEffect(() => {
-    if (params.id !== 'new') {
-      if(params.id === props.editorRdr.projectId) return
-      props.setProjectId(params.id)
-      if(params.section != null){
-        const index = sections.findIndex(it => it.key === params.section)
-        if(index > 0){
-          sectionIndexPipeline = [1, sectionIndexPipeline[index], ...sectionIndexPipeline.filter((it, itIndex) => index !== itIndex).slice(1)]
-        }
-      }
-    } else {
-      props.resetProject()
-    }
-  }, [])
+  }, [preload, sectionIndex, editorRdr]) // those variables are subscribers and React JS will always pay attention to their value
   return null
-}, (prevProps, nextProps) => { return prevProps.editorRdr.projectId === nextProps.editorRdr.projectId }))
+}
 
-export default ProjectInitHandler
+export default connect(
+  ({ editorRdr }) => ({ editorRdr }), actions
+)(ProjectInitHandler)

--- a/akvo/rsr/spa/app/modules/editor/project-init-handler.js
+++ b/akvo/rsr/spa/app/modules/editor/project-init-handler.js
@@ -15,7 +15,7 @@ const insertRouteParams = (route, params) => {
 const SECTION_RESULTS_INDICATORS = 4;
 
 let sectionIndexPipeline = [1, 2, 3, SECTION_RESULTS_INDICATORS, 5, 6, 7, 8, 9, 10, 11];
-const SECTION_COUNT = sectionIndexPipeline.length + 1;
+const SECTION_COUNT = sectionIndexPipeline.length;
 
 const ProjectInitHandler = connect(({editorRdr}) => ({ editorRdr }), actions)(React.memo(({ match: {params}, ...props}) => {
   const [nextSectionIndex, setNextSectionIndex] = useState(0)
@@ -74,6 +74,9 @@ const ProjectInitHandler = connect(({editorRdr}) => ({ editorRdr }), actions)(Re
     if (!props?.editorRdr[`section${nextSectionIndex + 1}`]?.isFetched) {
       fetchSection(sectionIndexPipeline[nextSectionIndex])
         .then(() => {
+          if(nextSectionIndex >= SECTION_COUNT){
+            return
+          }
           if (nextSectionIndex === SECTION_RESULTS_INDICATORS) {
             /**
              * Results and indicator need 10s delay to avoid fields component errors.
@@ -89,9 +92,9 @@ const ProjectInitHandler = connect(({editorRdr}) => ({ editorRdr }), actions)(Re
           }
         })
     }
+    const next = nextSectionIndex + 1
     // eslint-disable-next-line no-restricted-globals
-    if (!isNaN(params?.id) && (nextSectionIndex < SECTION_COUNT)) {
-      const next = nextSectionIndex + 1
+    if (!isNaN(params?.id) && (next < SECTION_COUNT)) {
       setNextSectionIndex(next)
     }
   }, [params.id, nextSectionIndex])


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Refactor ```project-init-handler``` by removing promise and changing some logic.
 - [x] Fix editor sections are loadedRe-fetching data when previous id is not equal with current ID.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Open project editor directly.
 - [ ] Open project editor indirectly.
 - [ ] Move one project to another and open the project editor.
 - [ ] Move randomly from one section to another in project editor.
 
## Open project editor directly
 - Make sure you are logged in.
 - Open this URL in your browser : https://rsr.akvotest.org/my-rsr/projects/6003/info
 - It should contain General information data from the backend.

## Open project editor indirectly

- Login with your account.
- Go to any project.
- Move to project editor.
- It should contain General information data from the backend.

## Move one project to another and open the project editor

- Login with your account.
- Let's try with the following projects : 
1. [OmiDelta Fonds Acteurs Non Etatiques pour la composante AEPHA](https://rsr.akvotest.org/my-rsr/projects/6024/results)
2. [ANAP](https://rsr.akvotest.org/my-rsr/projects/7021/results).
3. [Roblox Introx](https://rsr.akvotest.org/my-rsr/projects/10270/results).

