### PR TITLE
Update tools for training env deployment

### DIFF
--- a/ci/training-envs/Dockerfile
+++ b/ci/training-envs/Dockerfile
@@ -1,0 +1,8 @@
+FROM kiwigrid/gcloud-kubectl-helm:2.12.3-234.0.0-88
+
+# Update to a gcloud version known to work
+ARG GCLOUD_COMPONENTS_VERSION="399.0.0"
+USER 0
+RUN gcloud components update --version "$GCLOUD_COMPONENTS_VERSION" \
+    && adduser akvo -D -u 1000
+USER akvo

--- a/ci/training-envs/README.md
+++ b/ci/training-envs/README.md
@@ -12,7 +12,8 @@ To prepare a training set, a new empty environment will be created and, using th
 
 From the directory containing this README.md file run:
 
-    docker run --rm -it -w /data -v `pwd`:/data kiwigrid/gcloud-kubectl-helm:2.12.3-234.0.0-88 bash
+   mkdir .config 
+   docker-compose run akvo-rsr-helm
 
 Once the container has started, login to GCE with: 
 
@@ -31,14 +32,6 @@ After that you can run:
    1. rsr_version: RSR version to run. If not provided, it will the current production version. 
    Note that the containers for this version must already exists (right now this means that it must be at least deployed to test).
 
-### Login all the time is boring
-
-You can mount your ./.config at /home/gkh/.config to reuse your existing credentials. So add to the `docker run` command: 
-
-    -v ./.config:/home/gkh/.config
-
-**Note that the scripts will modify the cluster that `gcloud/kubectl` points to**. Make sure that you switch your environment before running any command outside this container.
-     
 ### Technical details
 
 The architecture:

--- a/ci/training-envs/docker-compose.yml
+++ b/ci/training-envs/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+
+services:
+  akvo-rsr-helm:
+    build:
+      context: .
+      args:
+        # Allow targetting a different gcloud version
+        GCLOUD_COMPONENTS_VERSION: "${GCLOUD_COMPONENTS_VERSION:-399.0.0}"
+    working_dir: /data
+    volumes:
+      - ./:/data
+      # Store gcloud credentials locally
+      - ./.config:/home/akvo/.config
+    command: bash

--- a/scripts/data/make-and-restore-production-dump.sh
+++ b/scripts/data/make-and-restore-production-dump.sh
@@ -21,9 +21,9 @@ docker run \
   --rm \
   -it \
   -v "$DUMP_DIR":/data \
-  -v "$CONFIG_DIR":/home/gkh/.config/gcloud \
-  -v "$DIR"/helper/make-gcp-dump.sh:/data/commands.sh:ro \
-    kiwigrid/gcloud-kubectl-helm:2.12.3-234.0.0-88
+  -v "$CONFIG_DIR":/root/.config/gcloud \
+  -v "$DIR"/helper/make-gcp-dump.sh:/commands.sh:ro \
+    gcr.io/google.com/cloudsdktool/google-cloud-cli bash /commands.sh
 
 ## Run just these two commands if you already have a dump and you want to restore it.
 docker-compose exec \


### PR DESCRIPTION

# TODO / Done

We weren't able to login using the gcloud SDK anymore  because it was too old.
Using docker-compose and Dockerfile, we now make it possible to target a specific version of gcloud.

 - [x] Update docker image for deploying training envs
 - [x] Update docker image for making production dumps
 - [x] Ensure docker image is updated in other places (if there are any)

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Run `docker-compose` instructions in `ci/trainings-env/README.md` 
 - [x] `./list.sh` in container