### PR TITLE
[#5096] iati export does not update checks after project is updated

### DIFF
--- a/akvo/iati/exports/iati_export.py
+++ b/akvo/iati/exports/iati_export.py
@@ -114,7 +114,14 @@ class IatiXML(object):
             for tree_element in tree_elements:
                 project_element.append(tree_element)
 
-    def __init__(self, projects, version='2.03', iati_export=None, excluded_elements=None):
+    def __init__(
+            self,
+            projects,
+            version='2.03',
+            iati_export=None,
+            excluded_elements=None,
+            utc_now: datetime = None,
+    ):
         """
         Initialise the IATI XML object, creating a 'iati-activities' etree Element as root.
 
@@ -122,6 +129,7 @@ class IatiXML(object):
         :param version: String of IATI version
         :param iati_export: IatiExport Django object
         :param excluded_elements: List of fieldnames that should be ignored when exporting
+        :param utc_now: The current time in UTC. Useful to override in tests for a stable time
         """
         from akvo.rsr.models import IatiExport
 
@@ -133,8 +141,9 @@ class IatiXML(object):
         self.iati_activities = etree.Element("iati-activities",
                                              nsmap={'akvo': 'http://akvo.org/iati-activities'})
         self.iati_activities.attrib['version'] = self.version
-        self.iati_activities.attrib['generated-datetime'] = datetime.utcnow().\
-            isoformat("T", "seconds")
+
+        utc_now = utc_now or datetime.utcnow()
+        self.iati_activities.attrib['generated-datetime'] = utc_now.isoformat("T", "seconds")
 
         for project in projects:
             # Add IATI activity export to indicate that export has started

--- a/akvo/iati/exports/iati_org_export.py
+++ b/akvo/iati/exports/iati_org_export.py
@@ -63,7 +63,14 @@ class IatiOrgXML(object):
             for tree_element in tree_elements:
                 organisation_element.append(tree_element)
 
-    def __init__(self, organisations, version='2.03', excluded_elements=None, context=None):
+    def __init__(
+            self,
+            organisations,
+            version='2.03',
+            excluded_elements=None,
+            context=None,
+            utc_now: datetime = None,
+    ):
         """
         Initialise the IATI XML object, creating a 'iati-organisations' etree Element as root.
 
@@ -71,6 +78,7 @@ class IatiOrgXML(object):
         :param context: Dictionary of additional context that might be required by element handler
         :param version: String of IATI version
         :param excluded_elements: List of fieldnames that should be ignored when exporting
+        :param utc_now: The current time in UTC. Useful to override in tests for a stable time
         """
         self.context = context or {}
         self.organisations = organisations
@@ -79,8 +87,9 @@ class IatiOrgXML(object):
         # TODO: Add Akvo namespace and RSR specific fields
         self.iati_organisations = etree.Element("iati-organisations")
         self.iati_organisations.attrib['version'] = self.version
-        self.iati_organisations.attrib['generated-datetime'] = datetime.utcnow().\
-            isoformat("T", "seconds")
+
+        utc_now = utc_now or datetime.utcnow()
+        self.iati_organisations.attrib['generated-datetime'] = utc_now.isoformat("T", "seconds")
 
         for organisation in organisations:
             self.add_organisation(organisation)

--- a/akvo/rsr/management/commands/perform_iati_checks.py
+++ b/akvo/rsr/management/commands/perform_iati_checks.py
@@ -5,7 +5,11 @@
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
 
 from django.core.management.base import BaseCommand
-from akvo.rsr.usecases.iati_validation import run_iati_organisation_validation_job, run_iati_activity_validation_job
+
+from akvo.rsr.usecases.iati_validation import (
+    run_iati_activity_validations,
+    run_iati_organisation_validation_job,
+)
 
 
 class Command(BaseCommand):
@@ -14,4 +18,4 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # Additions/changes to organisation will occur less frequently so they are prioritized.
         run_iati_organisation_validation_job()
-        run_iati_activity_validation_job()
+        run_iati_activity_validations()

--- a/akvo/rsr/usecases/iati_validation/__init__.py
+++ b/akvo/rsr/usecases/iati_validation/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     'VALIDATOR_TIMEOUT',
     'VALIDATOR_MAX_ATTEMPTS',
     'validator',
+    'run_iati_activity_validations',
     'run_iati_activity_validation_job',
     'run_iati_organisation_validation_job',
 ]

--- a/akvo/rsr/usecases/iati_validation/iati_validation_job_runner.py
+++ b/akvo/rsr/usecases/iati_validation/iati_validation_job_runner.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 
 from abc import ABC, abstractmethod
@@ -14,12 +15,12 @@ from akvo.rsr.models.iati_validation_job import IatiValidationJobMixin
 logger = logging.getLogger(__name__)
 
 
-def get_iati_activity_xml_doc(project: Project) -> bytes:
-    return etree.tostring(etree.ElementTree(IatiXML([project]).iati_activities))
+def get_iati_activity_xml_doc(project: Project, utc_now: datetime.datetime) -> bytes:
+    return etree.tostring(etree.ElementTree(IatiXML([project], utc_now=utc_now).iati_activities))
 
 
-def get_iati_organisation_xml_doc(organisation: Organisation) -> bytes:
-    return etree.tostring(etree.ElementTree(IatiOrgXML([organisation]).iati_organisations))
+def get_iati_organisation_xml_doc(organisation: Organisation, utc_now: datetime.datetime) -> bytes:
+    return etree.tostring(etree.ElementTree(IatiOrgXML([organisation], utc_now=utc_now).iati_organisations))
 
 
 class IatiValidationJobRunner(ABC):
@@ -31,6 +32,10 @@ class IatiValidationJobRunner(ABC):
     @abstractmethod
     def get_xml_document(self) -> bytes:
         pass
+
+    @classmethod
+    def get_utc_now(cls) -> datetime.datetime:
+        return datetime.datetime.utcnow()
 
     def run(self) -> Optional[IATIValidationResult]:
         self.job.mark_started()
@@ -47,10 +52,10 @@ class IatiValidationJobRunner(ABC):
 class IatiActivityValidationJobRunner(IatiValidationJobRunner):
 
     def get_xml_document(self) -> bytes:
-        return get_iati_activity_xml_doc(self.job.project)
+        return get_iati_activity_xml_doc(self.job.project, self.get_utc_now())
 
 
 class IatiOrganisationValidationJobRunner(IatiValidationJobRunner):
 
     def get_xml_document(self) -> bytes:
-        return get_iati_organisation_xml_doc(self.job.organisation)
+        return get_iati_organisation_xml_doc(self.job.organisation, self.get_utc_now())

--- a/akvo/rsr/usecases/iati_validation/schedule_validation.py
+++ b/akvo/rsr/usecases/iati_validation/schedule_validation.py
@@ -2,16 +2,18 @@
 # Akvo RSR is covered by the GNU Affero General Public License.
 # See more details in the license.txt file located at the root folder of the Akvo RSR module.
 # For additional details on the GNU license please see < http://www.gnu.org/licenses/agpl.html >.
-
+import logging
 from datetime import datetime, timedelta
 from django.utils.timezone import now
 from akvo.rsr.models import Project, Organisation, IatiActivityValidationJob, IatiOrganisationValidationJob
 from typing import Optional
 
 DEFAULT_SCHEDULE_DELAY_TIME = timedelta(minutes=15)
+logger = logging.getLogger(__name__)
 
 
 def schedule_iati_activity_validation(project: Project, schedule_at: Optional[datetime] = None):
+    logger.info("Scheduling IATI validation for project %s", project.id)
     scheduled_at = schedule_at if schedule_at else now() + DEFAULT_SCHEDULE_DELAY_TIME
     pending_jobs = IatiActivityValidationJob.objects.filter(project=project, started_at=None)
     if pending_jobs.exists():

--- a/akvo/rsr/usecases/iati_validation/schedule_validation.py
+++ b/akvo/rsr/usecases/iati_validation/schedule_validation.py
@@ -25,7 +25,7 @@ def schedule_iati_activity_validation(project: Project, schedule_at: Optional[da
 
     # Ensure that even if the job for the external check doesn't run, that the internal one will
     project.run_iati_checks = True
-    project.save()
+    project.save(update_fields=["run_iati_checks"])
 
 
 def schedule_iati_organisation_validation(organisation: Organisation, schedule_at: Optional[datetime] = None):

--- a/akvo/rsr/usecases/iati_validation/schedule_validation.py
+++ b/akvo/rsr/usecases/iati_validation/schedule_validation.py
@@ -23,6 +23,10 @@ def schedule_iati_activity_validation(project: Project, schedule_at: Optional[da
     else:
         IatiActivityValidationJob.objects.create(project=project, scheduled_at=scheduled_at)
 
+    # Ensure that even if the job for the external check doesn't run, that the internal one will
+    project.run_iati_checks = True
+    project.save()
+
 
 def schedule_iati_organisation_validation(organisation: Organisation, schedule_at: Optional[datetime] = None):
     scheduled_at = schedule_at if schedule_at else now() + DEFAULT_SCHEDULE_DELAY_TIME


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Add log for when a check job is scheduled for a project
 - [x] Set `project.run_iati_checks = True` --> schedule internal check when an external check is being scheduled
 - [x] Run internal checks on all projects with `run_iati_checks=True` in `perform_iati_checks` command
 - [x] Stabilize tests ensure they use a fixed datetime when comparing IATI XML documents which have the `generated-date` field (it normally uses the current time with a second resolution --> off by a second means test fail)

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Unit tests
 - [x] Manual test

## Manual test

 - Modify a few existing projects
 - Ensure that their `run_iati_checks` is `True`
 - Run `./manage.py perform_iati_checks` and ensure that there are no projects with `run_iati_check = True`

Closes [#5096