### PR TITLE
[#5114] Fix import results set option not available in the editor

### DIFF
--- a/akvo/rsr/spa/app/modules/editor/project-init-handler.js
+++ b/akvo/rsr/spa/app/modules/editor/project-init-handler.js
@@ -95,20 +95,18 @@ const ProjectInitHandler = ({ match: { params }, editorRdr, ...props }) => {
 
     /**
      * As long as ID is numeric &&
-     * sectionIndex is less then number of sections &&
-     * first section is fetched then
+     * sectionIndex is less then number of sections
      * it will increment to move to the next section
      */
     if (
       !isNaN(params?.id) &&
-      (sectionIndex <= SECTION_COUNT) &&
-      editorRdr.section1.isFetched
+      (sectionIndex <= SECTION_COUNT)
     ) {
       if (sectionHasEndpoint.includes(sectionIndex)) {
         fetchNextSection(sectionIndex)
       }
 
-      if (sectionInstanceToRoot.includes(sectionIndex)) {
+      if (editorRdr.section1.isFetched && sectionInstanceToRoot.includes(sectionIndex)) {
         props.fetchSectionRoot(sectionIndex)
         props.setSectionFetched(sectionIndex)
       }

--- a/akvo/rsr/spa/app/modules/editor/section5/section5.jsx
+++ b/akvo/rsr/spa/app/modules/editor/section5/section5.jsx
@@ -236,7 +236,10 @@ const Section5 = (props) => {
         })
     }
   }, [])
-  const hasParent = props.relatedProjects && props.relatedProjects.filter(it => it.relation === '1').length > 0
+  const hasParent = (
+    (props.relatedProjects && props.relatedProjects.filter(it => it.relation === '1').length > 0) ||
+    (props?.program?.id)
+  )
   let selectedResultIndex = -1
   let selectedIndicatorIndex = -1
   let selectedPeriodIndex = -1


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Fix ```import results set``` option not available in the editor

# Manual test

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Pulling newer data from production.
 - [ ] Create results framework in project ID [10126](http://localhost/my-rsr/projects/10126/results-n-indicators) with import option.
 - [ ] Create a new child project in the second level of program ID [10123](http://localhost/my-rsr/programs/10123/hierarchy)
 
## Create a new child project in the second level of program ID

Once a new child project is created, do the following steps : 

1. Move to section 5 (results n indicators) * make sure we have 3 options.
2. Move to any section (still in the project editor).
3. Go to the Hierarchy tab
4. Go to another project.
5. Go to the Hierarchy tab
6. Go back to the previous project (a new child project).
7. Move to section 5 
8. The result framework should have been imported automatically.
