### PR TITLE
Prefer deploying RSR training envs on specific nodes

### DIFF
--- a/ci/training-envs/templates/deployment.yaml
+++ b/ci/training-envs/templates/deployment.yaml
@@ -17,6 +17,21 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         rsr-version: "{{ .Values.rsrVersion }}"
     spec:
+      tolerations:
+        - key: "akvo-app"
+          operator: "Equal"
+          value: "rsr"
+          effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: "akvo-app"
+                    operator: "In"
+                    values:
+                      - "rsr"
       containers:
       - name: rsr-nginx
         image: "eu.gcr.io/akvo-lumen/rsr-nginx:{{ .Values.rsrVersion }}"

--- a/ci/training-envs/values.yaml
+++ b/ci/training-envs/values.yaml
@@ -9,6 +9,21 @@ postgresql:
     tag: 20200413.153931.5f37d97
   postgresqlUsername: postgres
   master:
+    tolerations:
+      - key: "akvo-app"
+        operator: "Equal"
+        value: "rsr"
+        effect: "NoSchedule"
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: "akvo-app"
+                  operator: "In"
+                  values:
+                    - "rsr"
     extraVolumeMounts:
       - name: "secret-config"
         mountPath: "/akvo-lumen-service-account-credentials.json"


### PR DESCRIPTION
These nodes are reserved for RSR and should only host it. They are more powerful and are the same VM type as production.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Deploy to training env https://rsr1.akvotest.org
 