### PR TITLE
[#5167] Handle password-protected partner sites

### DIFF
--- a/akvo/rsr/dir/app/modules/index/view.jsx
+++ b/akvo/rsr/dir/app/modules/index/view.jsx
@@ -83,7 +83,10 @@ const View = () => {
         setFilters(defaults)
       }
     }
-  }, [apiData])
+    if (apiError && apiError.response && apiError.response.status === 403) {
+      window.location.href = '/en/lockpass/?next='
+    }
+  }, [apiData, apiError])
   useEffect(() => {
     document.getElementById('root').classList.add(window.location.host.split('.')[0])
   }, [])

--- a/akvo/rsr/dir/app/modules/index/view.jsx
+++ b/akvo/rsr/dir/app/modules/index/view.jsx
@@ -11,6 +11,7 @@ import Map, { projectsToFeatureData } from './map'
 import Search from './search'
 import FilterBar from './filter-bar'
 import api from '../../utils/api'
+import { isPartnerSites } from '../../utils/misc'
 
 const isLocal = window.location.href.indexOf('localhost') !== -1 || window.location.href.indexOf('localakvoapp') !== -1
 const urlPrefix = isLocal ? 'http://rsr.akvo.org' : ''
@@ -83,7 +84,7 @@ const View = () => {
         setFilters(defaults)
       }
     }
-    if (apiError && apiError.response && apiError.response.status === 403) {
+    if ((apiError && apiError.response && apiError.response.status === 403) && isPartnerSites()) {
       window.location.href = '/en/lockpass/?next='
     }
   }, [apiData, apiError])

--- a/akvo/rsr/dir/app/modules/project-page/ProjectPage.jsx
+++ b/akvo/rsr/dir/app/modules/project-page/ProjectPage.jsx
@@ -1,4 +1,4 @@
-/* global document */
+/* global window, document */
 import React, { useEffect, useState } from 'react'
 import { Menu } from 'antd'
 import { Switch, Route, useHistory } from 'react-router-dom'
@@ -84,6 +84,9 @@ const ProjectPage = ({ match: { params }, location }) => {
     }
     if ((loading && (apiError || projectError)) || (loading && user && !apiError)) {
       setLoading(false)
+      if (projectError && projectError.response && projectError.response.status === 403) {
+        window.location.href = `/en/lockpass/?next=${window.location.href}`
+      }
     }
     // eslint-disable-next-line no-restricted-globals
     if (!isNaN(currentPath) && menu !== HOME_KEY) {

--- a/akvo/rsr/dir/app/modules/project-page/ProjectPage.jsx
+++ b/akvo/rsr/dir/app/modules/project-page/ProjectPage.jsx
@@ -28,6 +28,7 @@ import {
   UPDATES_KEY,
   projectPath,
 } from '../../utils/config'
+import { isPartnerSites } from '../../utils/misc'
 
 
 const ProjectPage = ({ match: { params }, location }) => {
@@ -84,7 +85,7 @@ const ProjectPage = ({ match: { params }, location }) => {
     }
     if ((loading && (apiError || projectError)) || (loading && user && !apiError)) {
       setLoading(false)
-      if (projectError && projectError.response && projectError.response.status === 403) {
+      if ((projectError && projectError.response && projectError.response.status === 403) && isPartnerSites()) {
         window.location.href = `/en/lockpass/?next=${window.location.href}`
       }
     }

--- a/akvo/rsr/dir/app/root.jsx
+++ b/akvo/rsr/dir/app/root.jsx
@@ -8,12 +8,13 @@ import WcaroRouter from './modules/wcaro-index/router'
 import ProjectPage from './modules/project-page/ProjectPage'
 import scheduleDemo from './modules/schedule-demo'
 import { Home } from './modules/home'
+import { isPartnerSites } from './utils/misc'
 
 export default () => {
     const isUNEP = window.location.href.indexOf('//unep.') !== -1
     // eslint-disable-next-line no-unused-vars
     const isWcaro = window.location.href.indexOf('//wcaro.') !== -1
-    const isPartner = window.location.href.indexOf('localakvoapp') !== -1 || window.location.href.indexOf('akvoapp') !== -1
+    const isPartner = isPartnerSites()
     return (
         <Router basename="/">
             <Route path="/" exact component={isUNEP ? UnepIndex : isPartner ? Index : Home} />

--- a/akvo/rsr/dir/app/utils/misc.js
+++ b/akvo/rsr/dir/app/utils/misc.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-useless-escape */
+/* global window */
 import moment from 'moment'
 import chunk from 'lodash/chunk'
 import orderBy from 'lodash/orderBy'
@@ -99,3 +100,5 @@ export const getLogo = logo => logo
 export const getFirstPhoto = photos => (photos && photos.length)
   ? photos.slice(0, 1).pop()
   : null
+
+export const isPartnerSites = () => (window.location.href.indexOf('localakvoapp') !== -1 || window.location.href.indexOf('akvoapp') !== -1)

--- a/akvo/rsr/dir/app/utils/misc.js
+++ b/akvo/rsr/dir/app/utils/misc.js
@@ -101,4 +101,4 @@ export const getFirstPhoto = photos => (photos && photos.length)
   ? photos.slice(0, 1).pop()
   : null
 
-export const isPartnerSites = () => (window.location.href.indexOf('localakvoapp') !== -1 || window.location.href.indexOf('akvoapp') !== -1)
+export const isPartnerSites = () => (window.location.hostname.endsWith('localakvoapp.org') || window.location.hostname.endsWith('akvoapp.org'))

--- a/akvo/rsr/views/__init__.py
+++ b/akvo/rsr/views/__init__.py
@@ -17,6 +17,14 @@ def index(request):
 
 
 def lockpass(request):
+    """Endpoint to make the password-protected partner site useable for users.
+
+    This is a hack that utilizes the Django-lockdown mechanism to prompt the password page
+    for password-protected partner sites.
+
+    See: akvo.rsr.middleware.RSRLockdownMiddleware
+    """
+
     next_page = request.GET.get("next")
     return HttpResponseRedirect(
         next_page if next_page else reverse("project-directory", args=[])

--- a/akvo/rsr/views/__init__.py
+++ b/akvo/rsr/views/__init__.py
@@ -14,3 +14,10 @@ def index(request):
     """Redirect user to project directory or My RSR."""
 
     return HttpResponseRedirect(reverse('project-directory', args=[]))
+
+
+def lockpass(request):
+    next_page = request.GET.get("next")
+    return HttpResponseRedirect(
+        next_page if next_page else reverse("project-directory", args=[])
+    )

--- a/akvo/urls.py
+++ b/akvo/urls.py
@@ -46,6 +46,10 @@ urlpatterns = i18n_patterns(
     url(r'^$',
         views.index, name='index'),
 
+    # Hack to prompt password on password-protected partner sites
+    url(r'^lockpass/$',
+        views.lockpass, name='lockpass'),
+
     # Projects
     url(r'^projects/$',
         project.directory, name='project-directory'),


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Endpoint to show the Django-lockdown password page
 - [x] Handle password protection for project-directory (landing) page
 - [x] Handle password protection for public project page

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Test password-protected project directory page
 - [ ] Test password-protected public project page
 
---
Closes #5167 