### PR TITLE
[#5202]: Deploy master to production by default

### DIFF
--- a/ci/deploy-semaphoreci.sh
+++ b/ci/deploy-semaphoreci.sh
@@ -14,7 +14,6 @@ export PROJECT_NAME=akvo-lumen
 # master applies config in test
 # promote-* tags applies config in production
 if [[ "${CI_BRANCH}" != "master" ]] \
-    && [[ "${CI_BRANCH}" != "production" ]] \
     && [[ "${CI_BRANCH}" != rsr-env-* ]] \
     && [[ ! "${CI_TAG:-}" =~ promote-.* ]]
 then
@@ -52,7 +51,7 @@ else
 
 fi
 
-if [[ "${CI_BRANCH}" = rsr-env-* ]] || [[ "${CI_BRANCH}" = "production" ]]; then
+if [[ "${CI_BRANCH}" = rsr-env-* ]] ; then
     exit 0
 fi
 

--- a/ci/promote-test-to-prod.sh
+++ b/ci/promote-test-to-prod.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-DEPLOY_COMMITISH="${1:-production}"
+DEPLOY_COMMITISH="${1:-master}"
 git fetch --all
 
 echo "Running E2E tests"

--- a/doc/deploying.md
+++ b/doc/deploying.md
@@ -9,7 +9,7 @@ Deploying to https://rsr.akvotest.org is done automatically once a PR is merged 
 
 # Production
 
-Currently, we use the `production` branch to promote changes to master.
+Currently, we use the `master` branch to promote changes to production.
 This a **manual** operation.
 
 In order to deploy to [production](https://rsr.akvo.org), the docker image must exist in the docker registry.


### PR DESCRIPTION
This used to be production as there was a big feature being developed on master. Now that it's merged, master can continue to be deployed as usual.

# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Update documentation
 - [x] Set default deployment branch to `master` (from `production`)

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Execute script without pushing to github

Closes #5202