### PR TITLE
[#5199] Optimize /project/children endpoint

### DIFF
--- a/akvo/rsr/spa/app/modules/hierarchy/services.js
+++ b/akvo/rsr/spa/app/modules/hierarchy/services.js
@@ -1,13 +1,9 @@
 import api from '../../utils/api'
 import { getProjectUuids } from '../../utils/misc'
 
-export const getChildrenApi = async (id, page = 1) => {
-  const response = await api.get(`/project/${id}/children/?format=json&page=${page}`)
-  const { results, next } = response.data
-  if (next) {
-    return results?.concat(await getChildrenApi(id, page + 1))
-  }
-  return results
+export const getChildrenApi = async (id) => {
+  const response = await api.get(`/project/${id}/children/?format=json`)
+  return response.data
 }
 
 export const getProgramApi = (id, successCallback, errorCallback) => {

--- a/akvo/rsr/tests/rest/test_project_hierarchy.py
+++ b/akvo/rsr/tests/rest/test_project_hierarchy.py
@@ -88,23 +88,22 @@ class ProjectHierarchyTestCase(BaseTestCase):
         self.assertFalse(self.user.has_perm('rsr.view_project', self.p5))
         self.assertFalse(self.user.has_perm('rsr.view_project', self.p6))
 
-    def assertReturnsProjects(self, response, project_set):
-        results = response.data["results"]
-        self.assertEqual(len(project_set), response.data["count"])
+    def assertReturnsProjects(self, results, count, project_set):
+        self.assertEqual(len(project_set), count)
         self.assertEqual(project_set, {p['id'] for p in results})
         self.assertFalse(results[0]['editable'])
 
     def test_fetch_root_projects(self):
         response = self.c.get('/rest/v1/program/?format=json', follow=True)
-        self.assertReturnsProjects(response, {self.p1.id, self.p5.id})
+        self.assertReturnsProjects(response.data["results"], response.data["count"], {self.p1.id, self.p5.id})
 
     def test_get_program_children(self):
         response = self.c.get(f'/rest/v1/project/{self.p1.id}/children?format=json', follow=True)
-        self.assertReturnsProjects(response, {self.p2.id})
+        self.assertReturnsProjects(response.data, len(response.data), {self.p2.id})
 
     def test_get_project_children(self):
         response = self.c.get(f'/rest/v1/project/{self.p2.id}/children?format=json', follow=True)
-        self.assertReturnsProjects(response, {self.p3.id})
+        self.assertReturnsProjects(response.data, len(response.data), {self.p3.id})
 
 
 class RawProjectHierarchyTestCase(BaseTestCase):


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

## Counting children

This was slow because we made a query for each project. Now we get the children and grand children.
A simple dict with each project and a list of their children is then built in python.

**Side effect**

Paging doesn't work anymore as the queryset includes grand children. Reimplementing it can be done another time if we really do have projects with enormous hierarchies.

## Parent retrieval

We already know who the parent is since we're getting its children --> no need to make another query.

## Locations

We weren't retrieving related objects, which we now do. Additionally, we iterated over the list of countries twice when one iteration was enough.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Manual testing

After testing with the [Orange Knowledge Program](https://localhost/my-rsr/programs/7350/hierarchy), the request took 3s to load everything instead of 22-30s previously.

Closes #5199