### PR TITLE
[#5212] Fix reports period.actual_value for cumulative indicators

### DIFF
--- a/akvo/rest/views/indicator_period_aggregation_job.py
+++ b/akvo/rest/views/indicator_period_aggregation_job.py
@@ -14,7 +14,7 @@ from ..filters import RSRGenericFilterBackend
 
 from ..serializers import IndicatorPeriodAggregationJobSerializer
 from ..viewsets import ReadOnlyPublicProjectViewSet, SafeMethodsPermissions
-from ...rsr.usecases.jobs.aggregation import schedule_aggregation_job
+from ...rsr.usecases.jobs.aggregation import schedule_aggregation_jobs
 
 
 class IndicatorPeriodAggregationJobViewSet(ReadOnlyPublicProjectViewSet):
@@ -41,7 +41,7 @@ class IndicatorPeriodAggregationJobViewSet(ReadOnlyPublicProjectViewSet):
         if job.status != IndicatorPeriodAggregationJob.Status.MAXXED:
             raise ValidationError("Maximum number of attempts not reached")
 
-        new_jobs = schedule_aggregation_job(job.period)
+        new_jobs = schedule_aggregation_jobs(job.period)
         serializer = self.get_serializer(new_jobs, many=True)
 
         return Response(serializer.data)

--- a/akvo/rest/views/indicator_period_aggregation_job.py
+++ b/akvo/rest/views/indicator_period_aggregation_job.py
@@ -41,7 +41,7 @@ class IndicatorPeriodAggregationJobViewSet(ReadOnlyPublicProjectViewSet):
         if job.status != IndicatorPeriodAggregationJob.Status.MAXXED:
             raise ValidationError("Maximum number of attempts not reached")
 
-        new_job = schedule_aggregation_job(job.period)
-        serializer = self.get_serializer(new_job)
+        new_jobs = schedule_aggregation_job(job.period)
+        serializer = self.get_serializer(new_jobs, many=True)
 
         return Response(serializer.data)

--- a/akvo/rsr/management/commands/recalculate_project_aggregation.py
+++ b/akvo/rsr/management/commands/recalculate_project_aggregation.py
@@ -2,14 +2,16 @@ from django.core.management.base import BaseCommand
 from django.db.models import Count, Q
 
 from akvo.rsr.models import Project, IndicatorPeriod, IndicatorPeriodData
+from akvo.rsr.models.result.utils import QUANTITATIVE
 from akvo.rsr.usecases.jobs.aggregation import schedule_aggregation_job
 
 
 class Command(BaseCommand):
-    help = 'Script for recalculating periods aggregation of a project'
+    help = 'Script for recalculating periods aggregation of a project. By default will only apply to periods that have approved updates.'
 
     def add_arguments(self, parser):
-        parser.add_argument('--no-filter', action='store_true')
+        parser.add_argument('--all', action='store_true', help="Apply to all periods including periods with no approved updates")
+        parser.add_argument('--quantitative', action='store_true', help="Apply to quantitative indicator periods only. Will be ignored if --all is used")
         parser.add_argument('project_id', type=int)
 
     def handle(self, *args, **options):
@@ -21,12 +23,16 @@ class Command(BaseCommand):
 
         descendants = project.descendants()
         periods = IndicatorPeriod.objects.filter(indicator__result__project__in=descendants)
-        if options.get("no_filter") is None:
+        if not options.get("all"):
             periods = periods.annotate(
                 approved_count=Count('data', filter=Q(data__status=IndicatorPeriodData.STATUS_APPROVED_CODE))
             ).filter(approved_count__gte=1)
+            if options.get("quantitative"):
+                periods = periods.filter(indicator__type=QUANTITATIVE)
 
+        jobs = set()
         for period in periods:
-            schedule_aggregation_job(period)
+            new_jobs = schedule_aggregation_job(period)
+            jobs = jobs.union(set(new_jobs))
 
-        print(f"Scheduled period aggregation jobs: {periods.count()}, on project: {project.title}")
+        print(f"Scheduled period aggregation jobs: {len(jobs)}, on root project: {project.title}")

--- a/akvo/rsr/management/commands/recalculate_project_aggregation.py
+++ b/akvo/rsr/management/commands/recalculate_project_aggregation.py
@@ -3,7 +3,7 @@ from django.db.models import Count, Q
 
 from akvo.rsr.models import Project, IndicatorPeriod, IndicatorPeriodData
 from akvo.rsr.models.result.utils import QUANTITATIVE
-from akvo.rsr.usecases.jobs.aggregation import schedule_aggregation_job
+from akvo.rsr.usecases.jobs.aggregation import schedule_aggregation_jobs
 
 
 class Command(BaseCommand):
@@ -32,7 +32,7 @@ class Command(BaseCommand):
 
         jobs = set()
         for period in periods:
-            new_jobs = schedule_aggregation_job(period)
+            new_jobs = schedule_aggregation_jobs(period)
             jobs = jobs.union(set(new_jobs))
 
         print(f"Scheduled period aggregation jobs: {len(jobs)}, on root project: {project.title}")

--- a/akvo/rsr/models/result/disaggregation.py
+++ b/akvo/rsr/models/result/disaggregation.py
@@ -9,7 +9,7 @@ from .indicator_period_data import IndicatorPeriodData
 from akvo.rsr.fields import ValidXMLTextField
 from akvo.rsr.mixins import TimestampsMixin, IndicatorUpdateMixin
 from akvo.rsr.models.result.utils import PERCENTAGE_MEASURE, QUALITATIVE
-from akvo.rsr.usecases.jobs.aggregation import schedule_aggregation_job
+from akvo.rsr.usecases.jobs.aggregation import schedule_aggregation_jobs
 
 from django.db import models
 from django.db.models import signals
@@ -73,14 +73,14 @@ class Disaggregation(TimestampsMixin, IndicatorUpdateMixin, models.Model):
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         if self.update.status == IndicatorPeriodData.STATUS_APPROVED_CODE:
-            schedule_aggregation_job(self.update.period)
+            schedule_aggregation_jobs(self.update.period)
 
     def delete(self, *args, **kwargs):
         old_status = self.update.status
         period = self.update.period
         super().delete(*args, **kwargs)
         if old_status == IndicatorPeriodData.STATUS_APPROVED_CODE:
-            schedule_aggregation_job(period)
+            schedule_aggregation_jobs(period)
 
 
 @receiver(signals.post_save, sender=Disaggregation)

--- a/akvo/rsr/models/result/indicator_period_data.py
+++ b/akvo/rsr/models/result/indicator_period_data.py
@@ -20,7 +20,7 @@ from .utils import (calculate_percentage, file_path, image_path,
                     QUANTITATIVE)
 from akvo.rsr.fields import ValidXMLCharField, ValidXMLTextField
 from akvo.rsr.mixins import TimestampsMixin, IndicatorUpdateMixin
-from akvo.rsr.usecases.jobs.aggregation import schedule_aggregation_job
+from akvo.rsr.usecases.jobs.aggregation import schedule_aggregation_jobs
 from akvo.utils import rsr_image_path
 
 
@@ -101,7 +101,7 @@ class IndicatorPeriodData(TimestampsMixin, IndicatorUpdateMixin, models.Model):
         # In case the status is approved, recalculate the period
         if recalculate and self.status == self.STATUS_APPROVED_CODE:
             # FIXME: Should we call this even when status is not approved?
-            schedule_aggregation_job(self.period)
+            schedule_aggregation_jobs(self.period)
             self.period.update_actual_comment()
         # Update score even when the update is not approved, yet. It handles the
         # case where an approved update is returned for revision, etc.
@@ -115,7 +115,7 @@ class IndicatorPeriodData(TimestampsMixin, IndicatorUpdateMixin, models.Model):
 
         # In case the status was approved, recalculate the period
         if old_status == self.STATUS_APPROVED_CODE:
-            schedule_aggregation_job(period)
+            schedule_aggregation_jobs(period)
             self.period.update_actual_comment()
             self.period.update_score()
 

--- a/akvo/rsr/tests/rest/jobs/test_indicator_period_aggregation.py
+++ b/akvo/rsr/tests/rest/jobs/test_indicator_period_aggregation.py
@@ -14,7 +14,7 @@ from akvo.rsr.models import IndicatorPeriodAggregationJob
 from akvo.rsr.permissions import GROUP_NAME_ME_MANAGERS
 from akvo.rsr.tests.base import BaseTestCase
 from akvo.rsr.tests.usecases.jobs.test_aggregation import AggregationJobBaseTests
-from akvo.rsr.usecases.jobs.aggregation import schedule_aggregation_job
+from akvo.rsr.usecases.jobs.aggregation import schedule_aggregation_jobs
 
 
 class AnonymousUserTestCase(BaseTestCase):
@@ -42,7 +42,7 @@ class EndpointTestCase(AggregationJobBaseTests):
         self.private_result = self.result.child_results.first()
         self.private_indicator = self.indicator.child_indicators.first()
         self.private_period = self.period.child_periods.first()
-        self.private_job = schedule_aggregation_job(self.private_period)[0]
+        self.private_job = schedule_aggregation_jobs(self.private_period)[0]
 
         # Create private project in another org
         self.other_private_user = self.create_user("other_private@akvo.org", "password", is_superuser=False)
@@ -51,7 +51,7 @@ class EndpointTestCase(AggregationJobBaseTests):
 
         self.other_private_result, self.other_private_indicator, self.other_private_period = \
             self._make_results_framework(self.other_private_project)
-        self.other_private_job = schedule_aggregation_job(self.other_private_period)[0]
+        self.other_private_job = schedule_aggregation_jobs(self.other_private_period)[0]
 
     def test_super_user(self):
         """Super users should be able to access all jobs"""

--- a/akvo/rsr/tests/rest/jobs/test_indicator_period_aggregation.py
+++ b/akvo/rsr/tests/rest/jobs/test_indicator_period_aggregation.py
@@ -42,7 +42,7 @@ class EndpointTestCase(AggregationJobBaseTests):
         self.private_result = self.result.child_results.first()
         self.private_indicator = self.indicator.child_indicators.first()
         self.private_period = self.period.child_periods.first()
-        self.private_job = schedule_aggregation_job(self.private_period)
+        self.private_job = schedule_aggregation_job(self.private_period)[0]
 
         # Create private project in another org
         self.other_private_user = self.create_user("other_private@akvo.org", "password", is_superuser=False)
@@ -51,7 +51,7 @@ class EndpointTestCase(AggregationJobBaseTests):
 
         self.other_private_result, self.other_private_indicator, self.other_private_period = \
             self._make_results_framework(self.other_private_project)
-        self.other_private_job = schedule_aggregation_job(self.other_private_period)
+        self.other_private_job = schedule_aggregation_job(self.other_private_period)[0]
 
     def test_super_user(self):
         """Super users should be able to access all jobs"""
@@ -141,7 +141,7 @@ class EndpointTestCase(AggregationJobBaseTests):
         self.assertEqual(response.status_code, HTTP_200_OK)
 
         data = response.json()
-        self.assertNotEqual(data["id"], self.private_job.id)
+        self.assertNotEqual(data[0]["id"], self.private_job.id)
 
         self.assertEqual(
             IndicatorPeriodAggregationJob.objects.filter(period=self.private_period).count(),

--- a/akvo/rsr/tests/results_framework/test_cumulative_updates.py
+++ b/akvo/rsr/tests/results_framework/test_cumulative_updates.py
@@ -57,7 +57,6 @@ class SingleUserCumulativeUnitUpdatesTestCase(CumulativeTestMixin, BaseTestCase)
                 self.DISAGGREGATION_TYPE_2: {'value': 1},
             }
         })
-        aggregate(self.period1.object)
 
         self.period2 = self.project.get_period(period_start=self.PERIOD_2_START)
         self.period2.add_update(user=user, value=3, disaggregations={
@@ -72,10 +71,12 @@ class SingleUserCumulativeUnitUpdatesTestCase(CumulativeTestMixin, BaseTestCase)
                 self.DISAGGREGATION_TYPE_2: {'value': 2},
             }
         })
-        aggregate(self.period2.object)
 
         self.period3 = self.project.get_period(period_start=self.PERIOD_3_START)
+        # The execution order of the aggregate function doesn't matters
         aggregate(self.period3.object)
+        aggregate(self.period1.object)
+        aggregate(self.period2.object)
 
     def test_period1(self):
         period1 = self.project.periods.get(id=self.period1.id)

--- a/akvo/rsr/tests/results_framework/test_cumulative_updates.py
+++ b/akvo/rsr/tests/results_framework/test_cumulative_updates.py
@@ -9,6 +9,7 @@ from akvo.rsr.usecases.period_update_aggregation import aggregate
 class CumulativeTestMixin:
     PERIOD_1_START = date(2020, 1, 1)
     PERIOD_2_START = date(2021, 1, 1)
+    PERIOD_3_START = date(2022, 1, 1)
     DISAGGREGATION_CATEGORY = 'Gender'
     DISAGGREGATION_TYPE_1 = 'Male'
     DISAGGREGATION_TYPE_2 = 'Female'
@@ -27,7 +28,8 @@ class CumulativeTestMixin:
                 'cumulative': True,
                 'periods': [
                     {'period_start': self.PERIOD_1_START, 'period_end': date(2020, 12, 31)},
-                    {'period_start': self.PERIOD_2_START, 'period_end': date(2021, 12, 31)}
+                    {'period_start': self.PERIOD_2_START, 'period_end': date(2021, 12, 31)},
+                    {'period_start': self.PERIOD_3_START, 'period_end': date(2022, 12, 31)},
                 ]
             }]
         }])
@@ -72,6 +74,9 @@ class SingleUserCumulativeUnitUpdatesTestCase(CumulativeTestMixin, BaseTestCase)
         })
         aggregate(self.period2.object)
 
+        self.period3 = self.project.get_period(period_start=self.PERIOD_3_START)
+        aggregate(self.period3.object)
+
     def test_period1(self):
         period1 = self.project.periods.get(id=self.period1.id)
         self.assertEqual(2, Decimal(period1.actual_value))
@@ -83,6 +88,13 @@ class SingleUserCumulativeUnitUpdatesTestCase(CumulativeTestMixin, BaseTestCase)
         self.assertEqual(5, Decimal(period2.actual_value))
         self.assertEqual(3, period2.disaggregations.get(dimension_value__value=self.DISAGGREGATION_TYPE_1).value)
         self.assertEqual(2, period2.disaggregations.get(dimension_value__value=self.DISAGGREGATION_TYPE_2).value)
+
+    def test_period_without_updates(self):
+        """
+        A cumulative indicator in a new period should carry over the value from the last period
+        """
+        period3 = self.project.periods.get(id=self.period3.id)
+        self.assertEqual(5, Decimal(period3.actual_value))
 
 
 class MultiUserCumulativeUnitUpdatesTestCase(CumulativeTestMixin, BaseTestCase):

--- a/akvo/rsr/tests/results_framework/test_cumulative_updates.py
+++ b/akvo/rsr/tests/results_framework/test_cumulative_updates.py
@@ -73,7 +73,7 @@ class SingleUserCumulativeUnitUpdatesTestCase(CumulativeTestMixin, BaseTestCase)
         })
 
         self.period3 = self.project.get_period(period_start=self.PERIOD_3_START)
-        # The execution order of the aggregate function doesn't matters
+        # The execution order of the aggregate function doesn't matter
         aggregate(self.period3.object)
         aggregate(self.period1.object)
         aggregate(self.period2.object)

--- a/akvo/rsr/tests/usecases/jobs/test_aggregation.py
+++ b/akvo/rsr/tests/usecases/jobs/test_aggregation.py
@@ -123,7 +123,7 @@ class AggregationJobScheduling(AggregationJobBaseTests):
     def test_no_existing_job(self):
         """Without an existing job, a new one should be created"""
         self.job.delete()
-        new_jobs = usecases.schedule_aggregation_job(self.period)
+        new_jobs = usecases.schedule_aggregation_jobs(self.period)
 
         scheduled_jobs = usecases.get_scheduled_jobs()
         self.assertEqual(scheduled_jobs.count(), 1)
@@ -131,7 +131,7 @@ class AggregationJobScheduling(AggregationJobBaseTests):
 
     def test_existing_period_job(self):
         """If a job is already scheduled, it should only be updated"""
-        jobs = usecases.schedule_aggregation_job(self.period)
+        jobs = usecases.schedule_aggregation_jobs(self.period)
 
         scheduled_jobs = usecases.get_scheduled_jobs()
         self.assertEqual(scheduled_jobs.count(), 1)
@@ -156,7 +156,7 @@ class JobSchedullingOnCumulativeIndicator(AggregationJobBaseTests):
     def test_no_existing_job(self):
         """Should create jobs for the given period and subsequent periods"""
         self.job.delete()
-        usecases.schedule_aggregation_job(self.period)
+        usecases.schedule_aggregation_jobs(self.period)
 
         scheduled_jobs = usecases.get_scheduled_jobs()
         self.assertEqual(scheduled_jobs.count(), 2)
@@ -164,7 +164,7 @@ class JobSchedullingOnCumulativeIndicator(AggregationJobBaseTests):
 
     def test_existing_period_job(self):
         """Should only create jobs for periods that don't have it yet"""
-        usecases.schedule_aggregation_job(self.period)
+        usecases.schedule_aggregation_jobs(self.period)
 
         scheduled_jobs = usecases.get_scheduled_jobs()
         self.assertEqual(scheduled_jobs.count(), 2)

--- a/akvo/rsr/tests/usecases/jobs/test_aggregation.py
+++ b/akvo/rsr/tests/usecases/jobs/test_aggregation.py
@@ -123,21 +123,54 @@ class AggregationJobScheduling(AggregationJobBaseTests):
     def test_no_existing_job(self):
         """Without an existing job, a new one should be created"""
         self.job.delete()
-        new_job = usecases.schedule_aggregation_job(self.period)
+        new_jobs = usecases.schedule_aggregation_job(self.period)
 
         scheduled_jobs = usecases.get_scheduled_jobs()
         self.assertEqual(scheduled_jobs.count(), 1)
-        self.assertEqual(scheduled_jobs.first(), new_job)
+        self.assertEqual(scheduled_jobs.first(), new_jobs[0])
 
     def test_existing_period_job(self):
         """If a job is already scheduled, it should only be updated"""
-        job = usecases.schedule_aggregation_job(self.period)
+        jobs = usecases.schedule_aggregation_job(self.period)
 
         scheduled_jobs = usecases.get_scheduled_jobs()
         self.assertEqual(scheduled_jobs.count(), 1)
-        self.assertEqual(scheduled_jobs.first(), job)
-        self.assertEqual(self.job, job)
-        self.assertNotEqual(self.job.updated_at, job.updated_at)
+        self.assertEqual(scheduled_jobs.first(), jobs[0])
+        self.assertEqual(self.job, jobs[0])
+        self.assertNotEqual(self.job.updated_at, jobs[0].updated_at)
+
+
+class JobSchedullingOnCumulativeIndicator(AggregationJobBaseTests):
+    def setUp(self):
+        super().setUp()
+        self.indicator.cumulative = True
+        self.indicator.save()
+
+        self.period2 = IndicatorPeriod.objects.create(
+            indicator=self.indicator,
+            period_start=datetime.date.today() + datetime.timedelta(days=2),
+            period_end=datetime.date.today() + datetime.timedelta(days=3),
+            target_value=120
+        )
+
+    def test_no_existing_job(self):
+        """Should create jobs for the given period and subsequent periods"""
+        self.job.delete()
+        usecases.schedule_aggregation_job(self.period)
+
+        scheduled_jobs = usecases.get_scheduled_jobs()
+        self.assertEqual(scheduled_jobs.count(), 2)
+        self.assertEqual([j.period for j in scheduled_jobs], [self.period, self.period2])
+
+    def test_existing_period_job(self):
+        """Should only create jobs for periods that don't have it yet"""
+        usecases.schedule_aggregation_job(self.period)
+
+        scheduled_jobs = usecases.get_scheduled_jobs()
+        self.assertEqual(scheduled_jobs.count(), 2)
+        self.assertEqual([j.period for j in scheduled_jobs], [self.period, self.period2])
+        existing_job = next(j for j in scheduled_jobs if j == self.job)
+        self.assertNotEqual(self.job.updated_at, existing_job.updated_at)
 
 
 class FailDeadJobTest(AggregationJobBaseTests):

--- a/akvo/rsr/usecases/jobs/aggregation.py
+++ b/akvo/rsr/usecases/jobs/aggregation.py
@@ -42,18 +42,21 @@ def get_finished_jobs() -> QuerySet[IndicatorPeriodAggregationJob]:
 
 
 def base_get_jobs() -> QuerySet[IndicatorPeriodAggregationJob]:
+    # TODO: sort by creation date ascending order
     return IndicatorPeriodAggregationJob.objects.select_related("period__indicator")
 
 
-def schedule_aggregation_job(period: IndicatorPeriod) -> IndicatorPeriodAggregationJob:
+def schedule_aggregation_job(period: IndicatorPeriod) -> List[IndicatorPeriodAggregationJob]:
     """
     Schedule a job for the period to be aggregated upwards if no job exists
     """
     logger.info("Scheduling indicator aggregation job for %s: %s", period, period.indicator.title)
+    # TODO: Get future periods if indicator is cumulative
     if existing_job := get_scheduled_jobs().filter(period=period).first():
         existing_job.save()
         return existing_job
 
+    # TODO: Create jobs for each future period in ascending order
     root_period = period.get_root_period()
     return IndicatorPeriodAggregationJob.objects.create(period=period, root_period=root_period)
 

--- a/akvo/rsr/usecases/jobs/aggregation.py
+++ b/akvo/rsr/usecases/jobs/aggregation.py
@@ -63,8 +63,15 @@ def execute_aggregation_jobs():
     Call the aggregation function for each aggregation job
     """
     handle_failed_jobs()
-
+    logger.info("Started with %s jobs", get_scheduled_jobs().count())
     while (scheduled_job := get_scheduled_jobs().first()):
+        logger.info(
+            "Running job %s for period '%s - %s' and indicator: %s",
+            scheduled_job.id,
+            scheduled_job.period.period_start,
+            scheduled_job.period.period_end,
+            scheduled_job.period.indicator,
+        )
         scheduled_job.mark_running()
         try:
             run_aggregation(scheduled_job.period)

--- a/akvo/rsr/usecases/jobs/aggregation.py
+++ b/akvo/rsr/usecases/jobs/aggregation.py
@@ -45,7 +45,7 @@ def base_get_jobs() -> QuerySet[IndicatorPeriodAggregationJob]:
     return IndicatorPeriodAggregationJob.objects.select_related("period__indicator").order_by("id")
 
 
-def schedule_aggregation_job(period: IndicatorPeriod) -> List[IndicatorPeriodAggregationJob]:
+def schedule_aggregation_jobs(period: IndicatorPeriod) -> List[IndicatorPeriodAggregationJob]:
     """
     Schedule a job for the period to be aggregated upwards if no job exists
     """
@@ -66,7 +66,7 @@ def schedule_aggregation_job(period: IndicatorPeriod) -> List[IndicatorPeriodAgg
 
 def _get_affected_periods(period: IndicatorPeriod) -> QuerySet[IndicatorPeriod]:
     """
-    For cumulative indicators, subsequent periods needs to be calculated in advance to reflect the carried-over values.
+    For cumulative indicators, subsequent periods need to be calculated in advance to reflect the carried-over values.
     This approach has the least amount of generated jobs compared to the other approaches we found. The compromise
     of this approach is that when visualizing data, it is necessary to add logic to hide values of future periods so
     as not to cause confusion to users.


### PR DESCRIPTION
# Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Handle cumulative indicator carried-over values aggregation jobs
 - [x] Add filtering args on the `recalculate_project_aggregations` command to limit generated jobs


# TODO on separate PR(s)

 - [ ] Hide carried-over values for future periods on the reports
 - [ ] Hide carried-over values for future periods on the frontend


# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Manual test
 - [x] unit test


Related to #5212