### PR TITLE
Fix Feature/4680 readiness and liveliness probe for k8s

### DIFF
--- a/ci/k8s/deployment.yml
+++ b/ci/k8s/deployment.yml
@@ -206,12 +206,10 @@ spec:
         name: worker
         readinessProbe:
           exec:
-            command:
-              - "./manage.py probe_django_q"
+            command: ["./manage.py", "probe_django_q"]
         livenessProbe:
           exec:
-            command:
-              - "./manage.py probe_django_q"
+            command: ["./manage.py", "probe_django_q"]
           initialDelaySeconds: 30
           periodSeconds: 10
         resources:

--- a/scripts/docker/dev/start-django.sh
+++ b/scripts/docker/dev/start-django.sh
@@ -4,7 +4,7 @@ set -eu
 
 ./scripts/docker/dev/wait-for-dependencies.sh
 
-if [ -z "${IS_REPORTS_CONTAINER:-}" ]; then
+if [ -z "${IS_REPORTS_CONTAINER:-}" ] && [[ -z "${IS_WORKER:-}" ]] ; then
   pushd akvo/rsr/front-end
     if [[ ! -d "node_modules" ]]; then
       npm install

--- a/scripts/docker/prod/start-django.sh
+++ b/scripts/docker/prod/start-django.sh
@@ -17,12 +17,12 @@ if [ ! -z "${WAIT_FOR_DEPENDENCIES:-}" ]; then
     ./wait-for-dependencies.sh
 fi
 
-if [ -z "${IS_REPORTS_CONTAINER:-}" ]; then
+if [ -z "${IS_REPORTS_CONTAINER:-}" ] && [[ -z "${IS_WORKER:-}" ]] ; then
   log Migrating
   SKIP_REQUIRED_AUTH_GROUPS=true python manage.py migrate --noinput
 fi
 
-if [ -z "${IS_REPORTS_CONTAINER:-}" ]; then
+if [ -z "${IS_REPORTS_CONTAINER:-}" ] && [[ -z "${IS_WORKER:-}" ]] ; then
   log Adding to crontab
   python manage.py crontab add
   log Making all environment vars available to cron jobs


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Fix command to check readiness and liveliness
 - [x] Clean up `start-django.sh` for prod and dev - only exec necessary processes in worker container

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Start up docker locally


Related to #4680