### PR TITLE
[#5239] Fix bug cumulative indicator sum up values

### DIFF
--- a/akvo/rsr/spa/app/components/ProgressBar.jsx
+++ b/akvo/rsr/spa/app/components/ProgressBar.jsx
@@ -1,12 +1,19 @@
 import React from 'react'
 import classNames from 'classnames'
+import { groupBy, sumBy } from 'lodash'
 import { Tooltip } from 'antd'
 import { useTranslation } from 'react-i18next'
 import { setNumberFormat } from '../utils/misc'
 
 import './ProgressBar.scss'
 
-const ProgressBar = ({ period, values, valueRef, onlyApproved = false }) => {
+const ProgressBar = ({
+  period,
+  values,
+  valueRef,
+  cumulative = false,
+  onlyApproved = false,
+}) => {
   const { t } = useTranslation()
 
   const handleOnClick = (index) => () => {
@@ -16,13 +23,19 @@ const ProgressBar = ({ period, values, valueRef, onlyApproved = false }) => {
   const perc = period.targetValue > 0
     ? Math.round((values.filter(it => it.status === 'A').reduce((a, v) => a + v.value, 0) / period.targetValue) * 100 * 10) / 10
     : 0
-  const valuesTotal = values.filter(it => it.status !== 'P').reduce((acc, val) => acc + val.value, 0)
+  const totalValue = values
+    .filter(it => ((onlyApproved && it.status === 'A') || (it.status !== 'P')))
+    .reduce((acc, val) => acc + val.value, 0)
+  const userUpdates = groupBy(values, 'userDetails.id')
+  const cumulativeUpdates = Object.keys(userUpdates)?.map((userID) => userUpdates[userID]?.shift())
+  const actualValue = cumulative ? sumBy(cumulativeUpdates, 'value') : sumBy(values, 'value')
+  const updateItems = cumulative ? cumulativeUpdates : values
   return (
     <div id="progressBar">
       <div className="labels">
         <div className="value-label actual">
           <div className="label">{t('Actual value')}</div>
-          <div className="value">{setNumberFormat(values.filter(it => it.status === 'A').reduce((acc, v) => acc + v.value, 0))}</div>
+          <div className="value">{setNumberFormat(actualValue)}</div>
         </div>
         {period.targetValue > 0 && (
           <div className="value-label target">
@@ -33,10 +46,10 @@ const ProgressBar = ({ period, values, valueRef, onlyApproved = false }) => {
           </div>
         )}
       </div>
-      <div className="bar">
+      <div className={classNames('bar', { cumulative })}>
         {
-          values
-            .sort((a, b) => { if (b.status === 'D' && a.status !== 'D') return -1; return 0; })
+          updateItems
+            .sort((a, b) => { if (b.status === 'D' && a.status !== 'D') return -1; return 0 })
             .filter((value) => ((onlyApproved && value.status === 'A') || !onlyApproved))
             .map((value, index) => {
               let barProps = {
@@ -46,7 +59,7 @@ const ProgressBar = ({ period, values, valueRef, onlyApproved = false }) => {
                 }),
                 tabIndex: '-1',
                 style: {
-                  flex: period.targetValue > 0 ? value.value / period.targetValue : value.value / valuesTotal
+                  flex: period.targetValue > 0 ? value.value / period.targetValue : value.value / totalValue
                 }
               }
               if (valueRef) {
@@ -57,7 +70,7 @@ const ProgressBar = ({ period, values, valueRef, onlyApproved = false }) => {
                 }
               }
               return (
-                <Tooltip title={String(value.value).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}>
+                <Tooltip title={setNumberFormat(value.value)}>
                   <div {...barProps}>
                     {
                       (

--- a/akvo/rsr/spa/app/components/ProgressBar.scss
+++ b/akvo/rsr/spa/app/components/ProgressBar.scss
@@ -79,5 +79,8 @@
       position: absolute;
       right: 5px;
     }
+    &.cumulative {
+      display: none;
+    }
   }
 }

--- a/akvo/rsr/spa/app/modules/results-admin/components/ReportedForm.jsx
+++ b/akvo/rsr/spa/app/modules/results-admin/components/ReportedForm.jsx
@@ -238,7 +238,18 @@ const ReportedForm = ({
                       disaggregations = dgs.map((dg, dgx) => ({ ...dg, typeId: disaggregations[dgx]?.typeId }))
                     }
                     const valueUpdates = periodUpdates.map(it => ({ value: it.value, status: it.status }))
-                    return <DsgOverview {...{ disaggregations, targets: period.disaggregationTargets, period, editPeriod: (props) => { editPeriod(props, indicator) }, values: valueUpdates }} />
+                    return (
+                      <DsgOverview
+                        {...{
+                          disaggregations,
+                          period,
+                          cumulative: indicator?.isCumulative,
+                          targets: period.disaggregationTargets,
+                          editPeriod: (props) => { editPeriod(props, indicator) },
+                          values: valueUpdates,
+                        }}
+                      />
+                    )
                   }}
                 </FormSpy>
               ) :

--- a/akvo/rsr/spa/app/modules/results-overview/components/UpdateItems.jsx
+++ b/akvo/rsr/spa/app/modules/results-overview/components/UpdateItems.jsx
@@ -65,15 +65,18 @@ const UpdateItems = ({
   const updatesListRef = useRef()
   const isPeriod = (targetsAt === 'period' && indicator.type === 1)
   const colSpan = isPeriod ? { left: 8, right: 16 } : { left: 24, right: 24 }
-  const approved = period?.updates?.filter((u) => u.status === 'A')
-  let data = orderBy(approved?.map(u => ({
-    label: u.createdAt ? moment(u.createdAt, 'YYYY-MM-DD').format('DD-MM-YYYY') : null,
-    unix: u.createdAt ? moment(u.createdAt, 'YYYY-MM-DD').unix() : null,
-    y: u.value
-  })), ['unix'], ['asc'])
-  data = approved.length === 1
-    ? [{ y: 0, label: null }, ...data].map((u, index) => ({ ...u, x: index }))
-    : data.map((u, index) => ({ ...u, x: index }))
+  const approved = period
+    ?.updates
+    ?.filter((u) => u.status === 'A')
+    ?.map((u) => ({
+      ...u,
+      label: u.createdAt ? moment(u.createdAt, 'YYYY-MM-DD').format('DD-MM-YYYY') : null,
+      y: u.value,
+    }))
+    ?.sort((a, b) => a?.id - b?.id)
+  const data = approved.length === 1
+    ? [{ y: 0, label: null }, ...approved].map((u, index) => ({ ...u, x: index }))
+    : approved.map((u, index) => ({ ...u, x: index }))
   return (
     <Row type="flex" align="top">
       <Col lg={colSpan.left} xs={24}>
@@ -81,7 +84,12 @@ const UpdateItems = ({
           (isPeriod && period.updates.length > 0) && (
             <Card bordered={false} className="periodCard">
               <Card.Grid hoverable={false} style={{ width: '100%' }}>
-                <ProgressBar period={period} values={period.updates} onlyApproved />
+                <ProgressBar
+                  period={period}
+                  values={period.updates}
+                  cumulative={indicator?.isCumulative}
+                  onlyApproved
+                />
               </Card.Grid>
               {
                 (data.length > 0 && indicator?.measure === measureType.UNIT) && (

--- a/akvo/rsr/spa/app/modules/results/dsg-overview.jsx
+++ b/akvo/rsr/spa/app/modules/results/dsg-overview.jsx
@@ -34,7 +34,15 @@ const TargetValue = ({ targetValue, size = 'default', onUpdate }) => {
   ]
 }
 
-const DsgOverview = ({ disaggregations, targets, period, values = [], updatesListRef, editPeriod}) => {
+const DsgOverview = ({
+  disaggregations,
+  targets,
+  period,
+  updatesListRef,
+  editPeriod,
+  cumulative = false,
+  values = [],
+}) => {
   const { t } = useTranslation()
   const dsgGroups = {}
   disaggregations.filter(it => it.value > 0).forEach(item => {
@@ -63,7 +71,12 @@ const DsgOverview = ({ disaggregations, targets, period, values = [], updatesLis
   return (
     <div className="dsg-overview">
       <header>
-        <ProgressBar period={period} values={values} valueRef={updatesListRef} />
+        <ProgressBar
+          cumulative={cumulative}
+          period={period}
+          values={values}
+          valueRef={updatesListRef}
+        />
       </header>
       <div className="groups">
       {Object.keys(dsgGroups).map(dsgKey => {
@@ -93,7 +106,7 @@ const DsgOverview = ({ disaggregations, targets, period, values = [], updatesLis
                           )}
                       </div>
                       <div className="bar">
-                        {item.vals.sort((a, b) => { if(b.status === 'D' && a.status !== 'D') return -1; return 0; }).filter(it => it.status !== 'P').map(({ val, status }, index) => {
+                        {item.vals.sort((a, b) => { if(b.status === 'D' && a.status !== 'D') return -1; return 0 }).filter(it => it.status !== 'P').map(({ val, status }, index) => {
                           return (
                             <Tooltip title={String(val).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}>
                             <div

--- a/akvo/rsr/spa/app/modules/results/dsg-overview.scss
+++ b/akvo/rsr/spa/app/modules/results/dsg-overview.scss
@@ -20,6 +20,8 @@
             }
         }
         &>header{
+          border-bottom: 1px solid #ccc;
+          margin-bottom: 1rem;
           .labels{
             display: flex;
             text-transform: uppercase;

--- a/akvo/rsr/spa/app/modules/results/period.jsx
+++ b/akvo/rsr/spa/app/modules/results/period.jsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useRef } from 'react'
 import moment from 'moment'
 import { Collapse, Button, Checkbox, Icon, Popconfirm, Row, Col, Divider, Alert } from 'antd'
 import classNames from 'classnames'
-import { cloneDeep, orderBy } from 'lodash'
+import { cloneDeep } from 'lodash'
 import axios from 'axios'
 import humps from 'humps'
 import { useTranslation } from 'react-i18next'
@@ -245,14 +245,14 @@ const Period = ({ setResults, period, measure, treeFilter, statusFilter, increas
   const canAddUpdate = measure === measureType.PERCENTAGE ? updates.filter(it => !it.isNew).length === 0 : true
   const mdParse = SimpleMarkdown.defaultBlockParse
   const mdOutput = SimpleMarkdown.defaultOutput
-  let data = updates
-  ?.filter((u) => u?.status === 'A')
-  ?.map(u => ({
-    label: u.createdAt ? moment(u.createdAt, 'YYYY-MM-DD').format('DD-MM-YYYY') : null,
-    unix: u.createdAt ? moment(u.createdAt, 'YYYY-MM-DD').unix() : null,
-    y: u.value
-  }))
-  data = orderBy(data, ['unix'], ['asc']).map((u, index) => ({ ...u, x: index }))
+  const data = updates
+    ?.filter((u) => u?.status === 'A')
+    ?.map((u, index) => ({
+      label: u.createdAt ? moment(u.createdAt, 'YYYY-MM-DD').format('DD-MM-YYYY') : null,
+      y: u.value,
+      x: index,
+    }))
+    ?.sort((a, b) => a?.id - b?.id)
   return (
     <Panel
       {...props}
@@ -291,7 +291,20 @@ const Period = ({ setResults, period, measure, treeFilter, statusFilter, increas
         {targetsAt === 'period' && indicator.type === 1 &&
           <div className="graph">
             <div className="sticky">
-              {disaggregations.length > 0 && <DsgOverview {...{ disaggregations, targets: period.disaggregationTargets, period, editPeriod, values: updates.map(it => ({ value: it.value, status: it.status })), updatesListRef, setHover }} />}
+              {disaggregations.length > 0 && (
+                <DsgOverview
+                  {...{
+                    disaggregations,
+                    period,
+                    editPeriod,
+                    updatesListRef,
+                    setHover,
+                    cumulative: indicator?.isCumulative,
+                    targets: period.disaggregationTargets,
+                    values: updates.map(it => ({ value: it.value, status: it.status })),
+                  }}
+                />
+              )}
               {disaggregations.length === 0 && (
                 <LineChart
                   width={480}


### PR DESCRIPTION
# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

- [x] Get cumulative status from the indicator.
- [x] In order to Sum up the last updated values when the cumulative indicator is True, we need to group updates by userDetails id and then get the first element as the last updates.
- [x] Hide the progress bar when the cumulative indicator is True.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [ ] Revalidate Actual value in the cumulative indicator
 - [ ] Revalidate Actual value in the non-cumulative indicator
 - [ ] Revalidate Actual value in Results Overview
 
## Revalidate Actual value in Results Overview
 - Login as MnE Manager.
 - Go to the project that has the cumulative indicator True.
 - Open Reporting period updates: Results > Indicator > Period.
 - Revalidate the actual value on the right side of update items.