### PR TITLE
[#5248] Disable catch-up for django-q

### DIFF
--- a/akvo/settings/41-django-q.conf
+++ b/akvo/settings/41-django-q.conf
@@ -6,4 +6,5 @@ Q_CLUSTER = {
     "save_limit": 250,
     "queue_limit": 500,
     "orm": "default",
+    "catch_up": False,
 }


### PR DESCRIPTION

# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Disable [catchup](https://django-q.readthedocs.io/en/latest/configure.html?highlight=catch%20up#catch-up)  
We do not need it as we schedule tasks with cron and they will eventually be executed. Especially tasks that are executed every minute to not need catching up.

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Manual test
 
## Manual test

 - Start RSR
 - Wait until everything is up
 - Stop the worker for a few minutes
 - Start the worker
 - Ensure that aggregation job is only scheduled once instead of  the number of minutes the worker was down


Related to #5248