### PR TITLE
[#5226] Fix spammy IATI validation emails

### DIFF
--- a/akvo/rsr/tests/usecases/test_schedule_iati_validation.py
+++ b/akvo/rsr/tests/usecases/test_schedule_iati_validation.py
@@ -15,6 +15,12 @@ class ScheduleIatiActivityValidationTestCase(BaseTestCase):
     def setUp(self):
         self.project = self.create_project('Test project')
 
+    def test_no_job_for_unpublished_project(self):
+        schedule_at = now() + timedelta(minutes=1)
+        self.project.unpublish()
+        schedule_iati_activity_validation(self.project, schedule_at)
+        self.assertEqual(0, IatiActivityValidationJob.objects.filter(project=self.project).count())
+
     def test_add_new_job(self):
         schedule_at = now() + timedelta(minutes=1)
         schedule_iati_activity_validation(self.project, schedule_at)

--- a/akvo/rsr/usecases/iati_validation/schedule_validation.py
+++ b/akvo/rsr/usecases/iati_validation/schedule_validation.py
@@ -13,15 +13,16 @@ logger = logging.getLogger(__name__)
 
 
 def schedule_iati_activity_validation(project: Project, schedule_at: Optional[datetime] = None):
-    logger.info("Scheduling IATI validation for project %s", project.id)
-    scheduled_at = schedule_at if schedule_at else now() + DEFAULT_SCHEDULE_DELAY_TIME
-    pending_jobs = IatiActivityValidationJob.objects.filter(project=project, started_at=None)
-    if pending_jobs.exists():
-        job = pending_jobs.first()
-        job.scheduled_at = scheduled_at
-        job.save(update_fields=['scheduled_at'])
-    else:
-        IatiActivityValidationJob.objects.create(project=project, scheduled_at=scheduled_at)
+    if project.is_published():
+        logger.info("Scheduling IATI validation for project %s", project.id)
+        scheduled_at = schedule_at if schedule_at else now() + DEFAULT_SCHEDULE_DELAY_TIME
+        pending_jobs = IatiActivityValidationJob.objects.filter(project=project, started_at=None)
+        if pending_jobs.exists():
+            job = pending_jobs.first()
+            job.scheduled_at = scheduled_at
+            job.save(update_fields=['scheduled_at'])
+        else:
+            IatiActivityValidationJob.objects.create(project=project, scheduled_at=scheduled_at)
 
     # Ensure that even if the job for the external check doesn't run, that the internal one will
     project.run_iati_checks = True


### PR DESCRIPTION
Only run external validation when project is published

# TODO / Done

Summarize what has been changed / what has to be done in order to finalize the PR.

 - [x] Skip validation job if the project is not published
 - [x] Make sure internal validation always runs

# Test plan

What tests are necessary to ensure this works or doesn't break anything working

 - [x] Unit test
 - [x] Manual testing
 
---

Closes #5226 