### PR TITLE
Block aggressive bot crawlers (Bytespider, GPTBot)

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -117,7 +117,31 @@ server {
         add_header Access-Control-Allow-Methods "*";
     }
 
+    # Block aggressive crawlers (Bytespider, PetalBot, GPTBot, HaloBot)
+    location /rest/ {
+        if ($is_blocked_bot) {
+            return 403;
+        }
+
+        proxy_pass   http://127.0.0.1:8000;
+        proxy_set_header   Host             $host;
+        proxy_set_header   X-Real-IP        $remote_addr;
+        proxy_set_header   X-Forwarded-Host $host;
+        proxy_set_header   X-Forwarded-Proto $http_x_forwarded_proto;
+
+        # rate limiting
+        limit_req zone=googlebot burst=2 nodelay;
+        limit_req zone=bots burst=2 nodelay;
+
+        add_header   Front-End-Https   on;
+        add_header Access-Control-Allow-Origin $allow_origin;
+        add_header Access-Control-Allow-Methods "*";
+    }
+
     location / {
+        if ($is_blocked_bot) {
+            return 403;
+        }
 
         proxy_pass   http://127.0.0.1:8000;
         proxy_set_header   Host             $host;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -17,6 +17,12 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
+    # BLOCK aggressive crawlers entirely
+    map $http_user_agent $is_blocked_bot {
+            default 0;
+            ~*(Bytespider|PetalBot|GPTBot|HaloBot) 1;
+    }
+
     # RATE LIMITING
     map $http_user_agent $isbot {
             default 0;

--- a/nginx/robots-production.txt
+++ b/nginx/robots-production.txt
@@ -1,2 +1,15 @@
+User-agent: Bytespider
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+User-agent: HaloBot
+Disallow: /
+
 User-agent: *
 Crawl-Delay: 30
+Disallow: /rest/v1/indicator_period_data_framework/


### PR DESCRIPTION
## Summary

- Block Bytespider, GPTBot, PetalBot, and HaloBot at nginx level with immediate 403 response
- Add `$is_blocked_bot` map in `nginx.conf` and apply it in `default.conf` for `/rest/` and `/` locations
- Update `robots.txt` to explicitly disallow these bots and protect the expensive `indicator_period_data_framework` endpoint

## Context

Bytespider was sending 900+ requests/75min to expensive REST API endpoints (e.g. `indicator_period_data_framework` with `limit=1&page=56000`), causing OOMKill, 19GB memory usage, 4.8 CPU cores saturation, and health probe failures on production.

## Test plan

- [x] Tested live on production via `nginx -s reload` (2026-03-17)
- [x] Bytespider/GPTBot getting 403 in 0.000s (was 55s per request)
- [x] Legitimate users serving normally (0.1-1s response)
- [x] CPU dropped from 4,818m to 911m, memory from 19GB to 11GB
- [x] Monitored 12+ hours overnight — stable, no new health probe failures

Fixes #5358