### PR TITLE
Block ChatGPT-User and Sogou crawlers

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,7 +20,7 @@ http {
     # BLOCK aggressive crawlers entirely
     map $http_user_agent $is_blocked_bot {
             default 0;
-            ~*(Bytespider|PetalBot|GPTBot|HaloBot) 1;
+            ~*(Bytespider|PetalBot|GPTBot|HaloBot|ChatGPT-User|Sogou) 1;
     }
 
     # RATE LIMITING

--- a/nginx/robots-production.txt
+++ b/nginx/robots-production.txt
@@ -10,6 +10,12 @@ Disallow: /
 User-agent: HaloBot
 Disallow: /
 
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: Sogou
+Disallow: /
+
 User-agent: *
 Crawl-Delay: 30
 Disallow: /rest/v1/indicator_period_data_framework/


### PR DESCRIPTION
## Summary
- Added ChatGPT-User and Sogou web spider to nginx `$is_blocked_bot` map (returns 403)
- Added both bots to `robots-production.txt` with `Disallow: /`
- Both bots were hitting expensive `/rest/v1/` endpoints with deep pagination (page=200+), causing 35-60s response times, 502/504 errors, and 100+ backend restarts in 15 hours

## Test plan
- [x] Applied live via `nginx -s reload` on running pod
- [x] Verified Sogou requests now return 403 with 0.000s response time
- [x] Verified ChatGPT-User requests now return 403 with 0.000s response time
- [x] Verified legitimate traffic unaffected