### PR TITLE
Update Semaphore CI OS image from ubuntu2004 to ubuntu2204

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: Build, test & deploy
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu2004
+    os_image: ubuntu2204
 blocks:
   - name: 'Build, test & deploy'
     task:


### PR DESCRIPTION
## Summary
- Ubuntu 20.04 was phased out by Semaphore in March 2026
- All CI pipelines (master and PRs) have been failing since then — jobs cannot allocate an agent
- Updated `.semaphore/semaphore.yml` from `ubuntu2004` to `ubuntu2204`

## Test plan
- [ ] This PR's own CI pipeline should pass with the new image