### PR TITLE
Remove rsr-dedicated node affinity and toleration

### DIFF
--- a/ci/k8s/deployment.yml
+++ b/ci/k8s/deployment.yml
@@ -22,21 +22,6 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
     spec:
-      tolerations:
-        - key: "akvo-app"
-          operator: "Equal"
-          value: "rsr-dedicated"
-          effect: "NoSchedule"
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              preference:
-                matchExpressions:
-                  - key: "akvo-app"
-                    operator: "In"
-                    values:
-                      - "rsr-dedicated"
       containers:
       - name: rsr-nginx
         image: eu.gcr.io/akvo-lumen/rsr-nginx:${TRAVIS_COMMIT}


### PR DESCRIPTION
## Summary
- Removed `tolerations` and `nodeAffinity` for `rsr-dedicated` from RSR deployment manifest
- The dedicated RSR node pool (`pool-rsr`) was removed during cluster migration to `e2-highmem-4`
- RSR now runs on the general pool alongside other workloads

## Test plan
- [x] RSR already running without dedicated node on production
- [x] CI passes