### PR TITLE
Persist nginx bot blocks, IP/CIDR rules, and PHP scanner guard

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -122,6 +122,12 @@ server {
         if ($is_blocked_bot) {
             return 403;
         }
+        if ($is_blocked_ip) {
+            return 403;
+        }
+        if ($is_php_scanner) {
+            return 403;
+        }
 
         proxy_pass   http://127.0.0.1:8000;
         proxy_set_header   Host             $host;
@@ -140,6 +146,12 @@ server {
 
     location / {
         if ($is_blocked_bot) {
+            return 403;
+        }
+        if ($is_blocked_ip) {
+            return 403;
+        }
+        if ($is_php_scanner) {
             return 403;
         }
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,7 +20,25 @@ http {
     # BLOCK aggressive crawlers entirely
     map $http_user_agent $is_blocked_bot {
             default 0;
-            ~*(Bytespider|PetalBot|GPTBot|HaloBot|ChatGPT-User|Sogou) 1;
+            ~*(Bytespider|PetalBot|GPTBot|HaloBot|ChatGPT-User|Sogou|DotBot|MJ12bot|SemrushBot|AhrefsBot|Amazonbot|ClaudeBot|GoogleOther|TikTokSpider|Baiduspider|YandexBot|Barkrowler) 1;
+    }
+
+    # BLOCK specific bad-actor IPs and ranges (matches anywhere in X-Forwarded-For)
+    map $http_x_forwarded_for $is_blocked_ip {
+            default 0;
+            "~(^|, )45\.13\.238\.62(,|$)"  1;
+            "~(^|, )23\.251\.135\.236(,|$)"  1;
+            "~(^|, )20\.151\.226\.69(,|$)"  1;
+            # Tencent Cloud CIDRs: 43.128.0.0/10, 170.106.0.0/16, 119.28.0.0/15
+            "~(^|, )43\.(12[89]|1[3-8][0-9]|19[01])\."  1;
+            "~(^|, )170\.106\."  1;
+            "~(^|, )119\.(28|29)\."  1;
+    }
+
+    # BLOCK PHP-exploit scanners (empty or '-' UA hitting .php paths)
+    map "$http_user_agent:$request_uri" $is_php_scanner {
+            default 0;
+            "~^-?:.*\.php(\?|$)" 1;
     }
 
     # RATE LIMITING


### PR DESCRIPTION
## Summary

Persists three nginx rules that have been applied as live `kubectl exec` patches on multiple occasions (2026-04-20, 2026-05-13) but were wiped each time the pod was recreated by a GKE node replacement.

### What this PR adds

**1. Expanded `$is_blocked_bot` UA list** in `nginx/nginx.conf`
Adds 11 crawlers that have been hammering `/rest/v1/*` with deep pagination: DotBot, MJ12bot, SemrushBot, AhrefsBot, Amazonbot, ClaudeBot, GoogleOther, TikTokSpider, Baiduspider, YandexBot, Barkrowler.

**2. New `$is_blocked_ip` map** in `nginx/nginx.conf`
Matches anywhere in `X-Forwarded-For` (not just the leading IP) so spoofed XFF headers cannot bypass the block. Covers:
- `45.13.238.62` (Jinja2 SSTI attacker, identified 2026-04-20)
- `23.251.135.236` (`/metrics` / `/report-metrics` scanner)
- `20.151.226.69` (Azure IP doing PHP-exploit probes and main-page hammer, identified 2026-05-13)
- Tencent Cloud CIDRs: `43.128.0.0/10`, `170.106.0.0/16`, `119.28.0.0/15` — a distributed scraping botnet using rotating Chrome UAs against every `/rest/v1/*` endpoint with `ordering=` cycling and page numbers up to 996.

**3. New `$is_php_scanner` map** in `nginx/nginx.conf`
Blocks requests with empty or `"-"` User-Agent hitting any `.php` URL. This pattern (e.g. `/doc.php`, `/ws80.php`, `/wp-content/.../wp_filemanager.php`) is mass exploit-scanner traffic that returns 404 from Django anyway but still consumes a gunicorn worker.

**4. `nginx/default.conf`** — three `if` guards added to both `location /rest/` and `location /`:
```nginx
if ($is_blocked_bot)  { return 403; }
if ($is_blocked_ip)   { return 403; }
if ($is_php_scanner)  { return 403; }
```

### Background

Following 2026-03/04 bot blocking work (#5359, #5360), more aggressive scrapers appeared. Two incidents took RSR down via `gunicorn` sync-worker saturation that caused `/healthz` to time out, triggering liveness-probe SIGTERMs in a restart loop. Memory was fine — the cause was workers pinned by slow `/rest/v1/*` requests, often from clients that had already disconnected (the 22s client-side timeout).

Live patches applied during each incident restored stability but were lost on the next pod recreation. This PR makes those defenses durable.

### Verification

All rules verified live against pod `rsr-755465f7cc-fqd6d` on 2026-05-13 immediately before this PR:

| Test | Result |
|---|---|
| Bytespider / MJ12bot / Barkrowler → `/rest/v1/project/` | 403 |
| Tencent `43.166.x` first in XFF | 403 |
| Tencent `43.166.x` with **spoofed** leading XFF (`1.2.3.4, 43.166.x, LB`) | 403 |
| Tencent `170.106.x` first in XFF | 403 |
| Azure `20.151.226.69` first in XFF | 403 (on `/rest/v1/*` and `/en/project/*`) |
| Empty UA → `/doc.php` | 403 |
| `43.127.x` (just below Tencent /11) | 200 (correctly NOT blocked) |
| `43.192.x` (just above Tencent /11) | 200 (correctly NOT blocked) |
| Firefox → `/healthz` and `/en/project/1234` | 200 |

After the patches were live, rsr-backend restart rate dropped from ~one every 3 minutes to **zero in the next 23+ minutes**, and 502/504 rates fell from 100+ per 30 min to single digits.

### Notes

- Template placeholders (`%REPORT_SERVER_API_KEY%`, `%REPORT_SERVER_URL%`, `%GOOGLE_STORAGE_BUCKET_NAME%`) and the `###GOOGLE_STORAGE_*` toggle markers are untouched.
- `robots-production.txt` is not modified here — the bot block is sufficient and `robots.txt` is advisory.
- The deeper structural fix (gunicorn `gthread` workers, pagination caps, Cloud Armor) is tracked as separate follow-up phases.

## Test plan

- [ ] CI builds `rsr-nginx:<sha>` image without errors
- [ ] Image deployed to test cluster (rsr.akvotest.org) and `nginx -t` passes
- [ ] After production rollout, confirm via `kubectl logs ... | grep '" 403 '` that blocks are firing
- [ ] Confirm `rsr-backend` restart count stays flat
- [ ] Confirm legitimate uptime monitors and Googlebot still get 200s